### PR TITLE
Admin analytics redesign — leadership-focused tiles (issue #49)

### DIFF
--- a/apps/core/fiscal_year.py
+++ b/apps/core/fiscal_year.py
@@ -39,3 +39,20 @@ def months_remaining(today: date) -> int:
     fy_end = fiscal_year_end(today)
     raw = (fy_end.year - today.year) * 12 + (fy_end.month - today.month)
     return max(1, raw)
+
+
+def get_current_fiscal_year_bounds(reference_date: date | None = None) -> tuple[date, date]:
+    """Return (start, end) dates for the fiscal year containing reference_date."""
+    today = reference_date or date.today()
+    return fiscal_year_start(today), fiscal_year_end(today)
+
+
+def get_prior_fiscal_year_bounds(reference_date: date | None = None) -> tuple[date, date]:
+    """Return (start, end) dates for the fiscal year immediately prior to the one
+    containing reference_date."""
+    today = reference_date or date.today()
+    current_start, current_end = get_current_fiscal_year_bounds(today)
+    return (
+        date(current_start.year - 1, current_start.month, current_start.day),
+        date(current_end.year - 1, current_end.month, current_end.day),
+    )

--- a/apps/core/tests/test_fiscal_year.py
+++ b/apps/core/tests/test_fiscal_year.py
@@ -6,9 +6,9 @@ FISC-02: months_remaining returns months from current month to end of fiscal yea
 Imports are deferred inside each test so pytest can collect all 8 items even before
 apps/core/fiscal_year.py exists. Tests fail at runtime with ImportError (correct RED state).
 """
-import pytest
 from datetime import date
 
+import pytest
 
 # FISC-01: fiscal_year_start boundary cases
 
@@ -16,24 +16,28 @@ from datetime import date
 def test_fiscal_year_start_august():
     """Aug 15, 2025 is within FY2025-2026 which starts July 1, 2025."""
     from apps.core.fiscal_year import fiscal_year_start
+
     assert fiscal_year_start(date(2025, 8, 15)) == date(2025, 7, 1)
 
 
 def test_fiscal_year_start_march():
     """Mar 12, 2026 is within FY2025-2026 which starts July 1, 2025."""
     from apps.core.fiscal_year import fiscal_year_start
+
     assert fiscal_year_start(date(2026, 3, 12)) == date(2025, 7, 1)
 
 
 def test_fiscal_year_start_july_1_exact():
     """July 1 is the exact start of a fiscal year — should return itself."""
     from apps.core.fiscal_year import fiscal_year_start
+
     assert fiscal_year_start(date(2025, 7, 1)) == date(2025, 7, 1)
 
 
 def test_fiscal_year_start_june_30():
     """June 30, 2025 is the last day of FY2024-2025 which started July 1, 2024."""
     from apps.core.fiscal_year import fiscal_year_start
+
     assert fiscal_year_start(date(2025, 6, 30)) == date(2024, 7, 1)
 
 
@@ -43,6 +47,7 @@ def test_fiscal_year_start_june_30():
 def test_fiscal_year_end_august():
     """Aug 1, 2025 is within FY2025-2026 which ends June 30, 2026."""
     from apps.core.fiscal_year import fiscal_year_end
+
     assert fiscal_year_end(date(2025, 8, 1)) == date(2026, 6, 30)
 
 
@@ -52,16 +57,111 @@ def test_fiscal_year_end_august():
 def test_months_remaining_normal_month():
     """Aug 15, 2025: months remaining after current month = Sep..Jun = 10 months."""
     from apps.core.fiscal_year import months_remaining
+
     assert months_remaining(date(2025, 8, 15)) == 10
 
 
 def test_months_remaining_june_minimum():
     """June 1 — the last month of the fiscal year. Minimum guard returns 1, not 0."""
     from apps.core.fiscal_year import months_remaining
+
     assert months_remaining(date(2026, 6, 1)) == 1
 
 
 def test_months_remaining_june_30_minimum():
     """June 30 — last day of fiscal year. Minimum guard returns 1, not 0."""
     from apps.core.fiscal_year import months_remaining
+
     assert months_remaining(date(2026, 6, 30)) == 1
+
+
+# FISC-03: get_current_fiscal_year_bounds
+
+
+def test_current_fiscal_year_bounds_august():
+    """Aug 15, 2025 -> FY2025-2026 -> (2025-07-01, 2026-06-30)."""
+    from apps.core.fiscal_year import get_current_fiscal_year_bounds
+
+    start, end = get_current_fiscal_year_bounds(date(2025, 8, 15))
+    assert start == date(2025, 7, 1)
+    assert end == date(2026, 6, 30)
+
+
+def test_current_fiscal_year_bounds_july_1_exact():
+    """July 1 is the exact start — should be the start of its own FY."""
+    from apps.core.fiscal_year import get_current_fiscal_year_bounds
+
+    start, end = get_current_fiscal_year_bounds(date(2025, 7, 1))
+    assert start == date(2025, 7, 1)
+    assert end == date(2026, 6, 30)
+
+
+def test_current_fiscal_year_bounds_june_30():
+    """June 30, 2025 -> prior FY -> (2024-07-01, 2025-06-30)."""
+    from apps.core.fiscal_year import get_current_fiscal_year_bounds
+
+    start, end = get_current_fiscal_year_bounds(date(2025, 6, 30))
+    assert start == date(2024, 7, 1)
+    assert end == date(2025, 6, 30)
+
+
+def test_current_fiscal_year_bounds_march():
+    """Mar 12, 2026 -> FY2025-2026."""
+    from apps.core.fiscal_year import get_current_fiscal_year_bounds
+
+    start, end = get_current_fiscal_year_bounds(date(2026, 3, 12))
+    assert start == date(2025, 7, 1)
+    assert end == date(2026, 6, 30)
+
+
+def test_current_fiscal_year_bounds_leap_feb_29():
+    """Leap-year Feb 29, 2024 -> FY2023-2024 -> (2023-07-01, 2024-06-30)."""
+    from apps.core.fiscal_year import get_current_fiscal_year_bounds
+
+    start, end = get_current_fiscal_year_bounds(date(2024, 2, 29))
+    assert start == date(2023, 7, 1)
+    assert end == date(2024, 6, 30)
+
+
+def test_current_fiscal_year_bounds_default_is_today():
+    """No reference_date defaults to date.today()."""
+    from apps.core.fiscal_year import (
+        fiscal_year_end,
+        fiscal_year_start,
+        get_current_fiscal_year_bounds,
+    )
+
+    today = date.today()
+    start, end = get_current_fiscal_year_bounds()
+    assert start == fiscal_year_start(today)
+    assert end == fiscal_year_end(today)
+
+
+# FISC-04: get_prior_fiscal_year_bounds
+
+
+def test_prior_fiscal_year_bounds_august():
+    """Aug 15, 2025 -> prior FY2024-2025 -> (2024-07-01, 2025-06-30)."""
+    from apps.core.fiscal_year import get_prior_fiscal_year_bounds
+
+    start, end = get_prior_fiscal_year_bounds(date(2025, 8, 15))
+    assert start == date(2024, 7, 1)
+    assert end == date(2025, 6, 30)
+
+
+def test_prior_fiscal_year_bounds_june_30():
+    """June 30, 2025 is in FY2024-2025; prior is FY2023-2024 -> (2023-07-01, 2024-06-30)."""
+    from apps.core.fiscal_year import get_prior_fiscal_year_bounds
+
+    start, end = get_prior_fiscal_year_bounds(date(2025, 6, 30))
+    assert start == date(2023, 7, 1)
+    assert end == date(2024, 6, 30)
+
+
+def test_prior_fiscal_year_bounds_july_1_exact():
+    """July 1, 2025 is in FY2025-2026; prior is FY2024-2025."""
+    from apps.core.fiscal_year import get_prior_fiscal_year_bounds
+
+    start, end = get_prior_fiscal_year_bounds(date(2025, 7, 1))
+    assert start == date(2024, 7, 1)
+    assert end == date(2025, 6, 30)

--- a/apps/insights/admin_analytics_services.py
+++ b/apps/insights/admin_analytics_services.py
@@ -1,0 +1,476 @@
+"""
+Service functions for the /admin/analytics redesign (Issue #49).
+
+Five leadership-focused services:
+  - get_fiscal_year_pace: hero pace metric
+  - get_missionaries_behind_goal: coaching accountability list
+  - get_pipeline_funnel_with_conversion: stage-to-stage conversion funnel
+  - get_weekly_engagement: active + on-pace missionaries over N weeks
+  - get_fiscal_year_donations: monthly FYTD totals vs prior year
+
+Scoping note: these endpoints are admin-only. When `request.view_as_user` is
+set, data is scoped to that user via get_visible_user_ids(); otherwise the
+services compute org-wide aggregates (matching existing admin analytics
+endpoints such as get_dashboard_overview, which intentionally bypass user
+scoping for cross-tenant views).
+"""
+from calendar import monthrange
+from datetime import date, timedelta
+
+from django.db.models import Case, IntegerField, Max, Sum, Value, When
+from django.db.models.functions import TruncMonth, TruncWeek
+
+from apps.core.fiscal_year import (
+    get_current_fiscal_year_bounds,
+    get_prior_fiscal_year_bounds,
+    months_elapsed_in_fiscal_year,
+)
+from apps.core.permissions import get_visible_user_ids
+from apps.gifts.models import Gift
+from apps.imports.models import ImportBatch, ImportBatchStatus, ImportBatchType
+from apps.journals.models import JournalStageEvent, PipelineStage
+from apps.users.models import User, UserRole
+
+# --- Pipeline stage ordering ---------------------------------------------------
+
+STAGE_ORDER = [
+    PipelineStage.CONTACT.value,
+    PipelineStage.SCHEDULED.value,
+    PipelineStage.MEET.value,
+    PipelineStage.CLOSE.value,
+    PipelineStage.DECISION.value,
+    PipelineStage.THANK.value,
+    PipelineStage.NEXT_STEPS.value,
+]
+STAGE_LABELS = {s.value: s.label for s in PipelineStage}
+
+# Import types that represent gift data (used for "last import at" timestamp).
+GIFT_IMPORT_TYPES = [
+    ImportBatchType.RE_GIFT,
+    ImportBatchType.RE_RECURRING_GIFT,
+    ImportBatchType.GENERIC_DONATIONS,
+    ImportBatchType.SPO_GIFT,
+]
+
+
+def _admin_scope_owner_ids(request):
+    """Return a set of owner user IDs to filter by, or None for no filter.
+
+    Admin analytics default to org-wide aggregates (no filter). When View As
+    is active, we scope to the target user by delegating to
+    get_visible_user_ids(), which returns {view_as_user.id}.
+    """
+    if getattr(request, "view_as_user", None) is not None:
+        return get_visible_user_ids(request.user, request=request)
+    return None
+
+
+def _filter_gifts_by_owner(queryset, owner_ids):
+    if owner_ids is None:
+        return queryset
+    return queryset.filter(donor_contact__owner_id__in=owner_ids)
+
+
+def _filter_users_by_scope(queryset, owner_ids):
+    if owner_ids is None:
+        return queryset
+    return queryset.filter(id__in=owner_ids)
+
+
+def _filter_stage_events_by_owner(queryset, owner_ids):
+    if owner_ids is None:
+        return queryset
+    return queryset.filter(journal_contact__journal__owner_id__in=owner_ids)
+
+
+def _active_missionaries(owner_ids):
+    """Return the base queryset of active missionary users in scope."""
+    qs = User.objects.filter(role=UserRole.MISSIONARY, is_active=True)
+    return _filter_users_by_scope(qs, owner_ids)
+
+
+def _clamp(value, lo, hi):
+    return max(lo, min(hi, value))
+
+
+def _last_gift_import_at(owner_ids):
+    """Return ISO timestamp of the most recent completed gift-related import,
+    or None if no such import exists. Org-wide when owner_ids is None; in
+    View As mode we scope by the uploader being the target user (best-effort —
+    uploader is typically an admin, so this stays org-wide in practice)."""
+    qs = ImportBatch.objects.filter(
+        status=ImportBatchStatus.COMPLETED,
+        import_type__in=GIFT_IMPORT_TYPES,
+    )
+    last = qs.order_by("-created_at").values_list("created_at", flat=True).first()
+    return last.isoformat() if last else None
+
+
+# --- 1. Fiscal year pace --------------------------------------------------------
+
+
+def get_fiscal_year_pace(request):
+    """Hero tile: raised vs annual goal with pace %, YoY, and last-import stamp."""
+    today = date.today()
+    fy_start, fy_end = get_current_fiscal_year_bounds(today)
+    prior_start, prior_end = get_prior_fiscal_year_bounds(today)
+    owner_ids = _admin_scope_owner_ids(request)
+
+    # Current FY gifts up to today
+    current_qs = Gift.objects.filter(gift_date__gte=fy_start, gift_date__lte=today)
+    current_qs = _filter_gifts_by_owner(current_qs, owner_ids)
+    raised_cents = current_qs.aggregate(total=Sum("amount_cents"))["total"] or 0
+
+    # Prior FY gifts through same day-of-year (one year ago)
+    prior_today = (
+        today.replace(year=today.year - 1)
+        if not (today.month == 2 and today.day == 29)
+        else date(today.year - 1, 2, 28)
+    )
+    prior_qs = Gift.objects.filter(gift_date__gte=prior_start, gift_date__lte=prior_today)
+    prior_qs = _filter_gifts_by_owner(prior_qs, owner_ids)
+    prior_year_raised_cents = prior_qs.aggregate(total=Sum("amount_cents"))["total"] or 0
+
+    # Annual goal = sum of (monthly_support_goal * 12) for active missionaries
+    goal_qs = _active_missionaries(owner_ids).filter(monthly_support_goal_cents__gt=0)
+    monthly_goal_sum = goal_qs.aggregate(total=Sum("monthly_support_goal_cents"))["total"] or 0
+    annual_goal_cents = monthly_goal_sum * 12
+
+    months_elapsed = months_elapsed_in_fiscal_year(today)
+    expected_by_today_cents = (
+        int(annual_goal_cents * months_elapsed / 12) if annual_goal_cents else 0
+    )
+
+    if expected_by_today_cents > 0:
+        raw_pace = raised_cents / expected_by_today_cents * 100
+        pace_percentage = round(_clamp(raw_pace, 0, 150), 1)
+    else:
+        pace_percentage = 0.0
+
+    if prior_year_raised_cents > 0:
+        yoy_delta_percentage = round(
+            (raised_cents - prior_year_raised_cents) / prior_year_raised_cents * 100, 1
+        )
+    else:
+        yoy_delta_percentage = None
+
+    return {
+        "fy_start": fy_start.isoformat(),
+        "fy_end": fy_end.isoformat(),
+        "raised_cents": int(raised_cents),
+        "annual_goal_cents": int(annual_goal_cents),
+        "expected_by_today_cents": int(expected_by_today_cents),
+        "pace_percentage": pace_percentage,
+        "prior_year_raised_cents": int(prior_year_raised_cents),
+        "yoy_delta_percentage": yoy_delta_percentage,
+        "last_import_at": _last_gift_import_at(owner_ids),
+    }
+
+
+# --- 2. Missionaries behind goal -----------------------------------------------
+
+
+def get_missionaries_behind_goal(request, limit=10):
+    """Ranked list (ascending pace %) of missionaries behind their monthly goal."""
+    today = date.today()
+    month_start = today.replace(day=1)
+    days_in_month = monthrange(today.year, today.month)[1]
+    day_of_month = today.day
+    owner_ids = _admin_scope_owner_ids(request)
+
+    with_goal = _active_missionaries(owner_ids).filter(monthly_support_goal_cents__gt=0)
+    without_goal_count = (
+        _active_missionaries(owner_ids).filter(monthly_support_goal_cents=0).count()
+    )
+    total_missionaries = _active_missionaries(owner_ids).count()
+
+    user_rows = list(
+        with_goal.values("id", "first_name", "last_name", "email", "monthly_support_goal_cents")
+    )
+    user_ids = [row["id"] for row in user_rows]
+
+    # Single aggregate: gifts this month grouped by owner.
+    month_totals_qs = Gift.objects.filter(
+        gift_date__gte=month_start,
+        gift_date__lte=today,
+        donor_contact__owner_id__in=user_ids,
+    )
+    if owner_ids is not None:
+        month_totals_qs = month_totals_qs.filter(donor_contact__owner_id__in=owner_ids)
+    month_totals = month_totals_qs.values("donor_contact__owner_id").annotate(
+        total=Sum("amount_cents")
+    )
+    owner_to_total = {
+        row["donor_contact__owner_id"]: int(row["total"] or 0) for row in month_totals
+    }
+
+    # Expected pace at this point in the month (prorated linearly).
+    ratio = day_of_month / days_in_month if days_in_month else 1
+
+    rows = []
+    for user in user_rows:
+        goal = int(user["monthly_support_goal_cents"])
+        raised = owner_to_total.get(user["id"], 0)
+        expected = goal * ratio
+        if expected > 0:
+            pace_pct = round(_clamp(raised / expected * 100, 0, 150), 1)
+        else:
+            pace_pct = 0.0
+        rows.append(
+            {
+                "user_id": str(user["id"]),
+                "name": f'{user["first_name"]} {user["last_name"]}'.strip(),
+                "email": user["email"],
+                "monthly_goal_cents": goal,
+                "this_month_raised_cents": raised,
+                "pace_percentage": pace_pct,
+            }
+        )
+
+    rows.sort(key=lambda r: r["pace_percentage"])
+    rows = rows[:limit]
+
+    return {
+        "missionaries": rows,
+        "total_excluded_no_goal": int(without_goal_count),
+        "total_missionaries": int(total_missionaries),
+        "as_of_date": today.isoformat(),
+    }
+
+
+# --- 3. Pipeline funnel with stage-to-stage conversion -------------------------
+
+
+def get_pipeline_funnel_with_conversion(request):
+    """Cumulative-reach funnel: for each stage, count journal contacts whose
+    deepest stage reached is >= that stage. Conversion = count[N] / count[N-1].
+    """
+    owner_ids = _admin_scope_owner_ids(request)
+    # Index each stage event via Case/When then take the max index per journal_contact.
+    stage_cases = [
+        When(stage=stage_value, then=Value(idx)) for idx, stage_value in enumerate(STAGE_ORDER)
+    ]
+    events_qs = JournalStageEvent.objects.all()
+    events_qs = _filter_stage_events_by_owner(events_qs, owner_ids)
+    max_indexes = events_qs.values("journal_contact_id").annotate(
+        max_idx=Max(Case(*stage_cases, default=Value(-1), output_field=IntegerField()))
+    )
+
+    # Build count_at_or_past[N] = # journal_contacts whose max_idx >= N.
+    counts_at_or_past = [0] * len(STAGE_ORDER)
+    total_in_pipeline = 0
+    for row in max_indexes:
+        idx = row["max_idx"]
+        if idx is None or idx < 0:
+            continue
+        total_in_pipeline += 1
+        for n in range(idx + 1):
+            counts_at_or_past[n] += 1
+
+    stages = []
+    weakest = None
+    for i, stage_value in enumerate(STAGE_ORDER):
+        count = counts_at_or_past[i]
+        if i == 0:
+            conversion = None
+        else:
+            prior = counts_at_or_past[i - 1]
+            conversion = round((count / prior * 100), 1) if prior > 0 else None
+        stages.append(
+            {
+                "stage": stage_value,
+                "label": STAGE_LABELS[stage_value],
+                "count_at_or_past": count,
+                "conversion_from_prior_percentage": conversion,
+                "is_weakest_transition": False,
+            }
+        )
+        if conversion is not None and (weakest is None or conversion < weakest["rate"]):
+            weakest = {
+                "from": STAGE_ORDER[i - 1],
+                "to": stage_value,
+                "rate": conversion,
+                "index": i,
+            }
+
+    if weakest is not None:
+        stages[weakest["index"]]["is_weakest_transition"] = True
+
+    return {
+        "stages": stages,
+        "total_in_pipeline": int(total_in_pipeline),
+        "weakest_transition": (
+            {
+                "from": weakest["from"],
+                "to": weakest["to"],
+                "rate": weakest["rate"],
+            }
+            if weakest is not None
+            else None
+        ),
+    }
+
+
+# --- 4. Weekly engagement ------------------------------------------------------
+
+
+def _week_start(d):
+    """Return Monday (ISO) of the week containing d."""
+    return d - timedelta(days=d.weekday())
+
+
+def get_weekly_engagement(request, weeks=12):
+    """Last N weeks: active-missionary count + on-pace-missionary count.
+
+    On-pace interpretation (month-to-date): a missionary is on-pace in week W
+    if their MTD raised (through the week-end date that is <= today) is at
+    least monthly_goal * day_of_month(week_end) / days_in_month(week_end).
+    """
+    today = date.today()
+    owner_ids = _admin_scope_owner_ids(request)
+
+    # Build the list of week starts (Monday) for the last `weeks` weeks.
+    current_week_start = _week_start(today)
+    week_starts = [current_week_start - timedelta(weeks=weeks - 1 - i) for i in range(weeks)]
+
+    # Active missionaries per week: distinct stage-event-triggering users.
+    active_qs = JournalStageEvent.objects.filter(
+        created_at__date__gte=week_starts[0],
+        created_at__date__lte=today,
+    )
+    active_qs = _filter_stage_events_by_owner(active_qs, owner_ids)
+    active_rows = (
+        active_qs.annotate(w=TruncWeek("created_at"))
+        .values("w", "journal_contact__journal__owner_id")
+        .distinct()
+    )
+    week_to_active_users = {ws: set() for ws in week_starts}
+    for row in active_rows:
+        w_date = row["w"].date() if hasattr(row["w"], "date") else row["w"]
+        if w_date in week_to_active_users:
+            week_to_active_users[w_date].add(row["journal_contact__journal__owner_id"])
+
+    # On-pace calc. Pull goals + monthly gift totals covering up to the current month.
+    goal_rows = list(
+        _active_missionaries(owner_ids)
+        .filter(monthly_support_goal_cents__gt=0)
+        .values("id", "monthly_support_goal_cents")
+    )
+    goal_map = {r["id"]: int(r["monthly_support_goal_cents"]) for r in goal_rows}
+    user_ids_with_goals = list(goal_map.keys())
+    total_missionaries = _active_missionaries(owner_ids).count()
+
+    # Gifts grouped by (owner, month) across the window months.
+    earliest_week_end_month = (week_starts[0] + timedelta(days=6)).replace(day=1)
+    gifts_qs = Gift.objects.filter(
+        gift_date__gte=earliest_week_end_month,
+        gift_date__lte=today,
+        donor_contact__owner_id__in=user_ids_with_goals,
+    )
+    if owner_ids is not None:
+        gifts_qs = gifts_qs.filter(donor_contact__owner_id__in=owner_ids)
+    # Per-day totals let us compute MTD through any week-end cheaply.
+    daily_totals = gifts_qs.values("donor_contact__owner_id", "gift_date").annotate(
+        total=Sum("amount_cents")
+    )
+    # Nested map: user_id -> {gift_date: total_cents}
+    user_day_totals = {}
+    for row in daily_totals:
+        uid = row["donor_contact__owner_id"]
+        user_day_totals.setdefault(uid, {})[row["gift_date"]] = int(row["total"] or 0)
+
+    weeks_out = []
+    for ws in week_starts:
+        week_end = min(ws + timedelta(days=6), today)
+        # week_end may be before "today" for past weeks and equals today for current.
+        month_start = week_end.replace(day=1)
+        days_in_month = monthrange(week_end.year, week_end.month)[1]
+        ratio = week_end.day / days_in_month if days_in_month else 1
+
+        on_pace = 0
+        for uid, goal in goal_map.items():
+            per_day = user_day_totals.get(uid, {})
+            mtd = sum(amt for d, amt in per_day.items() if month_start <= d <= week_end)
+            expected = goal * ratio
+            if expected > 0 and mtd >= expected:
+                on_pace += 1
+
+        weeks_out.append(
+            {
+                "week_start": ws.isoformat(),
+                "week_label": ws.strftime("%b %-d"),
+                "active_missionaries": len(week_to_active_users.get(ws, set())),
+                "on_pace_missionaries": on_pace,
+                "total_missionaries": int(total_missionaries),
+            }
+        )
+
+    return {"weeks": weeks_out}
+
+
+# --- 5. Fiscal year donations --------------------------------------------------
+
+
+def get_fiscal_year_donations(request):
+    """Monthly FYTD donations vs prior year, Jul -> Jun.
+    current_cents is null for months beyond the current month."""
+    today = date.today()
+    fy_start, fy_end = get_current_fiscal_year_bounds(today)
+    prior_start, prior_end = get_prior_fiscal_year_bounds(today)
+    owner_ids = _admin_scope_owner_ids(request)
+
+    current_qs = _filter_gifts_by_owner(
+        Gift.objects.filter(gift_date__gte=fy_start, gift_date__lte=today),
+        owner_ids,
+    )
+    prior_qs = _filter_gifts_by_owner(
+        Gift.objects.filter(gift_date__gte=prior_start, gift_date__lte=prior_end),
+        owner_ids,
+    )
+
+    current_by_month = {
+        row["m"].date() if hasattr(row["m"], "date") else row["m"]: int(row["total"] or 0)
+        for row in current_qs.annotate(m=TruncMonth("gift_date"))
+        .values("m")
+        .annotate(total=Sum("amount_cents"))
+    }
+    prior_by_month = {
+        row["m"].date() if hasattr(row["m"], "date") else row["m"]: int(row["total"] or 0)
+        for row in prior_qs.annotate(m=TruncMonth("gift_date"))
+        .values("m")
+        .annotate(total=Sum("amount_cents"))
+    }
+
+    months = []
+    # 12 entries starting at fy_start month (July), running through June.
+    for i in range(12):
+        month_year = fy_start.year + (1 if (fy_start.month + i) > 12 else 0)
+        month_num = ((fy_start.month - 1 + i) % 12) + 1
+        current_month = date(month_year, month_num, 1)
+        prior_month = date(month_year - 1, month_num, 1)
+
+        # is_future: month starts after the current month
+        is_future = current_month > today.replace(day=1)
+        current_cents = None if is_future else current_by_month.get(current_month, 0)
+        prior_cents = prior_by_month.get(prior_month, 0)
+
+        months.append(
+            {
+                "month": current_month.isoformat(),
+                "short_label": current_month.strftime("%b"),
+                "current_cents": current_cents,
+                "prior_cents": prior_cents,
+                "is_future": is_future,
+            }
+        )
+
+    current_total = sum(v for v in current_by_month.values())
+    prior_total = sum(v for v in prior_by_month.values())
+
+    return {
+        "fy_start": fy_start.isoformat(),
+        "fy_end": fy_end.isoformat(),
+        "months": months,
+        "current_fy_total_cents": int(current_total),
+        "prior_fy_total_cents": int(prior_total),
+    }

--- a/apps/insights/admin_analytics_services.py
+++ b/apps/insights/admin_analytics_services.py
@@ -93,16 +93,21 @@ def _clamp(value, lo, hi):
     return max(lo, min(hi, value))
 
 
-def _last_gift_import_at(owner_ids):
+def _last_gift_import_at():
     """Return ISO timestamp of the most recent completed gift-related import,
-    or None if no such import exists. Org-wide when owner_ids is None; in
-    View As mode we scope by the uploader being the target user (best-effort —
-    uploader is typically an admin, so this stays org-wide in practice)."""
-    qs = ImportBatch.objects.filter(
-        status=ImportBatchStatus.COMPLETED,
-        import_type__in=GIFT_IMPORT_TYPES,
+    or None. Org-wide by design — uploader is typically an admin, so scoping
+    the timestamp to an individual missionary would rarely differ from the
+    org-wide value.
+    """
+    last = (
+        ImportBatch.objects.filter(
+            status=ImportBatchStatus.COMPLETED,
+            import_type__in=GIFT_IMPORT_TYPES,
+        )
+        .order_by("-created_at")
+        .values_list("created_at", flat=True)
+        .first()
     )
-    last = qs.order_by("-created_at").values_list("created_at", flat=True).first()
     return last.isoformat() if last else None
 
 
@@ -163,7 +168,7 @@ def get_fiscal_year_pace(request):
         "pace_percentage": pace_percentage,
         "prior_year_raised_cents": int(prior_year_raised_cents),
         "yoy_delta_percentage": yoy_delta_percentage,
-        "last_import_at": _last_gift_import_at(owner_ids),
+        "last_import_at": _last_gift_import_at(),
     }
 
 
@@ -189,23 +194,24 @@ def get_missionaries_behind_goal(request, limit=10):
     )
     user_ids = [row["id"] for row in user_rows]
 
