### PR TITLE
fix(assignments): invalidate assignments cache on user role update

### DIFF
--- a/frontend/src/hooks/useUsers.ts
+++ b/frontend/src/hooks/useUsers.ts
@@ -44,6 +44,7 @@ export function useUpdateUser() {
     onSuccess: (_, { id }) => {
       queryClient.invalidateQueries({ queryKey: ["users"] })
       queryClient.invalidateQueries({ queryKey: ["users", id] })
+      queryClient.invalidateQueries({ queryKey: ["assignments"] })
     },
   })
 }


### PR DESCRIPTION
When a user's role changes (e.g. missionary → supervisor), the Assignments page cached stale supervisor/coach lists because useUpdateUser only invalidated the users query. Now also invalidates ["assignments"] so the new role is immediately reflected in the Assignments dropdowns.