-    # Single aggregate: gifts this month grouped by owner.
-    month_totals_qs = Gift.objects.filter(
-        gift_date__gte=month_start,
-        gift_date__lte=today,
-        donor_contact__owner_id__in=user_ids,
-    )
-    if owner_ids is not None:
-        month_totals_qs = month_totals_qs.filter(donor_contact__owner_id__in=owner_ids)
-    month_totals = month_totals_qs.values("donor_contact__owner_id").annotate(
-        total=Sum("amount_cents")
+    # Single aggregate: gifts this month grouped by owner. `user_ids` is
+    # already scoped by `owner_ids` via `with_goal`, so no separate scope
+    # filter is needed here.
+    month_totals = (
+        Gift.objects.filter(
+            gift_date__gte=month_start,
+            gift_date__lte=today,
+            donor_contact__owner_id__in=user_ids,
+        )
+        .values("donor_contact__owner_id")
+        .annotate(total=Sum("amount_cents"))
     )
     owner_to_total = {
         row["donor_contact__owner_id"]: int(row["total"] or 0) for row in month_totals
     }
 
     # Expected pace at this point in the month (prorated linearly).
-    ratio = day_of_month / days_in_month if days_in_month else 1
+    ratio = day_of_month / days_in_month
 
     rows = []
     for user in user_rows:
@@ -385,7 +391,7 @@ def get_weekly_engagement(request, weeks=12):
         # week_end may be before "today" for past weeks and equals today for current.
         month_start = week_end.replace(day=1)
         days_in_month = monthrange(week_end.year, week_end.month)[1]
-        ratio = week_end.day / days_in_month if days_in_month else 1
+        ratio = week_end.day / days_in_month
 
         on_pace = 0
         for uid, goal in goal_map.items():
@@ -464,8 +470,8 @@ def get_fiscal_year_donations(request):
             }
         )
 
-    current_total = sum(v for v in current_by_month.values())
-    prior_total = sum(v for v in prior_by_month.values())
+    current_total = sum(current_by_month.values())
+    prior_total = sum(prior_by_month.values())
 
     return {
         "fy_start": fy_start.isoformat(),

--- a/apps/insights/serializers.py
+++ b/apps/insights/serializers.py
@@ -222,12 +222,6 @@ class PipelineFunnelConversionStageSerializer(serializers.Serializer):
     is_weakest_transition = serializers.BooleanField()
 
 
-class PipelineFunnelWeakestTransitionSerializer(serializers.Serializer):
-    from_stage = serializers.CharField(source="from")
-    to = serializers.CharField()
-    rate = serializers.FloatField()
-
-
 class PipelineFunnelConversionResponseSerializer(serializers.Serializer):
     stages = PipelineFunnelConversionStageSerializer(many=True)
     total_in_pipeline = serializers.IntegerField()

--- a/apps/insights/serializers.py
+++ b/apps/insights/serializers.py
@@ -3,8 +3,8 @@ DRF serializers for insights/analytics endpoints.
 """
 from rest_framework import serializers
 
-
 # Nested serializers
+
 
 class DonationSummarySerializer(serializers.Serializer):
     total_amount = serializers.FloatField()
@@ -58,6 +58,7 @@ class TeamActivityItemSerializer(serializers.Serializer):
 
 # Response serializers for 5 admin analytics endpoints
 
+
 class DashboardOverviewSerializer(serializers.Serializer):
     total_contacts = serializers.IntegerField()
     active_journals = serializers.IntegerField()
@@ -103,6 +104,7 @@ class TeamTrendsResponseSerializer(serializers.Serializer):
 
 # User Detail Serializers (Phase 17)
 
+
 class UserTrendDataPointSerializer(serializers.Serializer):
     week_start = serializers.CharField()
     week_label = serializers.CharField()
@@ -131,6 +133,7 @@ class UserJournalsResponseSerializer(serializers.Serializer):
 
 # Stage Contacts Serializers (Phase 18)
 
+
 class StageContactItemSerializer(serializers.Serializer):
     id = serializers.CharField()
     full_name = serializers.CharField()
@@ -146,6 +149,7 @@ class StageContactsResponseSerializer(serializers.Serializer):
 
 
 # User Drilldown Serializers (Phase 18)
+
 
 class UserDrilldownUserSerializer(serializers.Serializer):
     id = serializers.CharField()
@@ -177,3 +181,82 @@ class UserDrilldownResponseSerializer(serializers.Serializer):
     user = UserDrilldownUserSerializer()
     stats = UserDrilldownStatsSerializer()
     journals = UserDrilldownJournalSerializer(many=True)
+
+
+# Admin Analytics Redesign (Issue #49)
+
+
+class FiscalYearPaceResponseSerializer(serializers.Serializer):
+    fy_start = serializers.CharField()
+    fy_end = serializers.CharField()
+    raised_cents = serializers.IntegerField()
+    annual_goal_cents = serializers.IntegerField()
+    expected_by_today_cents = serializers.IntegerField()
+    pace_percentage = serializers.FloatField()
+    prior_year_raised_cents = serializers.IntegerField()
+    yoy_delta_percentage = serializers.FloatField(allow_null=True)
+    last_import_at = serializers.CharField(allow_null=True)
+
+
+class MissionaryBehindGoalItemSerializer(serializers.Serializer):
+    user_id = serializers.CharField()
+    name = serializers.CharField()
+    email = serializers.CharField()
+    monthly_goal_cents = serializers.IntegerField()
+    this_month_raised_cents = serializers.IntegerField()
+    pace_percentage = serializers.FloatField()
+
+
+class MissionariesBehindGoalResponseSerializer(serializers.Serializer):
+    missionaries = MissionaryBehindGoalItemSerializer(many=True)
+    total_excluded_no_goal = serializers.IntegerField()
+    total_missionaries = serializers.IntegerField()
+    as_of_date = serializers.CharField()
+
+
+class PipelineFunnelConversionStageSerializer(serializers.Serializer):
+    stage = serializers.CharField()
+    label = serializers.CharField()
+    count_at_or_past = serializers.IntegerField()
+    conversion_from_prior_percentage = serializers.FloatField(allow_null=True)
+    is_weakest_transition = serializers.BooleanField()
+
+
+class PipelineFunnelWeakestTransitionSerializer(serializers.Serializer):
+    from_stage = serializers.CharField(source="from")
+    to = serializers.CharField()
+    rate = serializers.FloatField()
+
+
+class PipelineFunnelConversionResponseSerializer(serializers.Serializer):
+    stages = PipelineFunnelConversionStageSerializer(many=True)
+    total_in_pipeline = serializers.IntegerField()
+    weakest_transition = serializers.DictField(allow_null=True)
+
+
+class WeeklyEngagementPointSerializer(serializers.Serializer):
+    week_start = serializers.CharField()
+    week_label = serializers.CharField()
+    active_missionaries = serializers.IntegerField()
+    on_pace_missionaries = serializers.IntegerField()
+    total_missionaries = serializers.IntegerField()
+
+
+class WeeklyEngagementResponseSerializer(serializers.Serializer):
+    weeks = WeeklyEngagementPointSerializer(many=True)
+
+
+class FiscalYearDonationMonthSerializer(serializers.Serializer):
+    month = serializers.CharField()
+    short_label = serializers.CharField()
+    current_cents = serializers.IntegerField(allow_null=True)
+    prior_cents = serializers.IntegerField()
+    is_future = serializers.BooleanField()
+
+
+class FiscalYearDonationsResponseSerializer(serializers.Serializer):
+    fy_start = serializers.CharField()
+    fy_end = serializers.CharField()
+    months = FiscalYearDonationMonthSerializer(many=True)
+    current_fy_total_cents = serializers.IntegerField()
+    prior_fy_total_cents = serializers.IntegerField()

--- a/apps/insights/tests/test_admin_analytics_services.py
+++ b/apps/insights/tests/test_admin_analytics_services.py
@@ -1,0 +1,284 @@
+"""
+Unit tests for admin analytics redesign service functions (Issue #49).
+
+Covers:
+  - get_fiscal_year_pace
+  - get_missionaries_behind_goal
+  - get_pipeline_funnel_with_conversion
+  - get_weekly_engagement
+  - get_fiscal_year_donations
+"""
+from calendar import monthrange
+from datetime import date, timedelta
+from unittest.mock import patch
+
+from rest_framework.test import APIRequestFactory
+
+import pytest
+
+from apps.contacts.tests.factories import ContactFactory
+from apps.core.fiscal_year import get_current_fiscal_year_bounds, get_prior_fiscal_year_bounds
+from apps.gifts.tests.factories import GiftFactory
+from apps.insights.admin_analytics_services import (
+    get_fiscal_year_donations,
+    get_fiscal_year_pace,
+    get_missionaries_behind_goal,
+    get_pipeline_funnel_with_conversion,
+    get_weekly_engagement,
+)
+from apps.journals.models import (
+    Journal,
+    JournalContact,
+    JournalStageEvent,
+    PipelineStage,
+    StageEventType,
+)
+from apps.users.tests.factories import AdminUserFactory, UserFactory
+
+
+def _admin_request(admin_user=None):
+    """Return a DRF request authenticated as an admin."""
+    request = APIRequestFactory().get("/")
+    request.user = admin_user or AdminUserFactory()
+    return request
+
+
+# --- get_fiscal_year_pace ------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestFiscalYearPace:
+    def test_zero_state(self):
+        request = _admin_request()
+        result = get_fiscal_year_pace(request)
+        assert result["raised_cents"] == 0
+        assert result["annual_goal_cents"] == 0
+        assert result["pace_percentage"] == 0.0
+        assert result["yoy_delta_percentage"] is None
+
+    def test_sums_current_fy_gifts(self):
+        request = _admin_request()
+        fy_start, _ = get_current_fiscal_year_bounds()
+        # One missionary with a goal
+        missionary = UserFactory(role="missionary", monthly_support_goal_cents=100_000)
+        contact = ContactFactory(owner=missionary)
+        # Gift in current FY
+        GiftFactory(
+            donor_contact=contact, amount_cents=50_000, gift_date=fy_start + timedelta(days=10)
+        )
+        # Gift before FY -> must not count
+        GiftFactory(
+            donor_contact=contact, amount_cents=99_999, gift_date=fy_start - timedelta(days=1)
+        )
+
+        result = get_fiscal_year_pace(request)
+        assert result["raised_cents"] == 50_000
+        assert result["annual_goal_cents"] == 100_000 * 12
+
+    def test_yoy_delta_populated_when_prior_year_has_gifts(self):
+        request = _admin_request()
+        fy_start, _ = get_current_fiscal_year_bounds()
+        prior_start, _ = get_prior_fiscal_year_bounds()
+        missionary = UserFactory(role="missionary", monthly_support_goal_cents=100_000)
+        contact = ContactFactory(owner=missionary)
+        GiftFactory(
+            donor_contact=contact, amount_cents=200_000, gift_date=fy_start + timedelta(days=1)
+        )
+        GiftFactory(
+            donor_contact=contact, amount_cents=100_000, gift_date=prior_start + timedelta(days=1)
+        )
+
+        result = get_fiscal_year_pace(request)
+        assert result["yoy_delta_percentage"] is not None
+        # +100% growth expected
+        assert result["yoy_delta_percentage"] == pytest.approx(100.0, rel=0.01)
+
+    def test_excludes_users_with_zero_goal(self):
+        request = _admin_request()
+        UserFactory(role="missionary", monthly_support_goal_cents=0)
+        UserFactory(role="missionary", monthly_support_goal_cents=50_000)
+        result = get_fiscal_year_pace(request)
+        assert result["annual_goal_cents"] == 50_000 * 12
+
+
+# --- get_missionaries_behind_goal ----------------------------------------------
+
+
+@pytest.mark.django_db
+class TestMissionariesBehindGoal:
+    def test_empty_state(self):
+        request = _admin_request()
+        result = get_missionaries_behind_goal(request)
+        assert result["missionaries"] == []
+        assert result["total_missionaries"] == 0
+        assert result["total_excluded_no_goal"] == 0
+
+    def test_excludes_zero_goal_missionaries(self):
+        request = _admin_request()
+        UserFactory(role="missionary", monthly_support_goal_cents=0)
+        m2 = UserFactory(role="missionary", monthly_support_goal_cents=100_000)
+        result = get_missionaries_behind_goal(request)
+        assert len(result["missionaries"]) == 1
+        assert result["missionaries"][0]["user_id"] == str(m2.id)
+        assert result["total_excluded_no_goal"] == 1
+        assert result["total_missionaries"] == 2
+
+    def test_sorts_ascending_by_pace(self):
+        request = _admin_request()
+        today = date.today()
+        month_start = today.replace(day=1)
+        days_in_month = monthrange(today.year, today.month)[1]
+        ratio = today.day / days_in_month
+
+        # Missionary behind (0 raised)
+        m_low = UserFactory(role="missionary", monthly_support_goal_cents=100_000)
+        # Missionary on-pace: raised exactly expected amount
+        m_high = UserFactory(role="missionary", monthly_support_goal_cents=100_000)
+        contact = ContactFactory(owner=m_high)
+        expected = int(100_000 * ratio)
+        GiftFactory(donor_contact=contact, amount_cents=expected, gift_date=month_start)
+
+        result = get_missionaries_behind_goal(request)
+        assert [m["user_id"] for m in result["missionaries"]] == [str(m_low.id), str(m_high.id)]
+        assert (
+            result["missionaries"][0]["pace_percentage"]
+            < result["missionaries"][1]["pace_percentage"]
+        )
+
+    def test_limit_respected(self):
+        request = _admin_request()
+        for _ in range(5):
+            UserFactory(role="missionary", monthly_support_goal_cents=100_000)
+        result = get_missionaries_behind_goal(request, limit=3)
+        assert len(result["missionaries"]) == 3
+
+
+# --- get_pipeline_funnel_with_conversion --------------------------------------
+
+
+@pytest.mark.django_db
+class TestPipelineFunnelWithConversion:
+    def test_empty_pipeline(self):
+        request = _admin_request()
+        result = get_pipeline_funnel_with_conversion(request)
+        assert result["total_in_pipeline"] == 0
+        assert result["weakest_transition"] is None
+        for stage in result["stages"]:
+            assert stage["count_at_or_past"] == 0
+            assert stage["is_weakest_transition"] is False
+
+    def test_cumulative_reach_counts_and_weakest_flag(self):
+        request = _admin_request()
+        missionary = UserFactory(role="missionary")
+        journal = Journal.objects.create(owner=missionary, name="J", goal_amount=1000)
+
+        def _make_jc_with_max_stage(max_stage):
+            contact = ContactFactory(owner=missionary)
+            jc = JournalContact.objects.create(journal=journal, contact=contact)
+            JournalStageEvent.objects.create(
+                journal_contact=jc,
+                stage=max_stage,
+                event_type=StageEventType.NOTE_ADDED,
+            )
+            return jc
+
+        # 10 journal contacts reached CONTACT
+        for _ in range(10):
+            _make_jc_with_max_stage(PipelineStage.CONTACT)
+        # 5 reached SCHEDULED
+        for _ in range(5):
+            _make_jc_with_max_stage(PipelineStage.SCHEDULED)
+        # 1 reached MEET
+        for _ in range(1):
+            _make_jc_with_max_stage(PipelineStage.MEET)
+
+        result = get_pipeline_funnel_with_conversion(request)
+        counts = {s["stage"]: s["count_at_or_past"] for s in result["stages"]}
+        assert counts[PipelineStage.CONTACT.value] == 16
+        assert counts[PipelineStage.SCHEDULED.value] == 6
+        assert counts[PipelineStage.MEET.value] == 1
+        assert counts[PipelineStage.CLOSE.value] == 0
+
+        # weakest = MEET->CLOSE (0%)
+        weakest = result["weakest_transition"]
+        assert weakest is not None
+        assert weakest["from"] == PipelineStage.MEET.value
+        assert weakest["to"] == PipelineStage.CLOSE.value
+        # Exactly one stage flagged
+        flagged = [s for s in result["stages"] if s["is_weakest_transition"]]
+        assert len(flagged) == 1
+
+
+# --- get_weekly_engagement ----------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestWeeklyEngagement:
+    def test_returns_requested_number_of_weeks(self):
+        request = _admin_request()
+        result = get_weekly_engagement(request, weeks=12)
+        assert len(result["weeks"]) == 12
+
+    def test_counts_distinct_active_missionaries(self):
+        request = _admin_request()
+        m1 = UserFactory(role="missionary")
+        m2 = UserFactory(role="missionary")
+        for m in (m1, m2):
+            j = Journal.objects.create(owner=m, name="J", goal_amount=1000)
+            c = ContactFactory(owner=m)
+            jc = JournalContact.objects.create(journal=j, contact=c)
+            JournalStageEvent.objects.create(
+                journal_contact=jc,
+                stage=PipelineStage.CONTACT,
+                event_type=StageEventType.NOTE_ADDED,
+            )
+        result = get_weekly_engagement(request, weeks=2)
+        # Current week should reflect 2 distinct missionaries.
+        current_week = result["weeks"][-1]
+        assert current_week["active_missionaries"] == 2
+
+
+# --- get_fiscal_year_donations ------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestFiscalYearDonations:
+    def test_returns_twelve_months(self):
+        request = _admin_request()
+        result = get_fiscal_year_donations(request)
+        assert len(result["months"]) == 12
+
+    def test_future_months_marked_and_nulled(self):
+        request = _admin_request()
+        with patch("apps.insights.admin_analytics_services.date") as mock_date:
+            # Force "today" to be Aug 15, 2025 (FY 2025-2026, month index 2 of FY)
+            mock_date.today.return_value = date(2025, 8, 15)
+            mock_date.side_effect = lambda *args, **kw: date(*args, **kw)
+            result = get_fiscal_year_donations(request)
+
+        # Jul + Aug are non-future, Sep..Jun are future
+        future_flags = [m["is_future"] for m in result["months"]]
+        assert future_flags[:2] == [False, False]
+        assert all(future_flags[2:])
+        for m in result["months"]:
+            if m["is_future"]:
+                assert m["current_cents"] is None
+            else:
+                assert m["current_cents"] is not None
+
+    def test_sums_current_and_prior_year_gifts(self):
+        request = _admin_request()
+        fy_start, _ = get_current_fiscal_year_bounds()
+        prior_start, _ = get_prior_fiscal_year_bounds()
+        missionary = UserFactory(role="missionary")
+        contact = ContactFactory(owner=missionary)
+        GiftFactory(
+            donor_contact=contact, amount_cents=25_000, gift_date=fy_start + timedelta(days=5)
+        )
+        GiftFactory(
+            donor_contact=contact, amount_cents=40_000, gift_date=prior_start + timedelta(days=5)
+        )
+
+        result = get_fiscal_year_donations(request)
+        assert result["current_fy_total_cents"] == 25_000
+        assert result["prior_fy_total_cents"] == 40_000

--- a/apps/insights/tests/test_admin_analytics_views.py
+++ b/apps/insights/tests/test_admin_analytics_views.py
@@ -1,0 +1,128 @@
+"""
+Integration tests for admin analytics redesign DRF views (Issue #49).
+
+Verifies:
+  - Permission matrix: anonymous 401, non-admin 403, admin 200.
+  - Response shape matches serializer contract.
+  - Query params (limit, weeks) are honored and validated.
+"""
+from rest_framework import status
+from rest_framework.test import APIClient
+
+import pytest
+
+from apps.users.tests.factories import CoachUserFactory, SupervisorUserFactory, UserFactory
+
+ADMIN_ENDPOINTS = [
+    "/api/v1/insights/admin/fiscal-year-pace/",
+    "/api/v1/insights/admin/missionaries-behind-goal/",
+    "/api/v1/insights/admin/pipeline-funnel-conversion/",
+    "/api/v1/insights/admin/weekly-engagement/",
+    "/api/v1/insights/admin/fiscal-year-donations/",
+]
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("url", ADMIN_ENDPOINTS)
+class TestAdminAnalyticsPermissions:
+    def test_anonymous_gets_401(self, url):
+        response = APIClient().get(url)
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_missionary_gets_403(self, url, authenticated_client):
+        client, _ = authenticated_client
+        response = client.get(url)
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_supervisor_gets_403(self, url):
+        client = APIClient()
+        client.force_authenticate(user=SupervisorUserFactory())
+        response = client.get(url)
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_coach_gets_403(self, url):
+        client = APIClient()
+        client.force_authenticate(user=CoachUserFactory())
+        response = client.get(url)
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_admin_gets_200(self, url, admin_client):
+        client, _ = admin_client
+        response = client.get(url)
+        assert response.status_code == status.HTTP_200_OK
+
+
+@pytest.mark.django_db
+class TestFiscalYearPaceEndpoint:
+    def test_response_shape(self, admin_client):
+        client, _ = admin_client
+        response = client.get("/api/v1/insights/admin/fiscal-year-pace/")
+        assert response.status_code == 200
+        body = response.data
+        for key in (
+            "fy_start",
+            "fy_end",
+            "raised_cents",
+            "annual_goal_cents",
+            "expected_by_today_cents",
+            "pace_percentage",
+            "prior_year_raised_cents",
+            "yoy_delta_percentage",
+            "last_import_at",
+        ):
+            assert key in body
+
+
+@pytest.mark.django_db
+class TestMissionariesBehindGoalEndpoint:
+    def test_limit_capped_at_50(self, admin_client):
+        client, _ = admin_client
+        # Request out-of-range limit — view should clamp to 50.
+        response = client.get("/api/v1/insights/admin/missionaries-behind-goal/?limit=999")
+        assert response.status_code == 200
+        assert "missionaries" in response.data
+        assert "total_excluded_no_goal" in response.data
+
+    def test_respects_limit_param(self, admin_client):
+        client, _ = admin_client
+        for _ in range(4):
+            UserFactory(role="missionary", monthly_support_goal_cents=100_000)
+        response = client.get("/api/v1/insights/admin/missionaries-behind-goal/?limit=2")
+        assert response.status_code == 200
+        assert len(response.data["missionaries"]) == 2
+
+
+@pytest.mark.django_db
+class TestPipelineFunnelConversionEndpoint:
+    def test_returns_all_seven_stages(self, admin_client):
+        client, _ = admin_client
+        response = client.get("/api/v1/insights/admin/pipeline-funnel-conversion/")
+        assert response.status_code == 200
+        assert len(response.data["stages"]) == 7
+
+
+@pytest.mark.django_db
+class TestWeeklyEngagementEndpoint:
+    def test_weeks_param_honored(self, admin_client):
+        client, _ = admin_client
+        response = client.get("/api/v1/insights/admin/weekly-engagement/?weeks=4")
+        assert response.status_code == 200
+        assert len(response.data["weeks"]) == 4
+
+    def test_default_is_twelve_weeks(self, admin_client):
+        client, _ = admin_client
+        response = client.get("/api/v1/insights/admin/weekly-engagement/")
+        assert response.status_code == 200
+        assert len(response.data["weeks"]) == 12
+
+
+@pytest.mark.django_db
+class TestFiscalYearDonationsEndpoint:
+    def test_returns_twelve_months(self, admin_client):
+        client, _ = admin_client
+        response = client.get("/api/v1/insights/admin/fiscal-year-donations/")
+        assert response.status_code == 200
+        assert len(response.data["months"]) == 12
+        for month in response.data["months"]:
+            assert "short_label" in month
+            assert "is_future" in month

--- a/apps/insights/urls.py
+++ b/apps/insights/urls.py
@@ -3,50 +3,85 @@ URL patterns for insights app.
 """
 from django.urls import path
 
+from apps.insights.export_views import StalledContactsCSVView, TeamActivityCSVView
 from apps.insights.views import (
     ConversionFunnelView,
     DashboardOverviewView,
     DonationsByMonthView,
     DonationsByYearView,
+    FiscalYearDonationsView,
+    FiscalYearPaceView,
     FollowUpsView,
     LateDonationsView,
+    MissionariesBehindGoalView,
     MonthlyCommitmentsView,
+    PipelineFunnelConversionView,
+    StageContactsView,
     StalledContactsView,
     TeamActivityView,
     TeamTrendsView,
     TransactionsView,
+    UserDrilldownView,
+    UserJournalsView,
     UserPerformanceView,
     UserTrendsView,
-    UserJournalsView,
-    StageContactsView,
-    UserDrilldownView,
-)
-from apps.insights.export_views import (
-    StalledContactsCSVView,
-    TeamActivityCSVView,
+    WeeklyEngagementView,
 )
 
-app_name = 'insights'
+app_name = "insights"
 
 urlpatterns = [
-    path('donations-by-month/', DonationsByMonthView.as_view(), name='donations-by-month'),
-    path('donations-by-year/', DonationsByYearView.as_view(), name='donations-by-year'),
-    path('monthly-commitments/', MonthlyCommitmentsView.as_view(), name='monthly-commitments'),
-    path('late-donations/', LateDonationsView.as_view(), name='late-donations'),
-    path('follow-ups/', FollowUpsView.as_view(), name='follow-ups'),
-    path('transactions/', TransactionsView.as_view(), name='transactions'),
-
+    path("donations-by-month/", DonationsByMonthView.as_view(), name="donations-by-month"),
+    path("donations-by-year/", DonationsByYearView.as_view(), name="donations-by-year"),
+    path("monthly-commitments/", MonthlyCommitmentsView.as_view(), name="monthly-commitments"),
+    path("late-donations/", LateDonationsView.as_view(), name="late-donations"),
+    path("follow-ups/", FollowUpsView.as_view(), name="follow-ups"),
+    path("transactions/", TransactionsView.as_view(), name="transactions"),
     # Admin analytics endpoints (Phase 13)
-    path('admin/dashboard-overview/', DashboardOverviewView.as_view(), name='admin-dashboard-overview'),
-    path('admin/stalled-contacts/', StalledContactsView.as_view(), name='admin-stalled-contacts'),
-    path('admin/user-performance/', UserPerformanceView.as_view(), name='admin-user-performance'),
-    path('admin/conversion-funnel/', ConversionFunnelView.as_view(), name='admin-conversion-funnel'),
-    path('admin/team-activity/', TeamActivityView.as_view(), name='admin-team-activity'),
-    path('admin/team-trends/', TeamTrendsView.as_view(), name='admin-team-trends'),
-    path('admin/user-trends/', UserTrendsView.as_view(), name='admin-user-trends'),
-    path('admin/user-journals/', UserJournalsView.as_view(), name='admin-user-journals'),
-    path('admin/stage-contacts/', StageContactsView.as_view(), name='admin-stage-contacts'),
-    path('admin/user-drilldown/', UserDrilldownView.as_view(), name='admin-user-drilldown'),
-    path('admin/stalled-contacts/export/', StalledContactsCSVView.as_view(), name='admin-stalled-contacts-export'),
-    path('admin/team-activity/export/', TeamActivityCSVView.as_view(), name='admin-team-activity-export'),
+    path(
+        "admin/dashboard-overview/",
+        DashboardOverviewView.as_view(),
+        name="admin-dashboard-overview",
+    ),
+    path("admin/stalled-contacts/", StalledContactsView.as_view(), name="admin-stalled-contacts"),
+    path("admin/user-performance/", UserPerformanceView.as_view(), name="admin-user-performance"),
+    path(
+        "admin/conversion-funnel/", ConversionFunnelView.as_view(), name="admin-conversion-funnel"
+    ),
+    path("admin/team-activity/", TeamActivityView.as_view(), name="admin-team-activity"),
+    path("admin/team-trends/", TeamTrendsView.as_view(), name="admin-team-trends"),
+    path("admin/user-trends/", UserTrendsView.as_view(), name="admin-user-trends"),
+    path("admin/user-journals/", UserJournalsView.as_view(), name="admin-user-journals"),
+    path("admin/stage-contacts/", StageContactsView.as_view(), name="admin-stage-contacts"),
+    path("admin/user-drilldown/", UserDrilldownView.as_view(), name="admin-user-drilldown"),
+    path(
+        "admin/stalled-contacts/export/",
+        StalledContactsCSVView.as_view(),
+        name="admin-stalled-contacts-export",
+    ),
+    path(
+        "admin/team-activity/export/",
+        TeamActivityCSVView.as_view(),
+        name="admin-team-activity-export",
+    ),
+    # Admin analytics redesign (Issue #49)
+    path("admin/fiscal-year-pace/", FiscalYearPaceView.as_view(), name="admin-fiscal-year-pace"),
+    path(
+        "admin/missionaries-behind-goal/",
+        MissionariesBehindGoalView.as_view(),
+        name="admin-missionaries-behind-goal",
+    ),
+    path(
+        "admin/pipeline-funnel-conversion/",
+        PipelineFunnelConversionView.as_view(),
+        name="admin-pipeline-funnel-conversion",
+    ),
+    path(
+        "admin/weekly-engagement/", WeeklyEngagementView.as_view(), name="admin-weekly-engagement"
+    ),
+    path(
+        "admin/fiscal-year-donations/",
+        FiscalYearDonationsView.as_view(),
+        name="admin-fiscal-year-donations",
+    ),
 ]

--- a/apps/insights/views.py
+++ b/apps/insights/views.py
@@ -3,42 +3,55 @@ Views for Insights/Reports data.
 """
 
 
-from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework import permissions, status
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from drf_spectacular.utils import OpenApiParameter, extend_schema
+
 from apps.core.permissions import IsAdmin, is_financial_role
 from apps.core.utils import get_safe_int_param, get_safe_year_param, validate_date_params
+from apps.insights.admin_analytics_services import (
+    get_fiscal_year_donations,
+    get_fiscal_year_pace,
+    get_missionaries_behind_goal,
+    get_pipeline_funnel_with_conversion,
+    get_weekly_engagement,
+)
+from apps.insights.serializers import (
+    ConversionFunnelResponseSerializer,
+    DashboardOverviewSerializer,
+    FiscalYearDonationsResponseSerializer,
+    FiscalYearPaceResponseSerializer,
+    MissionariesBehindGoalResponseSerializer,
+    PipelineFunnelConversionResponseSerializer,
+    StageContactsResponseSerializer,
+    StalledContactsResponseSerializer,
+    TeamActivityResponseSerializer,
+    TeamTrendsResponseSerializer,
+    UserDrilldownResponseSerializer,
+    UserJournalsResponseSerializer,
+    UserPerformanceResponseSerializer,
+    UserTrendsResponseSerializer,
+    WeeklyEngagementResponseSerializer,
+)
 from apps.insights.services import (
+    get_conversion_funnel,
     get_dashboard_overview,
     get_donations_by_month,
     get_donations_by_year,
     get_follow_ups,
     get_late_donations,
     get_monthly_commitments,
+    get_stage_contacts,
     get_stalled_contacts,
-    get_transactions,
-    get_user_performance,
-    get_conversion_funnel,
     get_team_activity,
     get_team_trends,
-    get_user_trends,
-    get_user_journals,
-    get_stage_contacts,
+    get_transactions,
     get_user_drilldown,
-)
-from apps.insights.serializers import (
-    DashboardOverviewSerializer,
-    StalledContactsResponseSerializer,
-    UserPerformanceResponseSerializer,
-    ConversionFunnelResponseSerializer,
-    TeamActivityResponseSerializer,
-    TeamTrendsResponseSerializer,
-    UserTrendsResponseSerializer,
-    UserJournalsResponseSerializer,
-    StageContactsResponseSerializer,
-    UserDrilldownResponseSerializer,
+    get_user_journals,
+    get_user_performance,
+    get_user_trends,
 )
 
 
@@ -46,19 +59,20 @@ class DonationsByMonthView(APIView):
     """
     GET: Get donation totals grouped by month for a year.
     """
+
     permission_classes = [permissions.IsAuthenticated]
 
     @extend_schema(
-        tags=['insights'],
-        summary='Get donations by month',
+        tags=["insights"],
+        summary="Get donations by month",
         parameters=[
-            OpenApiParameter(name='year', description='Calendar year (default: current)', type=int)
-        ]
+            OpenApiParameter(name="year", description="Calendar year (default: current)", type=int)
+        ],
     )
     def get(self, request):
         if not is_financial_role(request.user):
-            return Response({'detail': 'Not authorized'}, status=status.HTTP_403_FORBIDDEN)
-        year = get_safe_year_param(request, 'year')
+            return Response({"detail": "Not authorized"}, status=status.HTTP_403_FORBIDDEN)
+        year = get_safe_year_param(request, "year")
         return Response(get_donations_by_month(request.user, year=year, request=request))
 
 
@@ -66,19 +80,22 @@ class DonationsByYearView(APIView):
     """
     GET: Get donation totals grouped by year.
     """
+
     permission_classes = [permissions.IsAuthenticated]
 
     @extend_schema(
-        tags=['insights'],
-        summary='Get donations by year',
+        tags=["insights"],
+        summary="Get donations by year",
         parameters=[
-            OpenApiParameter(name='years', description='Number of years to include (default: 5)', type=int)
-        ]
+            OpenApiParameter(
+                name="years", description="Number of years to include (default: 5)", type=int
+            )
+        ],
     )
     def get(self, request):
         if not is_financial_role(request.user):
-            return Response({'detail': 'Not authorized'}, status=status.HTTP_403_FORBIDDEN)
-        years = get_safe_int_param(request, 'years', default=5, min_val=1, max_val=50)
+            return Response({"detail": "Not authorized"}, status=status.HTTP_403_FORBIDDEN)
+        years = get_safe_int_param(request, "years", default=5, min_val=1, max_val=50)
         return Response(get_donations_by_year(request.user, years=years, request=request))
 
 
@@ -86,12 +103,13 @@ class MonthlyCommitmentsView(APIView):
     """
     GET: Get summary of active recurring pledges.
     """
+
     permission_classes = [permissions.IsAuthenticated]
 
-    @extend_schema(tags=['insights'], summary='Get monthly commitments')
+    @extend_schema(tags=["insights"], summary="Get monthly commitments")
     def get(self, request):
         if not is_financial_role(request.user):
-            return Response({'detail': 'Not authorized'}, status=status.HTTP_403_FORBIDDEN)
+            return Response({"detail": "Not authorized"}, status=status.HTTP_403_FORBIDDEN)
         return Response(get_monthly_commitments(request.user, request=request))
 
 
@@ -99,19 +117,20 @@ class LateDonationsView(APIView):
     """
     GET: Get pledges with late donations.
     """
+
     permission_classes = [permissions.IsAuthenticated]
 
     @extend_schema(
-        tags=['insights'],
-        summary='Get late donations',
+        tags=["insights"],
+        summary="Get late donations",
         parameters=[
-            OpenApiParameter(name='limit', description='Max results (default: 50)', type=int)
-        ]
+            OpenApiParameter(name="limit", description="Max results (default: 50)", type=int)
+        ],
     )
     def get(self, request):
         if not is_financial_role(request.user):
-            return Response({'detail': 'Not authorized'}, status=status.HTTP_403_FORBIDDEN)
-        limit = get_safe_int_param(request, 'limit', default=50, min_val=1, max_val=500)
+            return Response({"detail": "Not authorized"}, status=status.HTTP_403_FORBIDDEN)
+        limit = get_safe_int_param(request, "limit", default=50, min_val=1, max_val=500)
         return Response(get_late_donations(request.user, limit=limit))
 
 
@@ -119,17 +138,18 @@ class FollowUpsView(APIView):
     """
     GET: Get incomplete tasks needing follow-up.
     """
+
     permission_classes = [permissions.IsAuthenticated]
 
     @extend_schema(
-        tags=['insights'],
-        summary='Get follow-ups',
+        tags=["insights"],
+        summary="Get follow-ups",
         parameters=[
-            OpenApiParameter(name='limit', description='Max results (default: 50)', type=int)
-        ]
+            OpenApiParameter(name="limit", description="Max results (default: 50)", type=int)
+        ],
     )
     def get(self, request):
-        limit = get_safe_int_param(request, 'limit', default=50, min_val=1, max_val=500)
+        limit = get_safe_int_param(request, "limit", default=50, min_val=1, max_val=500)
         return Response(get_follow_ups(request.user, limit=limit, request=request))
 
 
@@ -138,37 +158,46 @@ class TransactionsView(APIView):
     GET: Get full transaction ledger.
     Admin-only endpoint.
     """
+
     permission_classes = [permissions.IsAuthenticated, IsAdmin]
 
     @extend_schema(
-        tags=['insights'],
-        summary='Get transactions ledger (admin only)',
+        tags=["insights"],
+        summary="Get transactions ledger (admin only)",
         parameters=[
-            OpenApiParameter(name='limit', description='Max results (default: 100)', type=int),
-            OpenApiParameter(name='offset', description='Offset for pagination (default: 0)', type=int),
-            OpenApiParameter(name='contact_id', description='Filter by contact ID', type=str),
-            OpenApiParameter(name='date_from', description='Filter by start date (YYYY-MM-DD)', type=str),
-            OpenApiParameter(name='date_to', description='Filter by end date (YYYY-MM-DD)', type=str),
-        ]
+            OpenApiParameter(name="limit", description="Max results (default: 100)", type=int),
+            OpenApiParameter(
+                name="offset", description="Offset for pagination (default: 0)", type=int
+            ),
+            OpenApiParameter(name="contact_id", description="Filter by contact ID", type=str),
+            OpenApiParameter(
+                name="date_from", description="Filter by start date (YYYY-MM-DD)", type=str
+            ),
+            OpenApiParameter(
+                name="date_to", description="Filter by end date (YYYY-MM-DD)", type=str
+            ),
+        ],
     )
     def get(self, request):
-        limit = get_safe_int_param(request, 'limit', default=100, min_val=1, max_val=1000)
-        offset = get_safe_int_param(request, 'offset', default=0, min_val=0, max_val=100000)
-        contact_id = request.query_params.get('contact_id')
+        limit = get_safe_int_param(request, "limit", default=100, min_val=1, max_val=1000)
+        offset = get_safe_int_param(request, "offset", default=0, min_val=0, max_val=100000)
+        contact_id = request.query_params.get("contact_id")
 
         dates, err = validate_date_params(request)
         if err:
             return err
-        date_from, date_to = dates['date_from'], dates['date_to']
+        date_from, date_to = dates["date_from"], dates["date_to"]
 
-        return Response(get_transactions(
-            request.user,
-            limit=limit,
-            offset=offset,
-            contact_id=contact_id,
-            date_from=date_from,
-            date_to=date_to,
-        ))
+        return Response(
+            get_transactions(
+                request.user,
+                limit=limit,
+                offset=offset,
+                contact_id=contact_id,
+                date_from=date_from,
+                date_to=date_to,
+            )
+        )
 
 
 # Admin Analytics Views (Phase 13)
@@ -179,24 +208,27 @@ class DashboardOverviewView(APIView):
     GET: Admin dashboard overview with cross-user aggregated stats.
     Admin-only endpoint.
     """
+
     permission_classes = [permissions.IsAuthenticated, IsAdmin]
 
     @extend_schema(
-        tags=['insights'],
-        summary='Get dashboard overview (admin only)',
-        description='Cross-user aggregation for admin dashboard: total contacts, active journals, stalled count, conversion rate, donation summary.',
+        tags=["insights"],
+        summary="Get dashboard overview (admin only)",
+        description="Cross-user aggregation for admin dashboard: total contacts, active journals, stalled count, conversion rate, donation summary.",
         parameters=[
-            OpenApiParameter(name='date_from', description='Filter start date (YYYY-MM-DD)', type=str),
-            OpenApiParameter(name='date_to', description='Filter end date (YYYY-MM-DD)', type=str),
+            OpenApiParameter(
+                name="date_from", description="Filter start date (YYYY-MM-DD)", type=str
+            ),
+            OpenApiParameter(name="date_to", description="Filter end date (YYYY-MM-DD)", type=str),
         ],
-        responses={200: DashboardOverviewSerializer}
+        responses={200: DashboardOverviewSerializer},
     )
     def get(self, request):
         _, err = validate_date_params(request)
         if err:
             return err
-        date_from = request.query_params.get('date_from')
-        date_to = request.query_params.get('date_to')
+        date_from = request.query_params.get("date_from")
+        date_to = request.query_params.get("date_to")
 
         data = get_dashboard_overview(date_from=date_from, date_to=date_to)
         serializer = DashboardOverviewSerializer(data)
@@ -208,43 +240,59 @@ class StalledContactsView(APIView):
     GET: Get contacts with last journal activity >14 days ago.
     Admin-only endpoint with pagination and sorting.
     """
+
     permission_classes = [permissions.IsAuthenticated, IsAdmin]
 
     @extend_schema(
-        tags=['insights'],
-        summary='Get stalled contacts (admin only)',
+        tags=["insights"],
+        summary="Get stalled contacts (admin only)",
         parameters=[
-            OpenApiParameter(name='limit', description='Max results (default: 50)', type=int),
-            OpenApiParameter(name='offset', description='Offset for pagination (default: 0)', type=int),
-            OpenApiParameter(name='sort_by', description='Sort field (days_stalled, full_name, owner_name, last_activity_date)', type=str),
-            OpenApiParameter(name='sort_dir', description='Sort direction (asc, desc)', type=str),
-            OpenApiParameter(name='date_from', description='Filter start date (YYYY-MM-DD)', type=str),
-            OpenApiParameter(name='date_to', description='Filter end date (YYYY-MM-DD)', type=str),
+            OpenApiParameter(name="limit", description="Max results (default: 50)", type=int),
+            OpenApiParameter(
+                name="offset", description="Offset for pagination (default: 0)", type=int
+            ),
+            OpenApiParameter(
+                name="sort_by",
+                description="Sort field (days_stalled, full_name, owner_name, last_activity_date)",
+                type=str,
+            ),
+            OpenApiParameter(name="sort_dir", description="Sort direction (asc, desc)", type=str),
+            OpenApiParameter(
+                name="date_from", description="Filter start date (YYYY-MM-DD)", type=str
+            ),
+            OpenApiParameter(name="date_to", description="Filter end date (YYYY-MM-DD)", type=str),
         ],
-        responses={200: StalledContactsResponseSerializer}
+        responses={200: StalledContactsResponseSerializer},
     )
     def get(self, request):
-        limit = get_safe_int_param(request, 'limit', default=50, min_val=1, max_val=100)
-        offset = get_safe_int_param(request, 'offset', default=0, min_val=0, max_val=100000)
+        limit = get_safe_int_param(request, "limit", default=50, min_val=1, max_val=100)
+        offset = get_safe_int_param(request, "offset", default=0, min_val=0, max_val=100000)
 
         # Parse and validate sort parameters
-        sort_by = request.query_params.get('sort_by', 'days_stalled')
-        sort_dir = request.query_params.get('sort_dir', 'desc')
+        sort_by = request.query_params.get("sort_by", "days_stalled")
+        sort_dir = request.query_params.get("sort_dir", "desc")
 
         # Validate sort_by against allowed values
-        if sort_by not in ('days_stalled', 'full_name', 'owner_name', 'last_activity_date'):
-            sort_by = 'days_stalled'
-        if sort_dir not in ('asc', 'desc'):
-            sort_dir = 'desc'
+        if sort_by not in ("days_stalled", "full_name", "owner_name", "last_activity_date"):
+            sort_by = "days_stalled"
+        if sort_dir not in ("asc", "desc"):
+            sort_dir = "desc"
 
         # Validate date parameters
         _, err = validate_date_params(request)
         if err:
             return err
-        date_from = request.query_params.get('date_from')
-        date_to = request.query_params.get('date_to')
+        date_from = request.query_params.get("date_from")
+        date_to = request.query_params.get("date_to")
 
-        data = get_stalled_contacts(limit=limit, offset=offset, sort_by=sort_by, sort_dir=sort_dir, date_from=date_from, date_to=date_to)
+        data = get_stalled_contacts(
+            limit=limit,
+            offset=offset,
+            sort_by=sort_by,
+            sort_dir=sort_dir,
+            date_from=date_from,
+            date_to=date_to,
+        )
         serializer = StalledContactsResponseSerializer(data)
         return Response(serializer.data)
 
@@ -254,13 +302,14 @@ class UserPerformanceView(APIView):
     GET: Per-missionary performance metrics.
     Admin-only endpoint.
     """
+
     permission_classes = [permissions.IsAuthenticated, IsAdmin]
 
     @extend_schema(
-        tags=['insights'],
-        summary='Get user performance metrics (admin only)',
-        description='Per-missionary: total contacts, active journals, decisions logged, donation totals.',
-        responses={200: UserPerformanceResponseSerializer}
+        tags=["insights"],
+        summary="Get user performance metrics (admin only)",
+        description="Per-missionary: total contacts, active journals, decisions logged, donation totals.",
+        responses={200: UserPerformanceResponseSerializer},
     )
     def get(self, request):
         data = get_user_performance()
@@ -273,25 +322,28 @@ class ConversionFunnelView(APIView):
     GET: Pipeline stage distribution across all missionaries.
     Admin-only endpoint.
     """
+
     permission_classes = [permissions.IsAuthenticated, IsAdmin]
 
     @extend_schema(
-        tags=['insights'],
-        summary='Get conversion funnel (admin only)',
-        description='Pipeline stage distribution with counts and percentages using Journal 6-stage pipeline.',
+        tags=["insights"],
+        summary="Get conversion funnel (admin only)",
+        description="Pipeline stage distribution with counts and percentages using Journal 6-stage pipeline.",
         parameters=[
-            OpenApiParameter(name='date_from', description='Filter start date (YYYY-MM-DD)', type=str),
-            OpenApiParameter(name='date_to', description='Filter end date (YYYY-MM-DD)', type=str),
+            OpenApiParameter(
+                name="date_from", description="Filter start date (YYYY-MM-DD)", type=str
+            ),
+            OpenApiParameter(name="date_to", description="Filter end date (YYYY-MM-DD)", type=str),
         ],
-        responses={200: ConversionFunnelResponseSerializer}
+        responses={200: ConversionFunnelResponseSerializer},
     )
     def get(self, request):
         # Validate date parameters
         _, err = validate_date_params(request)
         if err:
             return err
-        date_from = request.query_params.get('date_from')
-        date_to = request.query_params.get('date_to')
+        date_from = request.query_params.get("date_from")
+        date_to = request.query_params.get("date_to")
 
         data = get_conversion_funnel(date_from=date_from, date_to=date_to)
         serializer = ConversionFunnelResponseSerializer(data)
@@ -303,27 +355,30 @@ class TeamActivityView(APIView):
     GET: Recent activity across all users.
     Admin-only endpoint.
     """
+
     permission_classes = [permissions.IsAuthenticated, IsAdmin]
 
     @extend_schema(
-        tags=['insights'],
-        summary='Get team activity (admin only)',
+        tags=["insights"],
+        summary="Get team activity (admin only)",
         parameters=[
-            OpenApiParameter(name='limit', description='Max results (default: 50)', type=int),
-            OpenApiParameter(name='date_from', description='Filter start date (YYYY-MM-DD)', type=str),
-            OpenApiParameter(name='date_to', description='Filter end date (YYYY-MM-DD)', type=str),
+            OpenApiParameter(name="limit", description="Max results (default: 50)", type=int),
+            OpenApiParameter(
+                name="date_from", description="Filter start date (YYYY-MM-DD)", type=str
+            ),
+            OpenApiParameter(name="date_to", description="Filter end date (YYYY-MM-DD)", type=str),
         ],
-        responses={200: TeamActivityResponseSerializer}
+        responses={200: TeamActivityResponseSerializer},
     )
     def get(self, request):
-        limit = get_safe_int_param(request, 'limit', default=50, min_val=1, max_val=200)
+        limit = get_safe_int_param(request, "limit", default=50, min_val=1, max_val=200)
 
         # Validate date parameters
         _, err = validate_date_params(request)
         if err:
             return err
-        date_from = request.query_params.get('date_from')
-        date_to = request.query_params.get('date_to')
+        date_from = request.query_params.get("date_from")
+        date_to = request.query_params.get("date_to")
 
         data = get_team_activity(limit=limit, date_from=date_from, date_to=date_to)
         serializer = TeamActivityResponseSerializer(data)
@@ -335,28 +390,33 @@ class TeamTrendsView(APIView):
     GET: Team activity trends over past N weeks.
     Admin-only endpoint.
     """
+
     permission_classes = [permissions.IsAuthenticated, IsAdmin]
 
     @extend_schema(
-        tags=['insights'],
-        summary='Get team trends (admin only)',
-        description='Weekly aggregated metrics: decisions logged, donations received, stage progressions.',
+        tags=["insights"],
+        summary="Get team trends (admin only)",
+        description="Weekly aggregated metrics: decisions logged, donations received, stage progressions.",
         parameters=[
-            OpenApiParameter(name='weeks', description='Number of weeks (default: 12, min: 1, max: 52)', type=int),
-            OpenApiParameter(name='date_from', description='Filter start date (YYYY-MM-DD)', type=str),
-            OpenApiParameter(name='date_to', description='Filter end date (YYYY-MM-DD)', type=str),
+            OpenApiParameter(
+                name="weeks", description="Number of weeks (default: 12, min: 1, max: 52)", type=int
+            ),
+            OpenApiParameter(
+                name="date_from", description="Filter start date (YYYY-MM-DD)", type=str
+            ),
+            OpenApiParameter(name="date_to", description="Filter end date (YYYY-MM-DD)", type=str),
         ],
-        responses={200: TeamTrendsResponseSerializer}
+        responses={200: TeamTrendsResponseSerializer},
     )
     def get(self, request):
-        weeks = get_safe_int_param(request, 'weeks', default=12, min_val=1, max_val=52)
+        weeks = get_safe_int_param(request, "weeks", default=12, min_val=1, max_val=52)
 
         # Validate date parameters
         _, err = validate_date_params(request)
         if err:
             return err
-        date_from = request.query_params.get('date_from')
-        date_to = request.query_params.get('date_to')
+        date_from = request.query_params.get("date_from")
+        date_to = request.query_params.get("date_to")
 
         data = get_team_trends(weeks=weeks, date_from=date_from, date_to=date_to)
         serializer = TeamTrendsResponseSerializer(data)
@@ -368,24 +428,29 @@ class UserTrendsView(APIView):
     GET: User activity trends over past N weeks for a specific user.
     Admin-only endpoint.
     """
+
     permission_classes = [permissions.IsAuthenticated, IsAdmin]
 
     @extend_schema(
-        tags=['insights'],
-        summary='Get user trends (admin only)',
-        description='Weekly aggregated metrics for a specific user: decisions logged, donations received, stage progressions.',
+        tags=["insights"],
+        summary="Get user trends (admin only)",
+        description="Weekly aggregated metrics for a specific user: decisions logged, donations received, stage progressions.",
         parameters=[
-            OpenApiParameter(name='user_id', description='User ID (required)', type=str, required=True),
-            OpenApiParameter(name='weeks', description='Number of weeks (default: 12, min: 1, max: 52)', type=int),
+            OpenApiParameter(
+                name="user_id", description="User ID (required)", type=str, required=True
+            ),
+            OpenApiParameter(
+                name="weeks", description="Number of weeks (default: 12, min: 1, max: 52)", type=int
+            ),
         ],
-        responses={200: UserTrendsResponseSerializer}
+        responses={200: UserTrendsResponseSerializer},
     )
     def get(self, request):
-        user_id = request.query_params.get('user_id')
+        user_id = request.query_params.get("user_id")
         if not user_id:
-            return Response({'detail': 'user_id parameter is required'}, status=400)
+            return Response({"detail": "user_id parameter is required"}, status=400)
 
-        weeks = get_safe_int_param(request, 'weeks', default=12, min_val=1, max_val=52)
+        weeks = get_safe_int_param(request, "weeks", default=12, min_val=1, max_val=52)
         data = get_user_trends(user_id=user_id, weeks=weeks)
         serializer = UserTrendsResponseSerializer(data)
         return Response(serializer.data)
@@ -396,21 +461,24 @@ class UserJournalsView(APIView):
     GET: User journals with progress indicators for a specific user.
     Admin-only endpoint.
     """
+
     permission_classes = [permissions.IsAuthenticated, IsAdmin]
 
     @extend_schema(
-        tags=['insights'],
-        summary='Get user journals (admin only)',
-        description='Journal list with member count, decision count, and active member count for a specific user.',
+        tags=["insights"],
+        summary="Get user journals (admin only)",
+        description="Journal list with member count, decision count, and active member count for a specific user.",
         parameters=[
-            OpenApiParameter(name='user_id', description='User ID (required)', type=str, required=True),
+            OpenApiParameter(
+                name="user_id", description="User ID (required)", type=str, required=True
+            ),
         ],
-        responses={200: UserJournalsResponseSerializer}
+        responses={200: UserJournalsResponseSerializer},
     )
     def get(self, request):
-        user_id = request.query_params.get('user_id')
+        user_id = request.query_params.get("user_id")
         if not user_id:
-            return Response({'detail': 'user_id parameter is required'}, status=400)
+            return Response({"detail": "user_id parameter is required"}, status=400)
 
         data = get_user_journals(user_id=user_id)
         serializer = UserJournalsResponseSerializer(data)
@@ -422,28 +490,33 @@ class StageContactsView(APIView):
     GET: Get contacts currently in a given pipeline stage.
     Admin-only endpoint.
     """
+
     permission_classes = [permissions.IsAuthenticated, IsAdmin]
 
     @extend_schema(
-        tags=['insights'],
-        summary='Get stage contacts (admin only)',
+        tags=["insights"],
+        summary="Get stage contacts (admin only)",
         description='Contacts currently in a specific pipeline stage. Pass stage parameter (contact, meet, close, decision, thank, next_steps) or "none" for no activity.',
         parameters=[
-            OpenApiParameter(name='stage', description='Pipeline stage (required)', type=str, required=True),
-            OpenApiParameter(name='limit', description='Max results (default: 100, min: 1, max: 500)', type=int),
+            OpenApiParameter(
+                name="stage", description="Pipeline stage (required)", type=str, required=True
+            ),
+            OpenApiParameter(
+                name="limit", description="Max results (default: 100, min: 1, max: 500)", type=int
+            ),
         ],
-        responses={200: StageContactsResponseSerializer}
+        responses={200: StageContactsResponseSerializer},
     )
     def get(self, request):
-        stage = request.query_params.get('stage')
+        stage = request.query_params.get("stage")
         if stage is None:
-            return Response({'detail': 'stage parameter is required'}, status=400)
+            return Response({"detail": "stage parameter is required"}, status=400)
 
         # Handle special value "none" for null stage (No Activity contacts)
-        if stage == 'none' or stage == '':
+        if stage == "none" or stage == "":
             stage = None
 
-        limit = get_safe_int_param(request, 'limit', default=100, min_val=1, max_val=500)
+        limit = get_safe_int_param(request, "limit", default=100, min_val=1, max_val=500)
 
         data = get_stage_contacts(stage=stage, limit=limit)
         serializer = StageContactsResponseSerializer(data)
@@ -455,27 +528,115 @@ class UserDrilldownView(APIView):
     GET: Get combined summary for quick user inspection (user drilldown panel).
     Admin-only endpoint.
     """
+
     permission_classes = [permissions.IsAuthenticated, IsAdmin]
 
     @extend_schema(
-        tags=['insights'],
-        summary='Get user drilldown (admin only)',
-        description='Combined user summary with key stats, stalled count, and recent journals for quick inspection.',
+        tags=["insights"],
+        summary="Get user drilldown (admin only)",
+        description="Combined user summary with key stats, stalled count, and recent journals for quick inspection.",
         parameters=[
-            OpenApiParameter(name='user_id', description='User ID (required)', type=str, required=True),
+            OpenApiParameter(
+                name="user_id", description="User ID (required)", type=str, required=True
+            ),
         ],
-        responses={200: UserDrilldownResponseSerializer}
+        responses={200: UserDrilldownResponseSerializer},
     )
     def get(self, request):
-        user_id = request.query_params.get('user_id')
+        user_id = request.query_params.get("user_id")
         if not user_id:
-            return Response({'detail': 'user_id parameter is required'}, status=400)
+            return Response({"detail": "user_id parameter is required"}, status=400)
 
         data = get_user_drilldown(user_id=user_id)
 
         # Check if service returned an error (user not found)
-        if 'detail' in data:
+        if "detail" in data:
             return Response(data, status=404)
 
         serializer = UserDrilldownResponseSerializer(data)
         return Response(serializer.data)
+
+
+# Admin Analytics Redesign (Issue #49)
+
+
+class FiscalYearPaceView(APIView):
+    """GET: Hero pace tile — raised vs annual goal, YoY delta, last import."""
+
+    permission_classes = [permissions.IsAuthenticated, IsAdmin]
+
+    @extend_schema(
+        tags=["insights"],
+        summary="Fiscal year pace (admin only)",
+        responses={200: FiscalYearPaceResponseSerializer},
+    )
+    def get(self, request):
+        return Response(get_fiscal_year_pace(request))
+
+
+class MissionariesBehindGoalView(APIView):
+    """GET: Missionaries sorted ascending by this-month pace %."""
+
+    permission_classes = [permissions.IsAuthenticated, IsAdmin]
+
+    @extend_schema(
+        tags=["insights"],
+        summary="Missionaries behind goal (admin only)",
+        parameters=[
+            OpenApiParameter(
+                name="limit", description="Max results (default: 10, max: 50)", type=int
+            ),
+        ],
+        responses={200: MissionariesBehindGoalResponseSerializer},
+    )
+    def get(self, request):
+        limit = get_safe_int_param(request, "limit", default=10, min_val=1, max_val=50)
+        return Response(get_missionaries_behind_goal(request, limit=limit))
+
+
+class PipelineFunnelConversionView(APIView):
+    """GET: Stage-to-stage conversion funnel with weakest-transition flag."""
+
+    permission_classes = [permissions.IsAuthenticated, IsAdmin]
+
+    @extend_schema(
+        tags=["insights"],
+        summary="Pipeline funnel with conversion (admin only)",
+        responses={200: PipelineFunnelConversionResponseSerializer},
+    )
+    def get(self, request):
+        return Response(get_pipeline_funnel_with_conversion(request))
+
+
+class WeeklyEngagementView(APIView):
+    """GET: Weekly active + on-pace missionary counts over a rolling window."""
+
+    permission_classes = [permissions.IsAuthenticated, IsAdmin]
+
+    @extend_schema(
+        tags=["insights"],
+        summary="Weekly engagement (admin only)",
+        parameters=[
+            OpenApiParameter(
+                name="weeks", description="Lookback window (default: 12, max: 52)", type=int
+            ),
+        ],
+        responses={200: WeeklyEngagementResponseSerializer},
+    )
+    def get(self, request):
+        weeks = get_safe_int_param(request, "weeks", default=12, min_val=1, max_val=52)
+        return Response(get_weekly_engagement(request, weeks=weeks))
+
+
+class FiscalYearDonationsView(APIView):
+    """GET: Monthly FYTD donation totals vs prior year."""
+
+    permission_classes = [permissions.IsAuthenticated, IsAdmin]
+
+    @extend_schema(
+        tags=["insights"],
+        summary="Fiscal year donations vs prior year (admin only)",
+        responses={200: FiscalYearDonationsResponseSerializer},
+    )
+    def get(self, request):
+        return Response(get_fiscal_year_donations(request))

--- a/frontend/e2e/admin_analytics_redesign.admin.spec.ts
+++ b/frontend/e2e/admin_analytics_redesign.admin.spec.ts
@@ -1,0 +1,99 @@
+/**
+ * Admin Analytics Redesign E2E Tests (Issue #49, admin only)
+ *
+ * Verifies:
+ *   1. All 5 new tiles mount and reach a resolved (non-loading) state
+ *   2. The hero Fiscal Year Pace tile renders its labeled sub-values
+ *   3. Behind-goal rows are interactive
+ *
+ * Follows the #1 rule of E2E tests (CLAUDE.md): a test MUST fail when the
+ * feature it tests is broken. No "fixing the app inside the test".
+ *
+ * Backend tests (apps/insights/tests/test_admin_analytics_views.py) cover the
+ * auth matrix (401/403/200) — no need to re-prove that here.
+ */
+import { expect, type Page, test } from "@playwright/test"
+
+const ANALYTICS_URL = "/admin/analytics/dashboard"
+const TILE_RESOLVE_MS = 8_000
+
+/** Wait for a tile's data-state attribute to become "ready" or "error". */
+async function waitForTileResolved(page: Page, testid: string) {
+  const tile = page.getByTestId(testid)
+  await expect(tile).toBeVisible({ timeout: TILE_RESOLVE_MS })
+  await expect
+    .poll(
+      async () => tile.getAttribute("data-state"),
+      { timeout: TILE_RESOLVE_MS, message: `Tile ${testid} never exited loading` },
+    )
+    .not.toBe("loading")
+}
+
+test.describe("Admin Analytics Redesign (admin)", () => {
+  test("all five redesigned tiles render", async ({ page }) => {
+    await page.goto(ANALYTICS_URL)
+
+    await expect(
+      page.getByRole("heading", { name: "Analytics Dashboard" }),
+    ).toBeVisible({ timeout: 3_000 })
+
+    await waitForTileResolved(page, "fy-pace-tile")
+    await waitForTileResolved(page, "missionaries-behind-tile")
+    await waitForTileResolved(page, "weekly-engagement-tile")
+    await waitForTileResolved(page, "pipeline-funnel-tile")
+    await waitForTileResolved(page, "fy-donations-tile")
+
+    await page.screenshot({
+      path: "e2e/artifacts/admin_analytics_redesign_loaded.png",
+      fullPage: true,
+    })
+  })
+
+  test("fiscal year pace tile shows raised amount, pace badge, YoY, and import caption", async ({
+    page,
+  }) => {
+    await page.goto(ANALYTICS_URL)
+    await waitForTileResolved(page, "fy-pace-tile")
+
+    const paceTile = page.getByTestId("fy-pace-tile")
+    await expect(paceTile.getByTestId("fy-pace-raised")).toContainText(/\$/)
+    await expect(paceTile.getByTestId("fy-pace-badge")).toContainText(/% of pace/i)
+    await expect(paceTile.getByTestId("fy-pace-yoy")).toBeVisible()
+    await expect(paceTile.getByTestId("fy-pace-import-caption")).toBeVisible()
+  })
+
+  test("behind-goal tile either shows rows or the empty-state celebration", async ({ page }) => {
+    await page.goto(ANALYTICS_URL)
+    await waitForTileResolved(page, "missionaries-behind-tile")
+
+    const rows = page.getByTestId("missionaries-behind-row")
+    const rowCount = await rows.count()
+    if (rowCount === 0) {
+      await expect(page.getByText(/all missionaries on pace/i)).toBeVisible()
+      return
+    }
+
+    // Each row carries the missionary's monthly-goal cents formatted as currency
+    // and a pace percentage — prove both are present in the first row.
+    const firstRow = rows.first()
+    await expect(firstRow).toContainText(/\$/)
+    await expect(firstRow).toContainText(/%/)
+  })
+
+  test("pipeline funnel tile renders all 7 stages when there is pipeline activity", async ({
+    page,
+  }) => {
+    await page.goto(ANALYTICS_URL)
+    await waitForTileResolved(page, "pipeline-funnel-tile")
+
+    const tile = page.getByTestId("pipeline-funnel-tile")
+    const rows = tile.getByTestId("pipeline-stage-row")
+    const count = await rows.count()
+    if (count === 0) {
+      await expect(tile.getByText(/no pipeline activity/i)).toBeVisible()
+      return
+    }
+    // 7 stages always render when the funnel has data
+    expect(count).toBe(7)
+  })
+})

--- a/frontend/src/api/adminAnalytics.ts
+++ b/frontend/src/api/adminAnalytics.ts
@@ -1,0 +1,142 @@
+/**
+ * Typed API client for the /admin/analytics redesign (Issue #49).
+ *
+ * Endpoints live under /api/v1/insights/admin/ (same prefix as the legacy
+ * admin insights routes). All are admin-only on the backend.
+ */
+import { apiClient } from "./client"
+
+// --- Fiscal Year Pace ---------------------------------------------------------
+
+export interface FiscalYearPaceResponse {
+  fy_start: string
+  fy_end: string
+  raised_cents: number
+  annual_goal_cents: number
+  expected_by_today_cents: number
+  pace_percentage: number
+  prior_year_raised_cents: number
+  yoy_delta_percentage: number | null
+  last_import_at: string | null
+}
+
+export async function getFiscalYearPace(): Promise<FiscalYearPaceResponse> {
+  const response = await apiClient.get<FiscalYearPaceResponse>(
+    "/insights/admin/fiscal-year-pace/",
+  )
+  return response.data
+}
+
+// --- Missionaries Behind Goal -------------------------------------------------
+
+export interface MissionaryBehindGoalItem {
+  user_id: string
+  name: string
+  email: string
+  monthly_goal_cents: number
+  this_month_raised_cents: number
+  pace_percentage: number
+}
+
+export interface MissionariesBehindGoalResponse {
+  missionaries: MissionaryBehindGoalItem[]
+  total_excluded_no_goal: number
+  total_missionaries: number
+  as_of_date: string
+}
+
+export interface MissionariesBehindGoalParams {
+  limit?: number
+}
+
+export async function getMissionariesBehindGoal(
+  params?: MissionariesBehindGoalParams,
+): Promise<MissionariesBehindGoalResponse> {
+  const response = await apiClient.get<MissionariesBehindGoalResponse>(
+    "/insights/admin/missionaries-behind-goal/",
+    { params },
+  )
+  return response.data
+}
+
+// --- Pipeline Funnel Conversion -----------------------------------------------
+
+export interface PipelineFunnelConversionStage {
+  stage: string
+  label: string
+  count_at_or_past: number
+  conversion_from_prior_percentage: number | null
+  is_weakest_transition: boolean
+}
+
+export interface PipelineFunnelWeakestTransition {
+  from: string
+  to: string
+  rate: number
+}
+
+export interface PipelineFunnelConversionResponse {
+  stages: PipelineFunnelConversionStage[]
+  total_in_pipeline: number
+  weakest_transition: PipelineFunnelWeakestTransition | null
+}
+
+export async function getPipelineFunnelConversion(): Promise<PipelineFunnelConversionResponse> {
+  const response = await apiClient.get<PipelineFunnelConversionResponse>(
+    "/insights/admin/pipeline-funnel-conversion/",
+  )
+  return response.data
+}
+
+// --- Weekly Engagement --------------------------------------------------------
+
+export interface WeeklyEngagementPoint {
+  week_start: string
+  week_label: string
+  active_missionaries: number
+  on_pace_missionaries: number
+  total_missionaries: number
+}
+
+export interface WeeklyEngagementResponse {
+  weeks: WeeklyEngagementPoint[]
+}
+
+export interface WeeklyEngagementParams {
+  weeks?: number
+}
+
+export async function getWeeklyEngagement(
+  params?: WeeklyEngagementParams,
+): Promise<WeeklyEngagementResponse> {
+  const response = await apiClient.get<WeeklyEngagementResponse>(
+    "/insights/admin/weekly-engagement/",
+    { params },
+  )
+  return response.data
+}
+
+// --- Fiscal Year Donations ----------------------------------------------------
+
+export interface FiscalYearDonationMonth {
+  month: string
+  short_label: string
+  current_cents: number | null
+  prior_cents: number
+  is_future: boolean
+}
+
+export interface FiscalYearDonationsResponse {
+  fy_start: string
+  fy_end: string
+  months: FiscalYearDonationMonth[]
+  current_fy_total_cents: number
+  prior_fy_total_cents: number
+}
+
+export async function getFiscalYearDonations(): Promise<FiscalYearDonationsResponse> {
+  const response = await apiClient.get<FiscalYearDonationsResponse>(
+    "/insights/admin/fiscal-year-donations/",
+  )
+  return response.data
+}

--- a/frontend/src/hooks/useAdminAnalytics.ts
+++ b/frontend/src/hooks/useAdminAnalytics.ts
@@ -1,0 +1,65 @@
+/**
+ * React Query hooks for the admin analytics redesign (Issue #49).
+ *
+ * Staleness mirrors useInsights: 5 minutes fresh, 30-minute gcTime so the
+ * data survives panel/drawer open/close in the same session.
+ */
+import { useQuery } from "@tanstack/react-query"
+
+import {
+  getFiscalYearDonations,
+  getFiscalYearPace,
+  getMissionariesBehindGoal,
+  getPipelineFunnelConversion,
+  getWeeklyEngagement,
+  type MissionariesBehindGoalParams,
+  type WeeklyEngagementParams,
+} from "@/api/adminAnalytics"
+
+const STALE_TIME = 5 * 60 * 1000
+const GC_TIME = 30 * 60 * 1000
+
+export function useFiscalYearPace() {
+  return useQuery({
+    queryKey: ["admin-analytics", "fiscal-year-pace"],
+    queryFn: getFiscalYearPace,
+    staleTime: STALE_TIME,
+    gcTime: GC_TIME,
+  })
+}
+
+export function useMissionariesBehindGoal(params?: MissionariesBehindGoalParams) {
+  return useQuery({
+    queryKey: ["admin-analytics", "missionaries-behind-goal", params ?? {}],
+    queryFn: () => getMissionariesBehindGoal(params),
+    staleTime: STALE_TIME,
+    gcTime: GC_TIME,
+  })
+}
+
+export function usePipelineFunnelConversion() {
+  return useQuery({
+    queryKey: ["admin-analytics", "pipeline-funnel-conversion"],
+    queryFn: getPipelineFunnelConversion,
+    staleTime: STALE_TIME,
+    gcTime: GC_TIME,
+  })
+}
+
+export function useWeeklyEngagement(params?: WeeklyEngagementParams) {
+  return useQuery({
+    queryKey: ["admin-analytics", "weekly-engagement", params ?? {}],
+    queryFn: () => getWeeklyEngagement(params),
+    staleTime: STALE_TIME,
+    gcTime: GC_TIME,
+  })
+}
+
+export function useFiscalYearDonations() {
+  return useQuery({
+    queryKey: ["admin-analytics", "fiscal-year-donations"],
+    queryFn: getFiscalYearDonations,
+    staleTime: STALE_TIME,
+    gcTime: GC_TIME,
+  })
+}

--- a/frontend/src/lib/__tests__/format.test.ts
+++ b/frontend/src/lib/__tests__/format.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest"
+
+import { clampPercentage, formatCents } from "@/lib/format"
+
+describe("formatCents", () => {
+  it("formats integer cents as USD with cents suffix by default", () => {
+    expect(formatCents(12345)).toBe("$123.45")
+  })
+
+  it("drops fractional part when whole: true", () => {
+    expect(formatCents(12300, { whole: true })).toBe("$123")
+  })
+
+  it("rounds whole-formatted fractional cents to nearest dollar", () => {
+    expect(formatCents(12399, { whole: true })).toBe("$124")
+  })
+
+  it("returns em-dash for null/undefined", () => {
+    expect(formatCents(null)).toBe("—")
+    expect(formatCents(undefined)).toBe("—")
+  })
+
+  it("handles zero", () => {
+    expect(formatCents(0)).toBe("$0.00")
+    expect(formatCents(0, { whole: true })).toBe("$0")
+  })
+})
+
+describe("clampPercentage", () => {
+  it("passes through values in range", () => {
+    expect(clampPercentage(50)).toBe(50)
+    expect(clampPercentage(149.9)).toBeCloseTo(149.9)
+  })
+
+  it("clamps above the max", () => {
+    expect(clampPercentage(999)).toBe(150)
+    expect(clampPercentage(999, 0, 100)).toBe(100)
+  })
+
+  it("clamps below the min", () => {
+    expect(clampPercentage(-25)).toBe(0)
+  })
+
+  it("returns min for NaN/Infinity", () => {
+    expect(clampPercentage(NaN)).toBe(0)
+    expect(clampPercentage(Infinity)).toBe(0)
+  })
+})

--- a/frontend/src/lib/chart-palette.ts
+++ b/frontend/src/lib/chart-palette.ts
@@ -1,0 +1,18 @@
+/**
+ * Shared Recharts color palette for admin analytics.
+ *
+ * Colors come from the shadcn chart CSS variables (`--chart-1` … `--chart-6`)
+ * so light/dark themes stay consistent. Use these everywhere instead of
+ * hardcoding `hsl(var(--chart-N))` per file.
+ */
+export const CHART_COLORS = [
+  "hsl(var(--chart-1))",
+  "hsl(var(--chart-2))",
+  "hsl(var(--chart-3))",
+  "hsl(var(--chart-4))",
+  "hsl(var(--chart-5))",
+  "hsl(var(--chart-6))",
+] as const
+
+export const CHART_WARNING_COLOR = "hsl(38 92% 50%)"
+export const CHART_MUTED_COLOR = "hsl(var(--muted-foreground))"

--- a/frontend/src/lib/format.ts
+++ b/frontend/src/lib/format.ts
@@ -1,0 +1,46 @@
+/**
+ * Currency and number formatting helpers.
+ *
+ * Money moves as integer cents through the API; always format at the
+ * UI boundary, never render raw cents to the user.
+ */
+
+const USD_FORMATTER = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+})
+
+const USD_WHOLE_FORMATTER = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+  minimumFractionDigits: 0,
+  maximumFractionDigits: 0,
+})
+
+/**
+ * Format an integer cents value as a USD currency string.
+ *
+ * @param cents - Amount in integer cents, or null/undefined
+ * @param options.whole - If true, drop the `.00` suffix
+ * @returns Formatted currency string or em-dash if nullish
+ */
+export function formatCents(
+  cents: number | null | undefined,
+  options?: { whole?: boolean },
+): string {
+  if (cents === null || cents === undefined) return "—"
+  const dollars = cents / 100
+  return options?.whole
+    ? USD_WHOLE_FORMATTER.format(dollars)
+    : USD_FORMATTER.format(dollars)
+}
+
+/**
+ * Clamp a percentage for display. Backend pace % can exceed 100 — the
+ * UI caps at 150 by default so the progress-bar visualization stays
+ * meaningful without hiding large overruns entirely.
+ */
+export function clampPercentage(value: number, min = 0, max = 150): number {
+  if (Number.isNaN(value) || !Number.isFinite(value)) return min
+  return Math.max(min, Math.min(max, value))
+}

--- a/frontend/src/pages/admin/analytics/AdminAnalyticsDashboard.tsx
+++ b/frontend/src/pages/admin/analytics/AdminAnalyticsDashboard.tsx
@@ -21,9 +21,6 @@ const AlertsPanel = lazy(() =>
 const TrendCharts = lazy(() =>
   import("./components/TrendCharts").then((m) => ({ default: m.TrendCharts })),
 )
-const ConversionFunnelChart = lazy(() =>
-  import("./components/ConversionFunnelChart").then((m) => ({ default: m.ConversionFunnelChart })),
-)
 const FunnelDrilldownPanel = lazy(() =>
   import("./components/FunnelDrilldownPanel").then((m) => ({ default: m.FunnelDrilldownPanel })),
 )
@@ -38,6 +35,29 @@ const UserComparison = lazy(() =>
 )
 const MPDOverviewTable = lazy(() =>
   import("@/components/mpd/MPDOverviewTable").then((m) => ({ default: m.MPDOverviewTable })),
+)
+
+// Admin Analytics Redesign (Issue #49) — leadership tiles, lazy-loaded.
+const FiscalYearPaceTile = lazy(() =>
+  import("./components/FiscalYearPaceTile").then((m) => ({ default: m.FiscalYearPaceTile })),
+)
+const MissionariesBehindGoalTile = lazy(() =>
+  import("./components/MissionariesBehindGoalTile").then((m) => ({
+    default: m.MissionariesBehindGoalTile,
+  })),
+)
+const WeeklyEngagementTile = lazy(() =>
+  import("./components/WeeklyEngagementTile").then((m) => ({ default: m.WeeklyEngagementTile })),
+)
+const PipelineFunnelConversionTile = lazy(() =>
+  import("./components/PipelineFunnelConversionTile").then((m) => ({
+    default: m.PipelineFunnelConversionTile,
+  })),
+)
+const FiscalYearDonationsTile = lazy(() =>
+  import("./components/FiscalYearDonationsTile").then((m) => ({
+    default: m.FiscalYearDonationsTile,
+  })),
 )
 
 function SectionSkeleton({ className = "h-64" }: { className?: string }) {
@@ -154,21 +174,51 @@ export default function AdminAnalyticsDashboard() {
           </div>
 
           {/* Header */}
-          <div className="flex items-center justify-between">
+          <div className="flex items-start justify-between gap-4 flex-wrap">
             <div>
               <h1 className="text-3xl font-semibold tracking-tight">Analytics Dashboard</h1>
               <p className="text-muted-foreground mt-1">
                 Organization-wide fundraising analytics
               </p>
             </div>
-            <DateRangePicker value={dateRange} onChange={handleDateRangeChange} />
+            <div className="flex flex-col items-end gap-1">
+              <DateRangePicker value={dateRange} onChange={handleDateRangeChange} />
+              <p className="text-xs text-muted-foreground">
+                Date range applies to reference counts and activity below.
+              </p>
+            </div>
           </div>
 
-          {/* Summary Cards Row */}
+          {/* Row 1: Fiscal Year Pace (hero, full width) */}
+          <Suspense fallback={<SectionSkeleton className="h-48" />}>
+            <FiscalYearPaceTile />
+          </Suspense>
+
+          {/* Row 2: Missionaries Behind Goal (2-col) + Weekly Engagement (2-col) */}
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+            <Suspense fallback={<SectionSkeleton className="h-80" />}>
+              <MissionariesBehindGoalTile onUserClick={handleUserDrilldown} />
+            </Suspense>
+            <Suspense fallback={<SectionSkeleton className="h-80" />}>
+              <WeeklyEngagementTile />
+            </Suspense>
+          </div>
+
+          {/* Row 3: Pipeline Funnel with Conversion (full width) */}
+          <Suspense fallback={<SectionSkeleton className="h-80" />}>
+            <PipelineFunnelConversionTile onStageClick={handleStageClick} />
+          </Suspense>
+
+          {/* Row 4: Fiscal Year Donations (full width) */}
+          <Suspense fallback={<SectionSkeleton className="h-80" />}>
+            <FiscalYearDonationsTile />
+          </Suspense>
+
+          {/* Row 5: Reference counts (demoted, compact) */}
           {isLoading ? (
             <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
               {[...Array(4)].map((_, i) => (
-                <div key={i} className="h-32 bg-muted rounded-lg animate-pulse" />
+                <div key={i} className="h-24 bg-muted rounded-lg animate-pulse" />
               ))}
             </div>
           ) : error ? (
@@ -178,7 +228,7 @@ export default function AdminAnalyticsDashboard() {
           ) : data ? (
             <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
               <Card>
-                <CardHeader>
+                <CardHeader className="pb-2">
                   <CardTitle className="text-sm font-medium text-muted-foreground">
                     Total Contacts
                   </CardTitle>
@@ -189,7 +239,7 @@ export default function AdminAnalyticsDashboard() {
               </Card>
 
               <Card>
-                <CardHeader>
+                <CardHeader className="pb-2">
                   <CardTitle className="text-sm font-medium text-muted-foreground">
                     Active Journals
                   </CardTitle>
@@ -200,7 +250,7 @@ export default function AdminAnalyticsDashboard() {
               </Card>
 
               <Card>
-                <CardHeader>
+                <CardHeader className="pb-2">
                   <CardTitle className="text-sm font-medium text-muted-foreground">
                     Stalled Contacts
                   </CardTitle>
@@ -211,53 +261,32 @@ export default function AdminAnalyticsDashboard() {
               </Card>
 
               <Card>
-                <CardHeader>
+                <CardHeader className="pb-2">
                   <CardTitle className="text-sm font-medium text-muted-foreground">
-                    Conversion Rate
+                    Donations (12 Months)
                   </CardTitle>
                 </CardHeader>
                 <CardContent>
-                  <div className="text-2xl font-bold">{data.conversion_rate.toFixed(1)}%</div>
+                  <div className="text-2xl font-bold">
+                    {data.donations_12m.total_amount.toLocaleString('en-US', {
+                      style: 'currency',
+                      currency: 'USD',
+                      minimumFractionDigits: 0,
+                      maximumFractionDigits: 0,
+                    })}
+                  </div>
+                  <p className="text-xs text-muted-foreground mt-1">
+                    {data.donations_12m.total_count} gifts
+                  </p>
                 </CardContent>
               </Card>
             </div>
           ) : null}
 
-          {/* Donations Card */}
-          {data && (
-            <Card>
-              <CardHeader>
-                <CardTitle>Donations (12 Months)</CardTitle>
-              </CardHeader>
-              <CardContent>
-                <div className="flex items-baseline gap-4">
-                  <div>
-                    <p className="text-sm font-medium text-muted-foreground">Total Amount</p>
-                    <p className="text-2xl font-bold">
-                      {data.donations_12m.total_amount.toLocaleString('en-US', {
-                        style: 'currency',
-                        currency: 'USD'
-                      })}
-                    </p>
-                  </div>
-                  <div>
-                    <p className="text-sm font-medium text-muted-foreground">Donation Count</p>
-                    <p className="text-2xl font-bold">{data.donations_12m.total_count}</p>
-                  </div>
-                </div>
-              </CardContent>
-            </Card>
-          )}
-
-          {/* Charts Row: Trend Charts + Conversion Funnel */}
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-            <Suspense fallback={<SectionSkeleton className="h-80" />}>
-              <TrendCharts dateParams={dateParams} />
-            </Suspense>
-            <Suspense fallback={<SectionSkeleton className="h-80" />}>
-              <ConversionFunnelChart dateParams={dateParams} onStageClick={handleStageClick} />
-            </Suspense>
-          </div>
+          {/* Trend Charts (moved below, remains accessible) */}
+          <Suspense fallback={<SectionSkeleton className="h-80" />}>
+            <TrendCharts dateParams={dateParams} />
+          </Suspense>
 
           {/* Activity and Alerts Row: Team Activity Table (2/3) + Alerts Panel (1/3) */}
           <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">

--- a/frontend/src/pages/admin/analytics/components/ConversionFunnelChart.tsx
+++ b/frontend/src/pages/admin/analytics/components/ConversionFunnelChart.tsx
@@ -3,15 +3,9 @@ import { FunnelChart, Funnel, LabelList, Tooltip } from "recharts"
 import { ChartContainer } from "@/components/ui/chart"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { useAdminConversionFunnel } from "@/hooks/useInsights"
+import { CHART_COLORS } from "@/lib/chart-palette"
 
-const FUNNEL_COLORS = [
-  "hsl(var(--chart-1))",
-  "hsl(var(--chart-2))",
-  "hsl(var(--chart-3))",
-  "hsl(var(--chart-4))",
-  "hsl(var(--chart-5))",
-  "hsl(var(--chart-6))",
-]
+const FUNNEL_COLORS = CHART_COLORS
 
 interface ConversionFunnelChartProps {
   dateParams?: { date_from?: string; date_to?: string }

--- a/frontend/src/pages/admin/analytics/components/FiscalYearDonationsTile.tsx
+++ b/frontend/src/pages/admin/analytics/components/FiscalYearDonationsTile.tsx
@@ -1,0 +1,153 @@
+import {
+  Bar,
+  CartesianGrid,
+  ComposedChart,
+  Legend,
+  Line,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts"
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { ChartContainer } from "@/components/ui/chart"
+import { useFiscalYearDonations } from "@/hooks/useAdminAnalytics"
+import { CHART_COLORS } from "@/lib/chart-palette"
+import { formatCents } from "@/lib/format"
+
+export function FiscalYearDonationsTile() {
+  const { data, isLoading, error } = useFiscalYearDonations()
+
+  if (isLoading) {
+    return (
+      <Card data-testid="fy-donations-tile" data-state="loading">
+        <CardHeader>
+          <CardTitle>Fiscal Year Donations</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="h-72 bg-muted rounded animate-pulse" />
+        </CardContent>
+      </Card>
+    )
+  }
+
+  if (error || !data) {
+    return (
+      <Card data-testid="fy-donations-tile" data-state="error">
+        <CardHeader>
+          <CardTitle>Fiscal Year Donations</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="bg-destructive/10 border border-destructive/20 rounded-md p-4">
+            <p className="text-destructive text-sm">Failed to load donation totals.</p>
+          </div>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  const hasAnyData = data.current_fy_total_cents > 0 || data.prior_fy_total_cents > 0
+
+  // Recharts prefers dollar values; compute once for axis readability.
+  const chartData = data.months.map((m) => ({
+    short_label: m.short_label,
+    // `null` current_cents hides the bar for future months automatically.
+    current_dollars: m.current_cents === null ? null : m.current_cents / 100,
+    prior_dollars: m.prior_cents / 100,
+    is_future: m.is_future,
+  }))
+
+  return (
+    <Card data-testid="fy-donations-tile" data-state="ready">
+      <CardHeader>
+        <CardTitle>Fiscal Year Donations</CardTitle>
+        <CardDescription className="flex flex-wrap gap-x-6 gap-y-1">
+          <span>
+            Current FY total:{" "}
+            <span className="font-medium text-foreground">
+              {formatCents(data.current_fy_total_cents, { whole: true })}
+            </span>
+          </span>
+          <span>
+            Prior FY total:{" "}
+            <span className="font-medium text-foreground">
+              {formatCents(data.prior_fy_total_cents, { whole: true })}
+            </span>
+          </span>
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        {!hasAnyData ? (
+          <div className="py-12 text-center">
+            <p className="text-muted-foreground">No donation data yet.</p>
+          </div>
+        ) : (
+          <ChartContainer config={{}} className="h-[320px] w-full">
+            <ComposedChart data={chartData} margin={{ top: 16, right: 24, left: 0, bottom: 0 }}>
+                <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
+                <XAxis
+                  dataKey="short_label"
+                  tick={{ fontSize: 12 }}
+                  stroke="hsl(var(--muted-foreground))"
+                />
+                <YAxis
+                  tick={{ fontSize: 12 }}
+                  stroke="hsl(var(--muted-foreground))"
+                  tickFormatter={(v: number) =>
+                    v >= 1000 ? `$${Math.round(v / 1000)}k` : `$${v}`
+                  }
+                />
+                <Tooltip
+                  content={({ payload, label }) => {
+                    if (!payload?.length) return null
+                    const current = payload.find((p) => p.dataKey === "current_dollars")
+                    const prior = payload.find((p) => p.dataKey === "prior_dollars")
+                    return (
+                      <div className="bg-background border rounded-lg p-2 shadow-lg text-sm">
+                        <p className="font-medium mb-1">{label}</p>
+                        {current && current.value !== null && current.value !== undefined ? (
+                          <p className="text-muted-foreground">
+                            Current FY:{" "}
+                            <span className="font-medium text-foreground">
+                              {formatCents(Math.round((current.value as number) * 100), {
+                                whole: true,
+                              })}
+                            </span>
+                          </p>
+                        ) : null}
+                        {prior ? (
+                          <p className="text-muted-foreground">
+                            Prior FY:{" "}
+                            <span className="font-medium text-foreground">
+                              {formatCents(Math.round((prior.value as number) * 100), {
+                                whole: true,
+                              })}
+                            </span>
+                          </p>
+                        ) : null}
+                      </div>
+                    )
+                  }}
+                />
+                <Legend verticalAlign="top" align="right" wrapperStyle={{ fontSize: 12 }} />
+                <Bar
+                  dataKey="current_dollars"
+                  name="Current FY"
+                  fill={CHART_COLORS[0]}
+                  radius={[2, 2, 0, 0]}
+                />
+                <Line
+                  type="monotone"
+                  dataKey="prior_dollars"
+                  name="Prior FY"
+                  stroke={CHART_COLORS[2]}
+                  strokeWidth={2}
+                  dot={{ r: 3 }}
+                />
+            </ComposedChart>
+          </ChartContainer>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/frontend/src/pages/admin/analytics/components/FiscalYearPaceTile.tsx
+++ b/frontend/src/pages/admin/analytics/components/FiscalYearPaceTile.tsx
@@ -1,0 +1,126 @@
+import { ArrowDownIcon, ArrowUpIcon } from "lucide-react"
+
+import { Badge } from "@/components/ui/badge"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Progress } from "@/components/ui/progress"
+import { useFiscalYearPace } from "@/hooks/useAdminAnalytics"
+import { clampPercentage, formatCents } from "@/lib/format"
+import { formatLocalDate } from "@/lib/utils"
+
+export function FiscalYearPaceTile() {
+  const { data, isLoading, error } = useFiscalYearPace()
+
+  if (isLoading) {
+    return (
+      <Card data-testid="fy-pace-tile" data-state="loading">
+        <CardHeader>
+          <CardTitle>Fiscal Year Pace</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="h-32 bg-muted rounded animate-pulse" />
+        </CardContent>
+      </Card>
+    )
+  }
+
+  if (error || !data) {
+    return (
+      <Card data-testid="fy-pace-tile" data-state="error">
+        <CardHeader>
+          <CardTitle>Fiscal Year Pace</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="bg-destructive/10 border border-destructive/20 rounded-md p-4">
+            <p className="text-destructive text-sm">Failed to load fiscal year pace.</p>
+          </div>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  const hasGoal = data.annual_goal_cents > 0
+  const progressValue = hasGoal
+    ? clampPercentage((data.raised_cents / data.annual_goal_cents) * 100, 0, 100)
+    : 0
+  const paceDisplay = clampPercentage(data.pace_percentage, 0, 150)
+  const onPace = paceDisplay >= 100
+
+  const yoy = data.yoy_delta_percentage
+  const importedCaption = data.last_import_at
+    ? `Data as of ${formatLocalDate(data.last_import_at, "long")}`
+    : "Updated daily from Raiser's Edge"
+
+  return (
+    <Card data-testid="fy-pace-tile" data-state="ready">
+      <CardHeader className="flex flex-row items-start justify-between space-y-0 pb-2">
+        <div>
+          <CardTitle>Fiscal Year Pace</CardTitle>
+          <p className="text-xs text-muted-foreground mt-1">
+            {formatLocalDate(data.fy_start, "short")} – {formatLocalDate(data.fy_end, "short")}
+          </p>
+        </div>
+        <Badge variant={onPace ? "default" : "secondary"} data-testid="fy-pace-badge">
+          {paceDisplay.toFixed(0)}% of pace
+        </Badge>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="flex flex-wrap items-baseline gap-x-6 gap-y-2">
+          <div>
+            <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+              Raised
+            </p>
+            <p
+              className="text-3xl font-bold tracking-tight"
+              data-testid="fy-pace-raised"
+            >
+              {formatCents(data.raised_cents, { whole: true })}
+            </p>
+          </div>
+          <div>
+            <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+              Annual Goal
+            </p>
+            <p className="text-xl font-semibold">
+              {hasGoal ? formatCents(data.annual_goal_cents, { whole: true }) : "No goal set"}
+            </p>
+          </div>
+          <div>
+            <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+              Expected to date
+            </p>
+            <p className="text-xl font-semibold">
+              {formatCents(data.expected_by_today_cents, { whole: true })}
+            </p>
+          </div>
+        </div>
+
+        <Progress value={progressValue} className="h-3" />
+
+        <div className="flex items-center justify-between gap-4 flex-wrap">
+          <div data-testid="fy-pace-yoy">
+            {yoy === null ? (
+              <Badge variant="outline">No prior year data</Badge>
+            ) : (
+              <span
+                className={`inline-flex items-center gap-1 text-sm font-medium ${
+                  yoy >= 0 ? "text-emerald-600" : "text-destructive"
+                }`}
+              >
+                {yoy >= 0 ? (
+                  <ArrowUpIcon className="h-4 w-4" aria-hidden />
+                ) : (
+                  <ArrowDownIcon className="h-4 w-4" aria-hidden />
+                )}
+                {yoy >= 0 ? "+" : ""}
+                {yoy.toFixed(1)}% vs. last year
+              </span>
+            )}
+          </div>
+          <p className="text-xs text-muted-foreground" data-testid="fy-pace-import-caption">
+            {importedCaption}
+          </p>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/frontend/src/pages/admin/analytics/components/MissionariesBehindGoalTile.tsx
+++ b/frontend/src/pages/admin/analytics/components/MissionariesBehindGoalTile.tsx
@@ -1,3 +1,5 @@
+import { TargetIcon } from "lucide-react"
+
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Progress } from "@/components/ui/progress"
 import {
@@ -66,10 +68,9 @@ export function MissionariesBehindGoalTile({
       </CardHeader>
       <CardContent>
         {missionaries.length === 0 ? (
-          <div className="py-8 text-center">
-            <p className="text-muted-foreground">
-              All missionaries on pace this month 🎯
-            </p>
+          <div className="py-8 text-center flex flex-col items-center gap-2">
+            <TargetIcon className="h-6 w-6 text-emerald-600" aria-hidden />
+            <p className="text-muted-foreground">All missionaries on pace this month</p>
           </div>
         ) : (
           <Table>

--- a/frontend/src/pages/admin/analytics/components/MissionariesBehindGoalTile.tsx
+++ b/frontend/src/pages/admin/analytics/components/MissionariesBehindGoalTile.tsx
@@ -1,0 +1,127 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Progress } from "@/components/ui/progress"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import { useMissionariesBehindGoal } from "@/hooks/useAdminAnalytics"
+import { clampPercentage, formatCents } from "@/lib/format"
+
+interface MissionariesBehindGoalTileProps {
+  limit?: number
+  onUserClick?: (userId: string) => void
+}
+
+export function MissionariesBehindGoalTile({
+  limit = 10,
+  onUserClick,
+}: MissionariesBehindGoalTileProps) {
+  const { data, isLoading, error } = useMissionariesBehindGoal({ limit })
+
+  if (isLoading) {
+    return (
+      <Card data-testid="missionaries-behind-tile" data-state="loading">
+        <CardHeader>
+          <CardTitle>Missionaries Behind Goal</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-2">
+            {[...Array(5)].map((_, i) => (
+              <div key={i} className="h-10 bg-muted rounded animate-pulse" />
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  if (error || !data) {
+    return (
+      <Card data-testid="missionaries-behind-tile" data-state="error">
+        <CardHeader>
+          <CardTitle>Missionaries Behind Goal</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="bg-destructive/10 border border-destructive/20 rounded-md p-4">
+            <p className="text-destructive text-sm">Failed to load missionary pace.</p>
+          </div>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  const { missionaries, total_excluded_no_goal, total_missionaries } = data
+
+  return (
+    <Card data-testid="missionaries-behind-tile" data-state="ready">
+      <CardHeader>
+        <CardTitle>Missionaries Behind Goal</CardTitle>
+        <CardDescription>
+          Sorted by this-month pace. {total_missionaries} active missionaries.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        {missionaries.length === 0 ? (
+          <div className="py-8 text-center">
+            <p className="text-muted-foreground">
+              All missionaries on pace this month 🎯
+            </p>
+          </div>
+        ) : (
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Name</TableHead>
+                <TableHead className="text-right">Monthly Goal</TableHead>
+                <TableHead className="text-right">This Month</TableHead>
+                <TableHead className="w-32">Pace</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {missionaries.map((m) => {
+                const pace = clampPercentage(m.pace_percentage, 0, 150)
+                const barValue = clampPercentage(pace, 0, 100)
+                return (
+                  <TableRow
+                    key={m.user_id}
+                    className={onUserClick ? "cursor-pointer" : ""}
+                    onClick={() => onUserClick?.(m.user_id)}
+                    data-testid="missionaries-behind-row"
+                  >
+                    <TableCell>
+                      <div className="font-medium">{m.name}</div>
+                      <div className="text-xs text-muted-foreground truncate">{m.email}</div>
+                    </TableCell>
+                    <TableCell className="text-right">
+                      {formatCents(m.monthly_goal_cents, { whole: true })}
+                    </TableCell>
+                    <TableCell className="text-right">
+                      {formatCents(m.this_month_raised_cents, { whole: true })}
+                    </TableCell>
+                    <TableCell>
+                      <div className="flex items-center gap-2">
+                        <Progress value={barValue} className="h-2 flex-1" />
+                        <span className="text-xs font-medium tabular-nums w-10 text-right">
+                          {pace.toFixed(0)}%
+                        </span>
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                )
+              })}
+            </TableBody>
+          </Table>
+        )}
+        {total_excluded_no_goal > 0 && (
+          <p className="text-xs text-muted-foreground mt-4">
+            {total_excluded_no_goal} missionaries excluded (no goal set)
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/frontend/src/pages/admin/analytics/components/PipelineFunnelConversionTile.tsx
+++ b/frontend/src/pages/admin/analytics/components/PipelineFunnelConversionTile.tsx
@@ -1,0 +1,143 @@
+import { AlertTriangleIcon } from "lucide-react"
+
+import { Badge } from "@/components/ui/badge"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
+import { usePipelineFunnelConversion } from "@/hooks/useAdminAnalytics"
+import { CHART_COLORS, CHART_WARNING_COLOR } from "@/lib/chart-palette"
+
+interface PipelineFunnelConversionTileProps {
+  onStageClick?: (stage: string) => void
+}
+
+export function PipelineFunnelConversionTile({ onStageClick }: PipelineFunnelConversionTileProps) {
+  const { data, isLoading, error } = usePipelineFunnelConversion()
+
+  if (isLoading) {
+    return (
+      <Card data-testid="pipeline-funnel-tile" data-state="loading">
+        <CardHeader>
+          <CardTitle>Pipeline Funnel</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="h-64 bg-muted rounded animate-pulse" />
+        </CardContent>
+      </Card>
+    )
+  }
+
+  if (error || !data) {
+    return (
+      <Card data-testid="pipeline-funnel-tile" data-state="error">
+        <CardHeader>
+          <CardTitle>Pipeline Funnel</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="bg-destructive/10 border border-destructive/20 rounded-md p-4">
+            <p className="text-destructive text-sm">Failed to load pipeline funnel.</p>
+          </div>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  const { stages, total_in_pipeline, weakest_transition } = data
+  const maxCount = Math.max(...stages.map((s) => s.count_at_or_past), 1)
+
+  return (
+    <Card data-testid="pipeline-funnel-tile" data-state="ready">
+      <CardHeader>
+        <CardTitle>Pipeline Funnel</CardTitle>
+        <CardDescription>
+          {total_in_pipeline} contacts in pipeline. Stage-to-stage conversion shown between bars.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        {total_in_pipeline === 0 ? (
+          <div className="py-12 text-center">
+            <p className="text-muted-foreground">No pipeline activity yet.</p>
+          </div>
+        ) : (
+          <TooltipProvider>
+            <div className="space-y-3">
+              {stages.map((stage, idx) => {
+                const barWidth = (stage.count_at_or_past / maxCount) * 100
+                const color = stage.is_weakest_transition
+                  ? CHART_WARNING_COLOR
+                  : CHART_COLORS[idx % CHART_COLORS.length]
+                const conversion = stage.conversion_from_prior_percentage
+
+                return (
+                  <div key={stage.stage} data-testid="pipeline-stage-row">
+                    {conversion !== null && (
+                      <div className="flex items-center gap-2 pl-2 pb-1">
+                        <div className="h-2 w-px bg-border" aria-hidden />
+                        {stage.is_weakest_transition ? (
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <Badge
+                                variant="outline"
+                                className="border-amber-500/40 text-amber-600 bg-amber-50 gap-1"
+                                data-testid="pipeline-weakest-badge"
+                              >
+                                <AlertTriangleIcon className="h-3 w-3" aria-hidden />
+                                {conversion.toFixed(0)}% conversion
+                              </Badge>
+                            </TooltipTrigger>
+                            <TooltipContent side="right">
+                              Lowest conversion rate in funnel — coaching opportunity.
+                            </TooltipContent>
+                          </Tooltip>
+                        ) : (
+                          <span className="text-xs text-muted-foreground">
+                            {conversion.toFixed(0)}% conversion
+                          </span>
+                        )}
+                      </div>
+                    )}
+                    <button
+                      type="button"
+                      className="w-full text-left group"
+                      onClick={() => onStageClick?.(stage.stage)}
+                      disabled={!onStageClick}
+                    >
+                      <div className="flex items-center justify-between mb-1">
+                        <span className="text-sm font-medium">{stage.label}</span>
+                        <span className="text-sm tabular-nums text-muted-foreground">
+                          {stage.count_at_or_past}
+                        </span>
+                      </div>
+                      <div className="h-6 bg-muted rounded overflow-hidden">
+                        <div
+                          className="h-full rounded transition-all group-hover:opacity-90"
+                          style={{
+                            width: `${Math.max(barWidth, 2)}%`,
+                            backgroundColor: color,
+                          }}
+                        />
+                      </div>
+                    </button>
+                  </div>
+                )
+              })}
+            </div>
+            {weakest_transition && (
+              <p className="text-xs text-muted-foreground mt-4">
+                Weakest transition:{" "}
+                <span className="font-medium">
+                  {weakest_transition.from} → {weakest_transition.to}
+                </span>{" "}
+                ({weakest_transition.rate.toFixed(0)}% conversion)
+              </p>
+            )}
+          </TooltipProvider>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/frontend/src/pages/admin/analytics/components/WeeklyEngagementTile.tsx
+++ b/frontend/src/pages/admin/analytics/components/WeeklyEngagementTile.tsx
@@ -49,32 +49,39 @@ export function WeeklyEngagementTile({ weeks = 12 }: WeeklyEngagementTileProps) 
     )
   }
 
-  const totalActivity = data.weeks.reduce(
-    (sum, w) => sum + w.active_missionaries + w.on_pace_missionaries,
-    0,
+  const hasAnyActivity = data.weeks.some(
+    (w) => w.active_missionaries > 0 || w.on_pace_missionaries > 0,
   )
 
   return (
-    <Card data-testid="weekly-engagement-tile" data-state="ready">
+    <Card className="flex flex-col" data-testid="weekly-engagement-tile" data-state="ready">
       <CardHeader>
         <CardTitle>Weekly Engagement</CardTitle>
         <CardDescription>
           Active missionaries and on-pace count over the last {weeks} weeks.
         </CardDescription>
       </CardHeader>
-      <CardContent>
-        {totalActivity === 0 ? (
-          <div className="py-12 text-center">
+      <CardContent className="flex-1 flex flex-col">
+        {!hasAnyActivity ? (
+          <div className="flex-1 flex items-center justify-center py-12">
             <p className="text-muted-foreground">No engagement data for this window.</p>
           </div>
         ) : (
-          <ChartContainer config={{}} className="h-[280px] w-full">
-            <ComposedChart data={data.weeks} margin={{ top: 20, right: 20, left: 0, bottom: 0 }}>
+          <ChartContainer
+            config={{}}
+            className="flex-1 w-full min-h-[320px] aspect-auto"
+          >
+            <ComposedChart data={data.weeks} margin={{ top: 20, right: 20, left: 0, bottom: 16 }}>
                 <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
                 <XAxis
                   dataKey="week_label"
-                  tick={{ fontSize: 12 }}
+                  tick={{ fontSize: 11 }}
                   stroke="hsl(var(--muted-foreground))"
+                  interval={0}
+                  minTickGap={0}
+                  angle={-35}
+                  textAnchor="end"
+                  height={48}
                 />
                 <YAxis tick={{ fontSize: 12 }} stroke="hsl(var(--muted-foreground))" allowDecimals={false} />
                 <Tooltip
@@ -83,8 +90,8 @@ export function WeeklyEngagementTile({ weeks = 12 }: WeeklyEngagementTileProps) 
                     return (
                       <div className="bg-background border rounded-lg p-2 shadow-lg text-sm">
                         <p className="font-medium mb-1">Week of {label}</p>
-                        {payload.map((item) => (
-                          <p key={item.dataKey?.toString()} className="text-muted-foreground">
+                        {payload.map((item, idx) => (
+                          <p key={item.name ?? idx} className="text-muted-foreground">
                             <span
                               className="inline-block w-2 h-2 rounded-full mr-2 align-middle"
                               style={{ backgroundColor: item.color }}

--- a/frontend/src/pages/admin/analytics/components/WeeklyEngagementTile.tsx
+++ b/frontend/src/pages/admin/analytics/components/WeeklyEngagementTile.tsx
@@ -1,0 +1,120 @@
+import {
+  Bar,
+  CartesianGrid,
+  ComposedChart,
+  Legend,
+  Line,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts"
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { ChartContainer } from "@/components/ui/chart"
+import { useWeeklyEngagement } from "@/hooks/useAdminAnalytics"
+import { CHART_COLORS } from "@/lib/chart-palette"
+
+interface WeeklyEngagementTileProps {
+  weeks?: number
+}
+
+export function WeeklyEngagementTile({ weeks = 12 }: WeeklyEngagementTileProps) {
+  const { data, isLoading, error } = useWeeklyEngagement({ weeks })
+
+  if (isLoading) {
+    return (
+      <Card data-testid="weekly-engagement-tile" data-state="loading">
+        <CardHeader>
+          <CardTitle>Weekly Engagement</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="h-64 bg-muted rounded animate-pulse" />
+        </CardContent>
+      </Card>
+    )
+  }
+
+  if (error || !data) {
+    return (
+      <Card data-testid="weekly-engagement-tile" data-state="error">
+        <CardHeader>
+          <CardTitle>Weekly Engagement</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="bg-destructive/10 border border-destructive/20 rounded-md p-4">
+            <p className="text-destructive text-sm">Failed to load weekly engagement.</p>
+          </div>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  const totalActivity = data.weeks.reduce(
+    (sum, w) => sum + w.active_missionaries + w.on_pace_missionaries,
+    0,
+  )
+
+  return (
+    <Card data-testid="weekly-engagement-tile" data-state="ready">
+      <CardHeader>
+        <CardTitle>Weekly Engagement</CardTitle>
+        <CardDescription>
+          Active missionaries and on-pace count over the last {weeks} weeks.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        {totalActivity === 0 ? (
+          <div className="py-12 text-center">
+            <p className="text-muted-foreground">No engagement data for this window.</p>
+          </div>
+        ) : (
+          <ChartContainer config={{}} className="h-[280px] w-full">
+            <ComposedChart data={data.weeks} margin={{ top: 20, right: 20, left: 0, bottom: 0 }}>
+                <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
+                <XAxis
+                  dataKey="week_label"
+                  tick={{ fontSize: 12 }}
+                  stroke="hsl(var(--muted-foreground))"
+                />
+                <YAxis tick={{ fontSize: 12 }} stroke="hsl(var(--muted-foreground))" allowDecimals={false} />
+                <Tooltip
+                  content={({ payload, label }) => {
+                    if (!payload?.length) return null
+                    return (
+                      <div className="bg-background border rounded-lg p-2 shadow-lg text-sm">
+                        <p className="font-medium mb-1">Week of {label}</p>
+                        {payload.map((item) => (
+                          <p key={item.dataKey?.toString()} className="text-muted-foreground">
+                            <span
+                              className="inline-block w-2 h-2 rounded-full mr-2 align-middle"
+                              style={{ backgroundColor: item.color }}
+                            />
+                            {item.name}: <span className="font-medium text-foreground">{item.value}</span>
+                          </p>
+                        ))}
+                      </div>
+                    )
+                  }}
+                />
+                <Legend verticalAlign="top" align="right" wrapperStyle={{ fontSize: 12 }} />
+                <Bar
+                  dataKey="active_missionaries"
+                  name="Active"
+                  fill={CHART_COLORS[0]}
+                  radius={[2, 2, 0, 0]}
+                />
+                <Line
+                  type="monotone"
+                  dataKey="on_pace_missionaries"
+                  name="On pace"
+                  stroke={CHART_COLORS[2]}
+                  strokeWidth={2}
+                  dot={{ r: 3 }}
+                />
+            </ComposedChart>
+          </ChartContainer>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/frontend/src/pages/admin/analytics/components/__tests__/FiscalYearDonationsTile.test.tsx
+++ b/frontend/src/pages/admin/analytics/components/__tests__/FiscalYearDonationsTile.test.tsx
@@ -1,0 +1,92 @@
+import { render, screen } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import type { FiscalYearDonationsResponse } from "@/api/adminAnalytics"
+
+vi.mock("@/hooks/useAdminAnalytics", () => ({
+  useFiscalYearDonations: vi.fn(),
+}))
+
+// ChartContainer (shadcn) nests ResponsiveContainer. Stub it so jsdom renders
+// the chart tree at a fixed size without depending on real layout.
+vi.mock("recharts", async () => {
+  const actual = await vi.importActual<typeof import("recharts")>("recharts")
+  return {
+    ...actual,
+    ResponsiveContainer: ({ children }: { children: React.ReactNode }) => (
+      <div style={{ width: 600, height: 320 }}>{children}</div>
+    ),
+  }
+})
+
+import { useFiscalYearDonations } from "@/hooks/useAdminAnalytics"
+
+import { FiscalYearDonationsTile } from "../FiscalYearDonationsTile"
+
+type QueryResult = {
+  data: FiscalYearDonationsResponse | undefined
+  isLoading: boolean
+  error: Error | null
+}
+
+function mockHook(result: QueryResult) {
+  vi.mocked(useFiscalYearDonations).mockReturnValue(
+    result as ReturnType<typeof useFiscalYearDonations>,
+  )
+}
+
+function makeResponse(overrides: Partial<FiscalYearDonationsResponse> = {}): FiscalYearDonationsResponse {
+  return {
+    fy_start: "2025-07-01",
+    fy_end: "2026-06-30",
+    months: Array.from({ length: 12 }, (_, i) => ({
+      month: `2025-${String(7 + i).padStart(2, "0")}-01`,
+      short_label: ["Jul", "Aug", "Sep", "Oct", "Nov", "Dec", "Jan", "Feb", "Mar", "Apr", "May", "Jun"][i],
+      current_cents: i < 3 ? 100_000 * (i + 1) : null,
+      prior_cents: 50_000 * (i + 1),
+      is_future: i >= 3,
+    })),
+    current_fy_total_cents: 600_000,
+    prior_fy_total_cents: 3_900_000,
+    ...overrides,
+  }
+}
+
+describe("FiscalYearDonationsTile", () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it("renders a skeleton while loading", () => {
+    mockHook({ data: undefined, isLoading: true, error: null })
+    render(<FiscalYearDonationsTile />)
+    expect(screen.getByTestId("fy-donations-tile")).toHaveAttribute("data-state", "loading")
+  })
+
+  it("renders the error state when the hook errors", () => {
+    mockHook({ data: undefined, isLoading: false, error: new Error("boom") })
+    render(<FiscalYearDonationsTile />)
+    expect(screen.getByTestId("fy-donations-tile")).toHaveAttribute("data-state", "error")
+  })
+
+  it("renders an empty state when both totals are zero", () => {
+    mockHook({
+      data: makeResponse({ current_fy_total_cents: 0, prior_fy_total_cents: 0 }),
+      isLoading: false,
+      error: null,
+    })
+    render(<FiscalYearDonationsTile />)
+    expect(screen.getByText(/no donation data yet/i)).toBeInTheDocument()
+  })
+
+  it("renders totals with formatted currency when data is present", () => {
+    mockHook({ data: makeResponse(), isLoading: false, error: null })
+    render(<FiscalYearDonationsTile />)
+    expect(screen.getByTestId("fy-donations-tile")).toHaveAttribute("data-state", "ready")
+    expect(screen.getByText(/current fy total/i)).toBeInTheDocument()
+    expect(screen.getByText(/prior fy total/i)).toBeInTheDocument()
+    // $600,000 current total + $39,000 prior total (see makeResponse defaults)
+    expect(screen.getByText("$6,000")).toBeInTheDocument()
+    expect(screen.getByText("$39,000")).toBeInTheDocument()
+    // Empty-state copy must not appear when data is present.
+    expect(screen.queryByText(/no donation data yet/i)).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/admin/analytics/components/__tests__/FiscalYearPaceTile.test.tsx
+++ b/frontend/src/pages/admin/analytics/components/__tests__/FiscalYearPaceTile.test.tsx
@@ -1,0 +1,93 @@
+import { render, screen } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import type { FiscalYearPaceResponse } from "@/api/adminAnalytics"
+
+vi.mock("@/hooks/useAdminAnalytics", () => ({
+  useFiscalYearPace: vi.fn(),
+}))
+
+import { useFiscalYearPace } from "@/hooks/useAdminAnalytics"
+
+import { FiscalYearPaceTile } from "../FiscalYearPaceTile"
+
+type QueryResult = {
+  data: FiscalYearPaceResponse | undefined
+  isLoading: boolean
+  error: Error | null
+}
+
+function mockHook(result: QueryResult) {
+  vi.mocked(useFiscalYearPace).mockReturnValue(result as ReturnType<typeof useFiscalYearPace>)
+}
+
+const BASE_DATA: FiscalYearPaceResponse = {
+  fy_start: "2025-07-01",
+  fy_end: "2026-06-30",
+  raised_cents: 500_000_00,
+  annual_goal_cents: 1_000_000_00,
+  expected_by_today_cents: 400_000_00,
+  pace_percentage: 125.0,
+  prior_year_raised_cents: 300_000_00,
+  yoy_delta_percentage: 66.7,
+  last_import_at: "2026-04-21T10:00:00Z",
+}
+
+describe("FiscalYearPaceTile", () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it("renders a skeleton while loading", () => {
+    mockHook({ data: undefined, isLoading: true, error: null })
+    render(<FiscalYearPaceTile />)
+    expect(screen.getByTestId("fy-pace-tile")).toHaveAttribute("data-state", "loading")
+  })
+
+  it("renders an error state when the hook errors", () => {
+    mockHook({ data: undefined, isLoading: false, error: new Error("boom") })
+    render(<FiscalYearPaceTile />)
+    expect(screen.getByTestId("fy-pace-tile")).toHaveAttribute("data-state", "error")
+    expect(screen.getByText(/failed to load/i)).toBeInTheDocument()
+  })
+
+  it("formats currency and pace for the happy path", () => {
+    mockHook({ data: BASE_DATA, isLoading: false, error: null })
+    render(<FiscalYearPaceTile />)
+
+    expect(screen.getByTestId("fy-pace-raised")).toHaveTextContent("$500,000")
+    // pace is clamped to 150 and rendered as an integer
+    expect(screen.getByTestId("fy-pace-badge")).toHaveTextContent("125% of pace")
+    // YoY delta formats with a + sign when positive
+    expect(screen.getByTestId("fy-pace-yoy")).toHaveTextContent("+66.7% vs. last year")
+    expect(screen.getByTestId("fy-pace-import-caption")).toHaveTextContent(/data as of/i)
+  })
+
+  it("shows 'No prior year data' chip when yoy_delta_percentage is null", () => {
+    mockHook({
+      data: { ...BASE_DATA, yoy_delta_percentage: null },
+      isLoading: false,
+      error: null,
+    })
+    render(<FiscalYearPaceTile />)
+    expect(screen.getByTestId("fy-pace-yoy")).toHaveTextContent(/no prior year data/i)
+  })
+
+  it("falls back to 'Updated daily' caption when last_import_at is null", () => {
+    mockHook({
+      data: { ...BASE_DATA, last_import_at: null },
+      isLoading: false,
+      error: null,
+    })
+    render(<FiscalYearPaceTile />)
+    expect(screen.getByTestId("fy-pace-import-caption")).toHaveTextContent(/updated daily/i)
+  })
+
+  it("clamps the badge pace to 150% when backend returns an out-of-range value", () => {
+    mockHook({
+      data: { ...BASE_DATA, pace_percentage: 999 },
+      isLoading: false,
+      error: null,
+    })
+    render(<FiscalYearPaceTile />)
+    expect(screen.getByTestId("fy-pace-badge")).toHaveTextContent("150% of pace")
+  })
+})

--- a/frontend/src/pages/admin/analytics/components/__tests__/MissionariesBehindGoalTile.test.tsx
+++ b/frontend/src/pages/admin/analytics/components/__tests__/MissionariesBehindGoalTile.test.tsx
@@ -1,0 +1,108 @@
+import { fireEvent, render, screen } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import type { MissionariesBehindGoalResponse } from "@/api/adminAnalytics"
+
+vi.mock("@/hooks/useAdminAnalytics", () => ({
+  useMissionariesBehindGoal: vi.fn(),
+}))
+
+import { useMissionariesBehindGoal } from "@/hooks/useAdminAnalytics"
+
+import { MissionariesBehindGoalTile } from "../MissionariesBehindGoalTile"
+
+type QueryResult = {
+  data: MissionariesBehindGoalResponse | undefined
+  isLoading: boolean
+  error: Error | null
+}
+
+function mockHook(result: QueryResult) {
+  vi.mocked(useMissionariesBehindGoal).mockReturnValue(
+    result as ReturnType<typeof useMissionariesBehindGoal>,
+  )
+}
+
+const DATA_WITH_ROWS: MissionariesBehindGoalResponse = {
+  missionaries: [
+    {
+      user_id: "u1",
+      name: "Alice Behind",
+      email: "alice@example.com",
+      monthly_goal_cents: 500_000,
+      this_month_raised_cents: 100_000,
+      pace_percentage: 25,
+    },
+    {
+      user_id: "u2",
+      name: "Bob Almost",
+      email: "bob@example.com",
+      monthly_goal_cents: 400_000,
+      this_month_raised_cents: 300_000,
+      pace_percentage: 90,
+    },
+  ],
+  total_excluded_no_goal: 3,
+  total_missionaries: 8,
+  as_of_date: "2026-04-22",
+}
+
+describe("MissionariesBehindGoalTile", () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it("renders a skeleton while loading", () => {
+    mockHook({ data: undefined, isLoading: true, error: null })
+    render(<MissionariesBehindGoalTile />)
+    expect(screen.getByTestId("missionaries-behind-tile")).toHaveAttribute("data-state", "loading")
+  })
+
+  it("renders an error state when the hook errors", () => {
+    mockHook({ data: undefined, isLoading: false, error: new Error("boom") })
+    render(<MissionariesBehindGoalTile />)
+    expect(screen.getByTestId("missionaries-behind-tile")).toHaveAttribute("data-state", "error")
+  })
+
+  it("renders the empty state with a celebratory message", () => {
+    mockHook({
+      data: { ...DATA_WITH_ROWS, missionaries: [], total_excluded_no_goal: 0 },
+      isLoading: false,
+      error: null,
+    })
+    render(<MissionariesBehindGoalTile />)
+    expect(screen.getByText(/all missionaries on pace/i)).toBeInTheDocument()
+  })
+
+  it("renders rows for each missionary with formatted currency and pace", () => {
+    mockHook({ data: DATA_WITH_ROWS, isLoading: false, error: null })
+    render(<MissionariesBehindGoalTile />)
+
+    const rows = screen.getAllByTestId("missionaries-behind-row")
+    expect(rows).toHaveLength(2)
+    expect(rows[0]).toHaveTextContent("Alice Behind")
+    expect(rows[0]).toHaveTextContent("$5,000")
+    expect(rows[0]).toHaveTextContent("$1,000")
+    expect(rows[0]).toHaveTextContent("25%")
+
+    expect(screen.getByText(/3 missionaries excluded \(no goal set\)/i)).toBeInTheDocument()
+  })
+
+  it("calls onUserClick when a row is clicked", () => {
+    mockHook({ data: DATA_WITH_ROWS, isLoading: false, error: null })
+    const onUserClick = vi.fn()
+    render(<MissionariesBehindGoalTile onUserClick={onUserClick} />)
+
+    const rows = screen.getAllByTestId("missionaries-behind-row")
+    fireEvent.click(rows[0])
+    expect(onUserClick).toHaveBeenCalledWith("u1")
+  })
+
+  it("omits the excluded footer when total_excluded_no_goal is 0", () => {
+    mockHook({
+      data: { ...DATA_WITH_ROWS, total_excluded_no_goal: 0 },
+      isLoading: false,
+      error: null,
+    })
+    render(<MissionariesBehindGoalTile />)
+    expect(screen.queryByText(/excluded \(no goal set\)/i)).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/admin/analytics/components/__tests__/PipelineFunnelConversionTile.test.tsx
+++ b/frontend/src/pages/admin/analytics/components/__tests__/PipelineFunnelConversionTile.test.tsx
@@ -1,0 +1,102 @@
+import { fireEvent, render, screen } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import type { PipelineFunnelConversionResponse } from "@/api/adminAnalytics"
+
+vi.mock("@/hooks/useAdminAnalytics", () => ({
+  usePipelineFunnelConversion: vi.fn(),
+}))
+
+import { usePipelineFunnelConversion } from "@/hooks/useAdminAnalytics"
+
+import { PipelineFunnelConversionTile } from "../PipelineFunnelConversionTile"
+
+type QueryResult = {
+  data: PipelineFunnelConversionResponse | undefined
+  isLoading: boolean
+  error: Error | null
+}
+
+function mockHook(result: QueryResult) {
+  vi.mocked(usePipelineFunnelConversion).mockReturnValue(
+    result as ReturnType<typeof usePipelineFunnelConversion>,
+  )
+}
+
+const DATA: PipelineFunnelConversionResponse = {
+  stages: [
+    {
+      stage: "contact",
+      label: "Contact",
+      count_at_or_past: 100,
+      conversion_from_prior_percentage: null,
+      is_weakest_transition: false,
+    },
+    {
+      stage: "scheduled",
+      label: "Scheduled",
+      count_at_or_past: 60,
+      conversion_from_prior_percentage: 60,
+      is_weakest_transition: false,
+    },
+    {
+      stage: "meet",
+      label: "Meet",
+      count_at_or_past: 5,
+      conversion_from_prior_percentage: 8.3,
+      is_weakest_transition: true,
+    },
+  ],
+  total_in_pipeline: 100,
+  weakest_transition: { from: "scheduled", to: "meet", rate: 8.3 },
+}
+
+describe("PipelineFunnelConversionTile", () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it("renders a skeleton while loading", () => {
+    mockHook({ data: undefined, isLoading: true, error: null })
+    render(<PipelineFunnelConversionTile />)
+    expect(screen.getByTestId("pipeline-funnel-tile")).toHaveAttribute("data-state", "loading")
+  })
+
+  it("renders the empty state when no pipeline activity", () => {
+    mockHook({
+      data: {
+        stages: DATA.stages.map((s) => ({ ...s, count_at_or_past: 0, is_weakest_transition: false })),
+        total_in_pipeline: 0,
+        weakest_transition: null,
+      },
+      isLoading: false,
+      error: null,
+    })
+    render(<PipelineFunnelConversionTile />)
+    expect(screen.getByText(/no pipeline activity/i)).toBeInTheDocument()
+  })
+
+  it("renders one row per stage and shows the weakest badge once", () => {
+    mockHook({ data: DATA, isLoading: false, error: null })
+    render(<PipelineFunnelConversionTile />)
+
+    expect(screen.getAllByTestId("pipeline-stage-row")).toHaveLength(3)
+    const weakest = screen.getAllByTestId("pipeline-weakest-badge")
+    expect(weakest).toHaveLength(1)
+    expect(weakest[0]).toHaveTextContent("8% conversion")
+  })
+
+  it("shows a descriptive weakest-transition footer", () => {
+    mockHook({ data: DATA, isLoading: false, error: null })
+    render(<PipelineFunnelConversionTile />)
+    expect(screen.getByText(/scheduled → meet/i)).toBeInTheDocument()
+  })
+
+  it("calls onStageClick when a stage is clicked", () => {
+    mockHook({ data: DATA, isLoading: false, error: null })
+    const onStageClick = vi.fn()
+    render(<PipelineFunnelConversionTile onStageClick={onStageClick} />)
+
+    const firstStageButton = screen.getAllByRole("button")[0]
+    fireEvent.click(firstStageButton)
+    expect(onStageClick).toHaveBeenCalledWith("contact")
+  })
+})

--- a/frontend/src/pages/admin/analytics/components/__tests__/WeeklyEngagementTile.test.tsx
+++ b/frontend/src/pages/admin/analytics/components/__tests__/WeeklyEngagementTile.test.tsx
@@ -1,0 +1,87 @@
+import { render, screen } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import type { WeeklyEngagementResponse } from "@/api/adminAnalytics"
+
+vi.mock("@/hooks/useAdminAnalytics", () => ({
+  useWeeklyEngagement: vi.fn(),
+}))
+
+// ChartContainer (shadcn wrapper around Recharts) nests ResponsiveContainer
+// internally. ResponsiveContainer needs real layout which jsdom can't provide,
+// so stub it with a fixed-size div that still renders its children.
+vi.mock("recharts", async () => {
+  const actual = await vi.importActual<typeof import("recharts")>("recharts")
+  return {
+    ...actual,
+    ResponsiveContainer: ({ children }: { children: React.ReactNode }) => (
+      <div style={{ width: 600, height: 300 }}>{children}</div>
+    ),
+  }
+})
+
+import { useWeeklyEngagement } from "@/hooks/useAdminAnalytics"
+
+import { WeeklyEngagementTile } from "../WeeklyEngagementTile"
+
+type QueryResult = {
+  data: WeeklyEngagementResponse | undefined
+  isLoading: boolean
+  error: Error | null
+}
+
+function mockHook(result: QueryResult) {
+  vi.mocked(useWeeklyEngagement).mockReturnValue(
+    result as ReturnType<typeof useWeeklyEngagement>,
+  )
+}
+
+function makeWeeks(n: number, active: number, onPace: number): WeeklyEngagementResponse {
+  return {
+    weeks: Array.from({ length: n }, (_, i) => ({
+      week_start: `2026-02-${String((i % 28) + 1).padStart(2, "0")}`,
+      week_label: `Feb ${i + 1}`,
+      active_missionaries: active,
+      on_pace_missionaries: onPace,
+      total_missionaries: 40,
+    })),
+  }
+}
+
+describe("WeeklyEngagementTile", () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it("renders a skeleton while loading", () => {
+    mockHook({ data: undefined, isLoading: true, error: null })
+    render(<WeeklyEngagementTile />)
+    expect(screen.getByTestId("weekly-engagement-tile")).toHaveAttribute("data-state", "loading")
+  })
+
+  it("renders an error state when the hook errors", () => {
+    mockHook({ data: undefined, isLoading: false, error: new Error("boom") })
+    render(<WeeklyEngagementTile />)
+    expect(screen.getByTestId("weekly-engagement-tile")).toHaveAttribute("data-state", "error")
+  })
+
+  it("renders the empty state when all weeks are zero", () => {
+    mockHook({ data: makeWeeks(4, 0, 0), isLoading: false, error: null })
+    render(<WeeklyEngagementTile />)
+    expect(screen.getByText(/no engagement data/i)).toBeInTheDocument()
+  })
+
+  it("reaches the ready state with a descriptive caption when data is present", () => {
+    mockHook({ data: makeWeeks(12, 8, 4), isLoading: false, error: null })
+    render(<WeeklyEngagementTile />)
+    expect(screen.getByTestId("weekly-engagement-tile")).toHaveAttribute("data-state", "ready")
+    // Card description varies with the weeks prop and confirms data path executed.
+    expect(screen.getByText(/last 12 weeks/i)).toBeInTheDocument()
+    // Empty-state copy must not appear when data is present.
+    expect(screen.queryByText(/no engagement data/i)).not.toBeInTheDocument()
+  })
+
+  it("honors the weeks prop in the description", () => {
+    mockHook({ data: makeWeeks(4, 3, 1), isLoading: false, error: null })
+    render(<WeeklyEngagementTile weeks={4} />)
+    expect(screen.getByText(/last 4 weeks/i)).toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/groups/GroupList.tsx
+++ b/frontend/src/pages/groups/GroupList.tsx
@@ -42,7 +42,7 @@ const DEFAULT_COLORS = [
 export default function GroupList() {
   const navigate = useNavigate()
   const { isViewingAs } = useViewAs()
-  const { data: groups, isLoading, error } = useGroups()
+  const { data: groups, isLoading } = useGroups()
 
   const createMutation = useCreateGroup()
   const deleteMutation = useDeleteGroup()

--- a/frontend/src/pages/journals/components/LogEventDialog.tsx
+++ b/frontend/src/pages/journals/components/LogEventDialog.tsx
@@ -130,7 +130,7 @@ export const LogEventDialog = React.memo(function LogEventDialog({
         }
       }
 
-      await createEventMutation.mutateAsync(payload as Parameters<typeof createEventMutation.mutateAsync>[0])
+      await createEventMutation.mutateAsync(payload as unknown as Parameters<typeof createEventMutation.mutateAsync>[0])
       onOpenChange(false)
     } catch {
       // Error toast handled by hook

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -56,7 +56,12 @@
     --radius: 0.75rem;
 
     /* Chart Colors */
-    --chart-1: 220 34% 34%;          /* SPO Blue for charts */
+    --chart-1: 220 34% 34%;          /* SPO Blue */
+    --chart-2: 348 85% 61%;          /* SPO Red */
+    --chart-3: 142 71% 38%;          /* Green (on-pace / positive) */
+    --chart-4: 38 92% 50%;           /* Amber (warning) */
+    --chart-5: 262 52% 58%;          /* Purple */
+    --chart-6: 199 89% 48%;          /* Cyan */
   }
 
   .dark {
@@ -99,6 +104,11 @@
 
     /* Chart Colors */
     --chart-1: 210 40% 98%;          /* White/near-white for chart elements */
+    --chart-2: 348 85% 65%;          /* SPO Red (brighter for dark) */
+    --chart-3: 142 65% 55%;          /* Green (on-pace / positive) */
+    --chart-4: 38 92% 62%;           /* Amber (warning) */
+    --chart-5: 262 62% 70%;          /* Purple */
+    --chart-6: 199 89% 62%;          /* Cyan */
   }
 
   * {


### PR DESCRIPTION
Closes #49.

## Summary
- Reshapes `/admin/analytics/dashboard` into a weekly-checkin tool for Development leadership: fiscal-year pace (hero), missionaries behind goal (coaching), weekly engagement, pipeline funnel with conversion, FY donations vs prior year, then demoted reference counts.
- Five new admin-only read endpoints under `/api/v1/insights/admin/`, all gated by `IsAdmin`, with View-As scoping respected when active.
- Pure read layer — no migrations, no Celery, no `django-filter` bump. Extends existing fiscal-year utilities with bounds helpers.

## Backend (`c57cddc`)
- `apps/core/fiscal_year.py` — `get_current_fiscal_year_bounds`, `get_prior_fiscal_year_bounds` + tests (leap year, Jul 1, Jun 30, etc.)
- `apps/insights/admin_analytics_services.py` (new) — 5 services
- `apps/insights/{views,serializers,urls}.py` — 5 DRF views, 5 response serializers, 5 URL routes
- Tests: 64 passing (17 fiscal-year + 15 services + 32 views)

## Frontend (`ea6a618`)
- 5 new lazy-loaded tile components under `frontend/src/pages/admin/analytics/components/`
- New `api/adminAnalytics.ts` + `hooks/useAdminAnalytics.ts` (5-min staleTime, 30-min gcTime)
- Shared `lib/format.ts` (`formatCents`, `clampPercentage`) and `lib/chart-palette.ts`
- Dashboard layout reordered; standalone Conversion Rate tile removed; below-the-fold sections untouched
- `ConversionFunnelChart` refactored to consume the shared palette
- Bug caught by tests: removed redundant `ResponsiveContainer` wrapping (`ChartContainer` already provides one)

## Unrelated unblocker (`2b04ba3`)
Two pre-existing TS errors on `main` that were blocking `tsc -b`:
- `GroupList.tsx` TS6133 (unused `error`)
- `LogEventDialog.tsx` TS2352 (cast via `unknown`)

## Test plan
- [x] Backend: `pytest apps/core/tests/test_fiscal_year.py apps/insights/tests/test_admin_analytics_services.py apps/insights/tests/test_admin_analytics_views.py` — 64 passing
- [x] Backend lint: `black --check` + `isort --check-only` clean
- [x] Backend: `makemigrations --check --dry-run` — no changes
- [x] Frontend build: `npm run build` — clean
- [x] Frontend unit: `npx vitest run` — 48 passing across 8 files (35 new)
- [ ] Frontend E2E: `npx playwright test admin_analytics_redesign.admin.spec.ts` — needs dev servers running; run locally before merge
- [ ] Manual smoke: load `/admin/analytics/dashboard` as admin, verify all 5 tiles render with real data, verify reference counts row appears, verify Conversion Rate tile is gone

## Decisions locked during planning
- Paths: repo conventions (`pages/admin/analytics/components/`, `/api/v1/insights/admin/`)
- Permissions: admin-only (`IsAdmin`), matching existing route guard
- On-pace metric: month-to-date interpretation (simpler, cheap, matches leadership mental model)
- Admin scoping: org-wide by default, View-As overrides via `get_visible_user_ids`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/matkukla/donorcrm/pull/50" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
