### PR TITLE
Autonomous maintenance: CI gate, Dependabot, AI fix-issues + health-watch

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,20 @@
+[flake8]
+# Aligned with black (line-length 100, see pyproject.toml [tool.black]).
+max-line-length = 100
+extend-ignore =
+    # E203: whitespace before ':' — black formats slices in a way flake8
+    # flags; black is authoritative.
+    E203,
+    # W503: line break before binary operator — black's preferred style.
+    W503,
+exclude =
+    .git,
+    .venv,
+    venv,
+    __pycache__,
+    */migrations/*,
+    build,
+    dist
+# Per-file: __init__.py re-exports legitimately leave imports "unused".
+per-file-ignores =
+    __init__.py:F401

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,59 @@
+version: 2
+
+# Dependabot opens grouped dependency-bump PRs. Each one is vetted by the CI
+# gate (ci.yml) and the Claude review action (claude-code-review.yml) before a
+# human merges. This closes the loop on the CVEs that security.yml's pip-audit
+# already surfaces — but does NOT auto-merge (propose-and-approve).
+
+updates:
+  # Python — one entry per requirements file so PRs map to a single file.
+  - package-ecosystem: pip
+    directory: "/requirements"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: Etc/UTC
+    open-pull-requests-limit: 5
+    groups:
+      # Batch patch + minor bumps into one PR to cut review volume; majors
+      # come as individual PRs so breaking changes are reviewed in isolation.
+      python-minor-patch:
+        update-types: ["minor", "patch"]
+    labels: ["dependencies", "python"]
+    commit-message:
+      prefix: "chore"
+      include: scope
+    # django-filter must stay <25 (25.2+ requires Django 5.2). See CLAUDE.md.
+    ignore:
+      - dependency-name: "django-filter"
+        versions: [">=25.0"]
+
+  # Frontend npm
+  - package-ecosystem: npm
+    directory: "/frontend"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: Etc/UTC
+    open-pull-requests-limit: 5
+    groups:
+      npm-minor-patch:
+        update-types: ["minor", "patch"]
+    labels: ["dependencies", "frontend"]
+    commit-message:
+      prefix: "chore"
+      include: scope
+
+  # The GitHub Actions themselves (claude-code-action, checkout, setup-*).
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: Etc/UTC
+    labels: ["dependencies", "ci"]
+    commit-message:
+      prefix: "ci"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,83 @@
+name: CI
+
+# The verification gate. Everything downstream (Dependabot bumps, AI-authored
+# fix PRs) is only trustworthy because this runs on every PR. Branch protection
+# should require these jobs before merge.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  backend:
+    name: backend (pytest + lint)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Install dependencies
+        # Tests run on SQLite in-memory (config.settings.test), so prod.txt is
+        # not required; dev.txt pulls in base.txt + pytest/black/isort/flake8.
+        run: pip install -r requirements/dev.txt
+
+      # Lint is ADVISORY until the pre-existing formatting/lint debt is cleaned
+      # up (black would reformat ~153 files, plus isort/flake8 backlog). These
+      # steps surface violations without failing the build so the gate can land
+      # now. Cleanup tracked separately; flip continue-on-error off once green.
+      - name: black
+        run: black --check apps/ config/
+        continue-on-error: true
+
+      - name: isort
+        run: isort --check-only apps/ config/
+        continue-on-error: true
+
+      - name: flake8
+        run: flake8 apps/ config/
+        continue-on-error: true
+
+      # HARD gate: tests + 80% coverage must pass.
+      - name: pytest (80% coverage gate)
+        # --cov-fail-under=80 is enforced via pyproject.toml addopts.
+        env:
+          DJANGO_SETTINGS_MODULE: config.settings.test
+        run: pytest
+
+  frontend:
+    name: frontend (build + lint)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "npm"
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      # Advisory, same as the backend linters: ESLint has a pre-existing
+      # backlog (~51 errors). Surfaces issues without failing the build.
+      - name: ESLint
+        run: npm run lint
+        continue-on-error: true
+
+      # HARD gate: the TypeScript compile + production build must succeed.
+      - name: Build (tsc + vite)
+        run: npm run build

--- a/.github/workflows/fix-issues.yml
+++ b/.github/workflows/fix-issues.yml
@@ -1,0 +1,77 @@
+name: AI Fix Issues
+
+# Self-driving issue fixing, propose-and-approve. Label an issue `ai-fix` (or
+# trigger manually with an issue number) and Claude implements a fix on a
+# branch and opens a PR. It NEVER merges — the CI gate (ci.yml) and Claude
+# review (claude-code-review.yml) run on the PR, and a human merges.
+
+on:
+  issues:
+    types: [labeled]
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: "Issue number to fix"
+        required: true
+        type: string
+
+jobs:
+  fix:
+    # Only act when the `ai-fix` label is applied, or via manual dispatch.
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'issues' && github.event.label.name == 'ai-fix')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Resolve issue number
+        id: meta
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "number=${{ github.event.inputs.issue_number }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "number=${{ github.event.issue.number }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Implement fix and open PR
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: '--allowed-tools "Bash(git:*),Bash(gh:*),Bash(pytest:*),Bash(black:*),Bash(isort:*),Bash(flake8:*),Edit,Write,Read"'
+          prompt: |
+            Implement a fix for issue #${{ steps.meta.outputs.number }} in this
+            repository.
+
+            Workflow (follow exactly, then stop):
+            1. Read the issue with `gh issue view ${{ steps.meta.outputs.number }}`
+               to understand the request.
+            2. Read CLAUDE.md for project conventions (money in cents, owner
+               scoping, isort sections, black line-length 100, etc.).
+            3. Create a branch named `ai-fix/issue-${{ steps.meta.outputs.number }}`.
+            4. Implement the smallest correct change. Add or update tests that
+               FAIL before your change and PASS after — a test must fail when
+               the feature is broken (see the #1 E2E rule in CLAUDE.md).
+            5. Run locally and ensure all pass:
+               `black --check apps/ config/`, `isort --check-only apps/ config/`,
+               `flake8 apps/ config/`, and `pytest`.
+            6. Commit and open a PR with `gh pr create`, body linking the issue
+               (`Closes #${{ steps.meta.outputs.number }}`) and summarizing the
+               change and how you verified it.
+
+            Constraints:
+            - Do NOT merge the PR. Open it as a draft if you are not fully
+              confident in the fix.
+            - Do NOT touch migrations, secrets, deploy config (render.yaml), or
+              authentication/permission logic without flagging it prominently in
+              the PR body and leaving the PR as a draft.
+            - If the issue is ambiguous or too risky to fix safely, do NOT open
+              a PR — instead comment on the issue explaining what's blocking and
+              what you'd need.

--- a/.github/workflows/health-watch.yml
+++ b/.github/workflows/health-watch.yml
@@ -1,0 +1,86 @@
+name: Health Watch
+
+# Probes the production health endpoint on a schedule. If it's down, Claude
+# pulls Render logs, diagnoses the root cause, and opens an issue — the same
+# investigation done manually for the auth-500 incident, now automated.
+# It only DIAGNOSES and FILES; it never deploys or changes prod.
+
+on:
+  schedule:
+    # Every 30 minutes. Render web services can cold-start; a single blip
+    # shouldn't page, so the probe step retries before declaring failure.
+    - cron: "*/30 * * * *"
+  workflow_dispatch: {}
+
+env:
+  HEALTH_URL: https://donorcrm-web.onrender.com/api/v1/health/
+
+jobs:
+  probe:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      id-token: write
+    steps:
+      - name: Probe health endpoint
+        id: probe
+        run: |
+          ok=false
+          for attempt in 1 2 3; do
+            code=$(curl -s -o /tmp/body -w "%{http_code}" --max-time 30 "$HEALTH_URL" || echo 000)
+            echo "Attempt $attempt: HTTP $code"
+            if [ "$code" = "200" ]; then ok=true; break; fi
+            sleep 20
+          done
+          echo "status_code=$code" >> "$GITHUB_OUTPUT"
+          echo "body<<EOF" >> "$GITHUB_OUTPUT"; cat /tmp/body >> "$GITHUB_OUTPUT"; echo "" >> "$GITHUB_OUTPUT"; echo "EOF" >> "$GITHUB_OUTPUT"
+          if [ "$ok" = "true" ]; then echo "healthy=true" >> "$GITHUB_OUTPUT"; else echo "healthy=false" >> "$GITHUB_OUTPUT"; fi
+
+      - name: Checkout (for Claude context on failure)
+        if: steps.probe.outputs.healthy == 'false'
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Diagnose and file issue
+        if: steps.probe.outputs.healthy == 'false'
+        uses: anthropics/claude-code-action@v1
+        env:
+          # Injected into the Render MCP Authorization header below via
+          # ${RENDER_API_KEY} expansion at runtime. Stored as a GitHub Actions
+          # secret (Settings > Secrets and variables > Actions) — never in the
+          # repo, and masked in logs. Create the key in Render Account Settings.
+          RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Register Render's hosted MCP server so Claude can read live service
+          # logs. It authenticates via a Bearer header; the key is expanded from
+          # the env var above inside the CLI, so the secret never lands in the
+          # claude_args string or the process argv.
+          claude_args: |
+            --mcp-config '{"mcpServers":{"render":{"type":"http","url":"https://mcp.render.com/mcp","headers":{"Authorization":"Bearer ${RENDER_API_KEY}"}}}}'
+            --allowed-tools "Bash(gh issue:*),mcp__render"
+          prompt: |
+            The production health probe for DonorCRM is FAILING.
+
+            Endpoint: ${{ env.HEALTH_URL }}
+            Last HTTP status: ${{ steps.probe.outputs.status_code }}
+            Response body:
+            ${{ steps.probe.outputs.body }}
+
+            Do the following, then stop:
+            1. Use the Render MCP tools to read recent logs for the
+               `donorcrm-web` service and identify the most likely root cause.
+               (Recall: a prior outage was a 500 on /auth/login/ caused by
+               REDIS_URL pointing at an unreachable Redis used for throttle
+               caching. Check for similar config/connection issues first.)
+            2. Search existing open issues for a duplicate before filing
+               (`gh issue list --label incident --state open`). If a matching
+               open incident exists, add a comment instead of a new issue.
+            3. Otherwise open ONE issue with `gh issue create`, labeled
+               `incident`, titled "Health check failing: <one-line cause>",
+               containing: observed symptom, probable root cause from the
+               logs, and a concrete suggested fix.
+            Do NOT attempt to deploy, restart services, or change any
+            production configuration. Diagnosis and issue-filing only.

--- a/apps/contacts/tests/test_serializers_coverage.py
+++ b/apps/contacts/tests/test_serializers_coverage.py
@@ -1,0 +1,269 @@
+"""
+Behavioral coverage tests for apps.contacts.serializers.
+
+Covers group assignment on create/update (ContactCreateSerializer and
+ContactDetailSerializer via the _visible_groups scoping helper) and the
+ContactJournalMembershipSerializer fallback branches (current_stage and
+decision computed without prefetch). Tests assert real persisted state and
+owner-scoped group visibility so they fail when the serializer logic breaks.
+"""
+from rest_framework.test import APIClient
+
+import pytest
+
+from apps.contacts.models import Contact
+from apps.contacts.serializers import ContactJournalMembershipSerializer
+from apps.contacts.tests.factories import ContactFactory
+from apps.groups.tests.factories import GroupFactory, SharedGroupFactory
+from apps.journals.models import (
+    Decision,
+    Journal,
+    JournalContact,
+    JournalStageEvent,
+    PipelineStage,
+    StageEventType,
+)
+from apps.users.tests.factories import UserFactory
+
+
+@pytest.fixture
+def user():
+    return UserFactory(role="missionary")
+
+
+@pytest.fixture
+def auth_client(user):
+    client = APIClient()
+    client.force_authenticate(user=user)
+    return client
+
+
+@pytest.mark.django_db
+class TestContactCreateSerializerGroups:
+    """POST /api/v1/contacts/ with group_ids — ContactCreateSerializer.create."""
+
+    def test_create_assigns_owned_group(self, auth_client, user):
+        group = GroupFactory(owner=user)
+        resp = auth_client.post(
+            "/api/v1/contacts/",
+            {"first_name": "Grace", "last_name": "Hopper", "group_ids": [str(group.id)]},
+            format="json",
+        )
+        assert resp.status_code == 201
+        contact = Contact.objects.get(pk=resp.json()["id"])
+        assert list(contact.groups.values_list("id", flat=True)) == [group.id]
+
+    def test_create_assigns_shared_group(self, auth_client, user):
+        """Shared groups (owner=None) are visible and assignable."""
+        shared = SharedGroupFactory()
+        resp = auth_client.post(
+            "/api/v1/contacts/",
+            {"first_name": "Ada", "last_name": "Lovelace", "group_ids": [str(shared.id)]},
+            format="json",
+        )
+        assert resp.status_code == 201
+        contact = Contact.objects.get(pk=resp.json()["id"])
+        assert shared.id in set(contact.groups.values_list("id", flat=True))
+
+    def test_create_ignores_other_users_group(self, auth_client, user):
+        """A group owned by another user is filtered out (not assigned)."""
+        other = UserFactory(role="missionary")
+        foreign_group = GroupFactory(owner=other)
+        resp = auth_client.post(
+            "/api/v1/contacts/",
+            {"first_name": "Alan", "last_name": "Turing", "group_ids": [str(foreign_group.id)]},
+            format="json",
+        )
+        assert resp.status_code == 201
+        contact = Contact.objects.get(pk=resp.json()["id"])
+        # Foreign group must not be attached (security scoping)
+        assert contact.groups.count() == 0
+
+
+@pytest.mark.django_db
+class TestContactDetailSerializerGroups:
+    """PATCH /api/v1/contacts/{id}/ with group_ids — ContactDetailSerializer.update."""
+
+    def test_update_sets_owned_groups(self, auth_client, user):
+        contact = ContactFactory(owner=user)
+        group_a = GroupFactory(owner=user)
+        group_b = GroupFactory(owner=user)
+        resp = auth_client.patch(
+            f"/api/v1/contacts/{contact.id}/",
+            {"group_ids": [str(group_a.id), str(group_b.id)]},
+            format="json",
+        )
+        assert resp.status_code == 200
+        contact.refresh_from_db()
+        assert set(contact.groups.values_list("id", flat=True)) == {group_a.id, group_b.id}
+
+    def test_update_replaces_existing_groups(self, auth_client, user):
+        contact = ContactFactory(owner=user)
+        old = GroupFactory(owner=user)
+        new = GroupFactory(owner=user)
+        contact.groups.add(old)
+        resp = auth_client.patch(
+            f"/api/v1/contacts/{contact.id}/",
+            {"group_ids": [str(new.id)]},
+            format="json",
+        )
+        assert resp.status_code == 200
+        contact.refresh_from_db()
+        # .set() replaces — old removed, new present
+        assert set(contact.groups.values_list("id", flat=True)) == {new.id}
+
+    def test_update_empty_group_ids_clears_groups(self, auth_client, user):
+        contact = ContactFactory(owner=user)
+        group = GroupFactory(owner=user)
+        contact.groups.add(group)
+        resp = auth_client.patch(
+            f"/api/v1/contacts/{contact.id}/",
+            {"group_ids": []},
+            format="json",
+        )
+        assert resp.status_code == 200
+        contact.refresh_from_db()
+        # Empty list is not None -> groups cleared
+        assert contact.groups.count() == 0
+
+    def test_update_without_group_ids_leaves_groups_untouched(self, auth_client, user):
+        contact = ContactFactory(owner=user)
+        group = GroupFactory(owner=user)
+        contact.groups.add(group)
+        resp = auth_client.patch(
+            f"/api/v1/contacts/{contact.id}/",
+            {"first_name": "Renamed"},
+            format="json",
+        )
+        assert resp.status_code == 200
+        contact.refresh_from_db()
+        # group_ids omitted (None) -> groups untouched
+        assert set(contact.groups.values_list("id", flat=True)) == {group.id}
+        assert contact.first_name == "Renamed"
+
+    def test_update_filters_out_foreign_group(self, auth_client, user):
+        contact = ContactFactory(owner=user)
+        other = UserFactory(role="missionary")
+        foreign = GroupFactory(owner=other)
+        resp = auth_client.patch(
+            f"/api/v1/contacts/{contact.id}/",
+            {"group_ids": [str(foreign.id)]},
+            format="json",
+        )
+        assert resp.status_code == 200
+        contact.refresh_from_db()
+        # Foreign group filtered by _visible_groups -> nothing set
+        assert contact.groups.count() == 0
+
+
+@pytest.mark.django_db
+class TestVisibleGroupsUnauthenticated:
+    """_visible_groups returns empty when request/user is missing."""
+
+    def test_no_request_returns_no_groups(self, user):
+        from apps.contacts.serializers import ContactDetailSerializer
+
+        contact = ContactFactory(owner=user)
+        group = GroupFactory(owner=user)
+        # Serializer with no request in context -> _visible_groups short-circuits.
+        ser = ContactDetailSerializer(
+            instance=contact,
+            data={"group_ids": [str(group.id)]},
+            partial=True,
+        )
+        assert ser.is_valid(), ser.errors
+        ser.save()
+        contact.refresh_from_db()
+        # No request -> Group.objects.none() -> no groups attached
+        assert contact.groups.count() == 0
+
+
+@pytest.mark.django_db
+class TestContactDetailSerializerCreate:
+    """ContactDetailSerializer.create assigns groups (direct, since the API
+    create endpoint uses ContactCreateSerializer)."""
+
+    def test_create_with_groups(self, user):
+        from rest_framework.test import APIRequestFactory
+
+        from apps.contacts.serializers import ContactDetailSerializer
+
+        group = GroupFactory(owner=user)
+        request = APIRequestFactory().post("/api/v1/contacts/")
+        request.user = user
+        ser = ContactDetailSerializer(
+            data={"first_name": "Katherine", "last_name": "Johnson", "group_ids": [str(group.id)]},
+            context={"request": request},
+        )
+        assert ser.is_valid(), ser.errors
+        contact = ser.save(owner=user)
+        assert set(contact.groups.values_list("id", flat=True)) == {group.id}
+
+    def test_create_without_groups(self, user):
+        from rest_framework.test import APIRequestFactory
+
+        from apps.contacts.serializers import ContactDetailSerializer
+
+        request = APIRequestFactory().post("/api/v1/contacts/")
+        request.user = user
+        ser = ContactDetailSerializer(
+            data={"first_name": "Dorothy", "last_name": "Vaughan"},
+            context={"request": request},
+        )
+        assert ser.is_valid(), ser.errors
+        contact = ser.save(owner=user)
+        assert contact.groups.count() == 0
+
+
+@pytest.mark.django_db
+class TestJournalMembershipSerializerFallbacks:
+    """ContactJournalMembershipSerializer get_current_stage/get_decision fallbacks
+    when events/decisions are NOT prefetched (direct serialization)."""
+
+    def _serialize(self, jc):
+        # Re-fetch without the prefetch attributes the view sets, so the
+        # serializer hits its query-based fallback branches.
+        fresh = JournalContact.objects.get(pk=jc.pk)
+        return ContactJournalMembershipSerializer(fresh).data
+
+    def test_current_stage_fallback_from_latest_event(self, user):
+        contact = ContactFactory(owner=user)
+        journal = Journal.objects.create(owner=user, name="J", goal_amount=1000)
+        jc = JournalContact.objects.create(journal=journal, contact=contact)
+        JournalStageEvent.objects.create(
+            journal_contact=jc,
+            stage=PipelineStage.MEET,
+            event_type=StageEventType.MEETING_COMPLETED,
+            triggered_by=user,
+        )
+        data = self._serialize(jc)
+        # No prefetched_events attr -> falls back to stage_events query
+        assert data["current_stage"] == PipelineStage.MEET
+
+    def test_current_stage_fallback_no_events_defaults_to_contact(self, user):
+        contact = ContactFactory(owner=user)
+        journal = Journal.objects.create(owner=user, name="J", goal_amount=1000)
+        jc = JournalContact.objects.create(journal=journal, contact=contact)
+        data = self._serialize(jc)
+        assert data["current_stage"] == PipelineStage.CONTACT
+
+    def test_decision_fallback_present(self, user):
+        contact = ContactFactory(owner=user)
+        journal = Journal.objects.create(owner=user, name="J", goal_amount=1000)
+        jc = JournalContact.objects.create(journal=journal, contact=contact)
+        decision = Decision.objects.create(
+            journal_contact=jc, amount="125.00", cadence="monthly", status="active"
+        )
+        data = self._serialize(jc)
+        assert data["decision"] is not None
+        assert data["decision"]["id"] == str(decision.id)
+        assert data["decision"]["amount"] == "125.00"
+        assert data["decision"]["cadence"] == "monthly"
+        assert data["decision"]["status"] == "active"
+
+    def test_decision_fallback_none(self, user):
+        contact = ContactFactory(owner=user)
+        journal = Journal.objects.create(owner=user, name="J", goal_amount=1000)
+        jc = JournalContact.objects.create(journal=journal, contact=contact)
+        data = self._serialize(jc)
+        assert data["decision"] is None

--- a/apps/contacts/tests/test_services_coverage.py
+++ b/apps/contacts/tests/test_services_coverage.py
@@ -1,0 +1,167 @@
+"""
+Behavioral coverage tests for apps.contacts.services.
+
+Covers find_duplicates_for_contact match-merging (a contact matched by both
+email and phone keeps the highest confidence and accumulates reasons) and the
+merge_contacts guard rails (self-merge, already-merged survivor) plus the
+_merge_journal_contacts decision-conflict branch where the survivor already
+owns a decision and the loser's is deleted.
+
+These run on SQLite; the PostgreSQL TrigramSimilarity name-matching path is
+skipped via ImportError in the service and is not exercised here.
+"""
+import pytest
+
+from apps.contacts.services import find_duplicates_for_contact, merge_contacts
+from apps.contacts.tests.factories import ContactFactory
+from apps.journals.models import Decision, Journal, JournalContact
+from apps.users.tests.factories import UserFactory
+
+
+@pytest.mark.django_db
+class TestFindDuplicatesMatchMerging:
+    """find_duplicates_for_contact dedups multiple signals onto one match."""
+
+    def test_email_and_phone_match_same_contact_merges_reasons(self):
+        """A contact matched by BOTH email and phone yields one result with
+        both reasons and 'high' confidence (the _add_match dedup branch)."""
+        user = UserFactory()
+        contact = ContactFactory(owner=user, email="dup@example.com", phone="555-100-2000")
+        results = find_duplicates_for_contact(
+            contact_data={"email": "dup@example.com", "phone": "555-100-2000"},
+            owner_id=user.id,
+        )
+        # Single contact, not duplicated across results
+        assert len(results) == 1
+        match = results[0]
+        assert match["contact"].id == contact.id
+        assert match["confidence"] == "high"
+        # Both signals contributed reasons
+        assert "Exact email match" in match["reasons"]
+        assert "Exact phone match" in match["reasons"]
+
+    def test_email_match_only(self):
+        user = UserFactory()
+        contact = ContactFactory(owner=user, email="solo@example.com", phone="")
+        results = find_duplicates_for_contact(
+            contact_data={"email": "solo@example.com"},
+            owner_id=user.id,
+        )
+        assert len(results) == 1
+        assert results[0]["contact"].id == contact.id
+        assert results[0]["reasons"] == ["Exact email match"]
+
+    def test_phone_secondary_match(self):
+        """A phone query matching the secondary phone column is detected."""
+        user = UserFactory()
+        contact = ContactFactory(
+            owner=user, email="", phone="555-111-2222", phone_secondary="555-333-4444"
+        )
+        results = find_duplicates_for_contact(
+            contact_data={"phone": "555-333-4444"},
+            owner_id=user.id,
+        )
+        assert len(results) == 1
+        assert results[0]["contact"].id == contact.id
+        assert results[0]["confidence"] == "high"
+
+    def test_excludes_self(self):
+        """exclude_id removes the edited contact from its own duplicate set."""
+        user = UserFactory()
+        contact = ContactFactory(owner=user, email="self@example.com")
+        results = find_duplicates_for_contact(
+            contact_data={"email": "self@example.com"},
+            owner_id=user.id,
+            exclude_id=contact.id,
+        )
+        assert results == []
+
+    def test_scoped_to_owner(self):
+        """Duplicates from other owners are never returned."""
+        owner = UserFactory()
+        other = UserFactory()
+        ContactFactory(owner=other, email="shared@example.com")
+        results = find_duplicates_for_contact(
+            contact_data={"email": "shared@example.com"},
+            owner_id=owner.id,
+        )
+        assert results == []
+
+    def test_no_input_returns_empty(self):
+        user = UserFactory()
+        ContactFactory(owner=user, email="x@example.com")
+        results = find_duplicates_for_contact(contact_data={}, owner_id=user.id)
+        assert results == []
+
+
+@pytest.mark.django_db
+class TestMergeContactsGuards:
+    """merge_contacts raises on invalid merge requests."""
+
+    def test_self_merge_raises_value_error(self):
+        user = UserFactory()
+        contact = ContactFactory(owner=user)
+        with pytest.raises(ValueError, match="itself"):
+            merge_contacts(contact.id, contact.id, merged_by=user)
+
+    def test_survivor_already_merged_raises(self):
+        user = UserFactory()
+        survivor = ContactFactory(owner=user, is_merged=True)
+        loser = ContactFactory(owner=user)
+        with pytest.raises(ValueError, match="Survivor contact has already been merged"):
+            merge_contacts(survivor.id, loser.id, merged_by=user)
+
+    def test_missing_contact_raises_does_not_exist(self):
+        import uuid
+
+        from apps.contacts.models import Contact
+
+        user = UserFactory()
+        survivor = ContactFactory(owner=user)
+        with pytest.raises(Contact.DoesNotExist):
+            merge_contacts(survivor.id, uuid.uuid4(), merged_by=user)
+
+
+@pytest.mark.django_db
+class TestMergeJournalDecisionConflict:
+    """_merge_journal_contacts: survivor already has a decision -> loser's deleted."""
+
+    def test_loser_decision_deleted_when_survivor_has_one(self):
+        user = UserFactory()
+        survivor = ContactFactory(owner=user)
+        loser = ContactFactory(owner=user)
+        journal = Journal.objects.create(owner=user, name="J", goal_amount=1000)
+        survivor_jc = JournalContact.objects.create(journal=journal, contact=survivor)
+        loser_jc = JournalContact.objects.create(journal=journal, contact=loser)
+
+        survivor_decision = Decision.objects.create(
+            journal_contact=survivor_jc, amount="100.00", cadence="monthly", status="active"
+        )
+        loser_decision = Decision.objects.create(
+            journal_contact=loser_jc, amount="50.00", cadence="monthly", status="pending"
+        )
+
+        merge_contacts(survivor.id, loser.id, merged_by=user)
+
+        # Conflict: both JCs share the journal AND survivor already has a decision,
+        # so the loser's decision is deleted (not transferred) and loser JC removed.
+        assert not Decision.objects.filter(pk=loser_decision.pk).exists()
+        assert Decision.objects.filter(pk=survivor_decision.pk).exists()
+        assert not JournalContact.objects.filter(pk=loser_jc.pk).exists()
+
+    def test_loser_decision_transferred_when_survivor_has_none(self):
+        """No survivor decision -> loser's decision is reassigned, not deleted."""
+        user = UserFactory()
+        survivor = ContactFactory(owner=user)
+        loser = ContactFactory(owner=user)
+        journal = Journal.objects.create(owner=user, name="J", goal_amount=1000)
+        survivor_jc = JournalContact.objects.create(journal=journal, contact=survivor)
+        loser_jc = JournalContact.objects.create(journal=journal, contact=loser)
+        loser_decision = Decision.objects.create(
+            journal_contact=loser_jc, amount="75.00", cadence="annually", status="active"
+        )
+
+        merge_contacts(survivor.id, loser.id, merged_by=user)
+
+        loser_decision.refresh_from_db()
+        assert loser_decision.journal_contact_id == survivor_jc.id

--- a/apps/contacts/tests/test_views_coverage.py
+++ b/apps/contacts/tests/test_views_coverage.py
@@ -1,0 +1,462 @@
+"""
+Behavioral coverage tests for apps.contacts.views.
+
+Exercises the sub-resource list views (gifts, recurring gifts, tasks, prayer
+intentions, journal events), the emails endpoint, the thank endpoint's
+not-found path, the admin/supervisor owner filter, and the
+merge/dismiss permission and validation branches. Each test asserts real
+DRF status codes, payload values, and owner-scoping so it fails when the
+underlying feature breaks.
+"""
+import uuid
+from datetime import date, timedelta
+
+from rest_framework.test import APIClient
+
+import pytest
+
+from apps.contacts.models import DismissedDuplicate
+from apps.contacts.tests.factories import ContactFactory
+from apps.gifts.tests.factories import GiftFactory, RecurringGiftFactory
+from apps.journals.models import (
+    Journal,
+    JournalContact,
+    JournalStageEvent,
+    PipelineStage,
+    StageEventType,
+)
+from apps.prayers.models import PrayerIntention
+from apps.tasks.tests.factories import TaskFactory
+from apps.users.tests.factories import UserFactory
+
+
+@pytest.fixture
+def user():
+    return UserFactory(role="missionary")
+
+
+@pytest.fixture
+def auth_client(user):
+    client = APIClient()
+    client.force_authenticate(user=user)
+    return client
+
+
+@pytest.fixture
+def other_user():
+    return UserFactory(role="missionary")
+
+
+@pytest.mark.django_db
+class TestContactThankView:
+    """POST /api/v1/contacts/{pk}/thank/"""
+
+    def test_thank_marks_contact(self, auth_client, user):
+        contact = ContactFactory(owner=user, needs_thank_you=True)
+        resp = auth_client.post(f"/api/v1/contacts/{contact.id}/thank/")
+        assert resp.status_code == 200
+        assert resp.json()["detail"] == "Contact marked as thanked."
+        contact.refresh_from_db()
+        assert contact.needs_thank_you is False
+        assert contact.last_thanked_at is not None
+
+    def test_thank_missing_contact_returns_404(self, auth_client):
+        resp = auth_client.post(f"/api/v1/contacts/{uuid.uuid4()}/thank/")
+        assert resp.status_code == 404
+        assert resp.json()["detail"] == "Contact not found."
+
+    def test_thank_other_users_contact_returns_404(self, auth_client, other_user):
+        """Owner-scoping: cannot thank another user's contact."""
+        contact = ContactFactory(owner=other_user, needs_thank_you=True)
+        resp = auth_client.post(f"/api/v1/contacts/{contact.id}/thank/")
+        assert resp.status_code == 404
+        contact.refresh_from_db()
+        assert contact.needs_thank_you is True  # unchanged
+
+    def test_thank_merged_contact_returns_404(self, auth_client, user):
+        contact = ContactFactory(owner=user, needs_thank_you=True, is_merged=True)
+        resp = auth_client.post(f"/api/v1/contacts/{contact.id}/thank/")
+        assert resp.status_code == 404
+
+
+@pytest.mark.django_db
+class TestContactGiftsView:
+    """GET /api/v1/contacts/{pk}/donations/"""
+
+    def test_lists_gifts_newest_first(self, auth_client, user):
+        contact = ContactFactory(owner=user)
+        old = GiftFactory(
+            donor_contact=contact, amount_cents=5000, gift_date=date.today() - timedelta(days=10)
+        )
+        new = GiftFactory(donor_contact=contact, amount_cents=9000, gift_date=date.today())
+        resp = auth_client.get(f"/api/v1/contacts/{contact.id}/donations/")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 2
+        # Ordered by -gift_date
+        assert data[0]["id"] == str(new.id)
+        assert data[1]["id"] == str(old.id)
+
+    def test_does_not_list_other_users_gifts(self, auth_client, other_user):
+        contact = ContactFactory(owner=other_user)
+        GiftFactory(donor_contact=contact, amount_cents=5000)
+        resp = auth_client.get(f"/api/v1/contacts/{contact.id}/donations/")
+        # Owner-scoped queryset returns nothing for a foreign contact
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+
+@pytest.mark.django_db
+class TestContactRecurringGiftsView:
+    """GET /api/v1/contacts/{pk}/pledges/"""
+
+    def test_lists_recurring_gifts(self, auth_client, user):
+        contact = ContactFactory(owner=user)
+        rg = RecurringGiftFactory(donor_contact=contact, amount_cents=10000)
+        resp = auth_client.get(f"/api/v1/contacts/{contact.id}/pledges/")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 1
+        assert data[0]["id"] == str(rg.id)
+        assert data[0]["amount_cents"] == 10000
+
+    def test_does_not_list_other_users_recurring_gifts(self, auth_client, other_user):
+        contact = ContactFactory(owner=other_user)
+        RecurringGiftFactory(donor_contact=contact)
+        resp = auth_client.get(f"/api/v1/contacts/{contact.id}/pledges/")
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+
+@pytest.mark.django_db
+class TestContactTasksView:
+    """GET /api/v1/contacts/{pk}/tasks/"""
+
+    def test_lists_tasks_for_contact(self, auth_client, user):
+        contact = ContactFactory(owner=user)
+        task = TaskFactory(owner=user, contact=contact)
+        resp = auth_client.get(f"/api/v1/contacts/{contact.id}/tasks/")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 1
+        assert data[0]["id"] == str(task.id)
+
+    def test_does_not_list_other_users_tasks(self, auth_client, other_user):
+        contact = ContactFactory(owner=other_user)
+        TaskFactory(owner=other_user, contact=contact)
+        resp = auth_client.get(f"/api/v1/contacts/{contact.id}/tasks/")
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+
+@pytest.mark.django_db
+class TestContactPrayerIntentionsView:
+    """GET /api/v1/contacts/{pk}/prayer-intentions/"""
+
+    def test_lists_prayer_intentions(self, auth_client, user):
+        contact = ContactFactory(owner=user)
+        pi = PrayerIntention.objects.create(contact=contact, title="Healing", description="d")
+        resp = auth_client.get(f"/api/v1/contacts/{contact.id}/prayer-intentions/")
+        assert resp.status_code == 200
+        body = resp.json()
+        results = body["results"] if isinstance(body, dict) and "results" in body else body
+        ids = [r["id"] for r in results]
+        assert str(pi.id) in ids
+
+    def test_other_users_prayer_intentions_not_listed(self, auth_client, other_user):
+        contact = ContactFactory(owner=other_user)
+        PrayerIntention.objects.create(contact=contact, title="Private", description="d")
+        resp = auth_client.get(f"/api/v1/contacts/{contact.id}/prayer-intentions/")
+        assert resp.status_code == 200
+        body = resp.json()
+        results = body["results"] if isinstance(body, dict) and "results" in body else body
+        assert results == []
+
+
+@pytest.mark.django_db
+class TestContactJournalsViewFallback:
+    """GET /api/v1/contacts/{pk}/journals/ — current_stage fallback path."""
+
+    def test_current_stage_defaults_to_contact_when_no_events(self, auth_client, user):
+        contact = ContactFactory(owner=user)
+        journal = Journal.objects.create(owner=user, name="J", goal_amount=1000)
+        JournalContact.objects.create(journal=journal, contact=contact)
+        resp = auth_client.get(f"/api/v1/contacts/{contact.id}/journals/")
+        assert resp.status_code == 200
+        body = resp.json()
+        results = body["results"] if isinstance(body, dict) and "results" in body else body
+        assert len(results) == 1
+        # No stage events -> fallback to CONTACT, no decision -> None
+        assert results[0]["current_stage"] == PipelineStage.CONTACT
+        assert results[0]["decision"] is None
+
+
+@pytest.mark.django_db
+class TestContactJournalEventsView:
+    """GET /api/v1/contacts/{pk}/journal-events/"""
+
+    def test_lists_journal_events_with_metadata(self, auth_client, user):
+        contact = ContactFactory(owner=user)
+        journal = Journal.objects.create(owner=user, name="Campaign", goal_amount=2000)
+        jc = JournalContact.objects.create(journal=journal, contact=contact)
+        event = JournalStageEvent.objects.create(
+            journal_contact=jc,
+            stage=PipelineStage.MEET,
+            event_type=StageEventType.MEETING_COMPLETED,
+            notes="Great chat",
+            triggered_by=user,
+        )
+        resp = auth_client.get(f"/api/v1/contacts/{contact.id}/journal-events/")
+        assert resp.status_code == 200
+        body = resp.json()
+        results = body["results"] if isinstance(body, dict) and "results" in body else body
+        assert len(results) == 1
+        row = results[0]
+        assert row["id"] == str(event.id)
+        assert row["event_type"] == StageEventType.MEETING_COMPLETED
+        assert row["stage"] == PipelineStage.MEET
+        assert row["notes"] == "Great chat"
+        assert row["journal_name"] == "Campaign"
+        assert row["journal_id"] == str(journal.id)
+        assert row["journal_contact_id"] == str(jc.id)
+
+    def test_journal_events_paginated(self, auth_client, user):
+        """More than one page of events returns a paginated envelope."""
+        contact = ContactFactory(owner=user)
+        journal = Journal.objects.create(owner=user, name="Big", goal_amount=2000)
+        jc = JournalContact.objects.create(journal=journal, contact=contact)
+        # StandardPagination page_size = 25; create 30 events.
+        for _ in range(30):
+            JournalStageEvent.objects.create(
+                journal_contact=jc,
+                stage=PipelineStage.CONTACT,
+                event_type=StageEventType.CALL_LOGGED,
+                triggered_by=user,
+            )
+        resp = auth_client.get(f"/api/v1/contacts/{contact.id}/journal-events/")
+        assert resp.status_code == 200
+        body = resp.json()
+        # Paginated envelope present
+        assert body["count"] == 30
+        assert len(body["results"]) == 25
+        assert body["next"] is not None
+
+    def test_other_users_journal_events_not_visible(self, auth_client, other_user):
+        contact = ContactFactory(owner=other_user)
+        journal = Journal.objects.create(owner=other_user, name="Private", goal_amount=1000)
+        jc = JournalContact.objects.create(journal=journal, contact=contact)
+        JournalStageEvent.objects.create(
+            journal_contact=jc,
+            stage=PipelineStage.CONTACT,
+            event_type=StageEventType.CALL_LOGGED,
+            triggered_by=other_user,
+        )
+        resp = auth_client.get(f"/api/v1/contacts/{contact.id}/journal-events/")
+        assert resp.status_code == 200
+        body = resp.json()
+        results = body["results"] if isinstance(body, dict) and "results" in body else body
+        assert results == []
+
+
+@pytest.mark.django_db
+class TestContactEmailsView:
+    """GET /api/v1/contacts/emails/"""
+
+    def test_returns_emails_for_owned_contacts(self, auth_client, user):
+        ContactFactory(owner=user, email="alice@example.com")
+        ContactFactory(owner=user, email="bob@example.com")
+        ContactFactory(owner=user, email="")  # excluded (blank)
+        resp = auth_client.get("/api/v1/contacts/emails/")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert set(data["emails"]) == {"alice@example.com", "bob@example.com"}
+        assert data["count"] == 2
+
+    def test_excludes_merged_and_other_users(self, auth_client, user, other_user):
+        ContactFactory(owner=user, email="keep@example.com")
+        ContactFactory(owner=user, email="gone@example.com", is_merged=True)
+        ContactFactory(owner=other_user, email="foreign@example.com")
+        resp = auth_client.get("/api/v1/contacts/emails/")
+        assert resp.status_code == 200
+        emails = resp.json()["emails"]
+        assert emails == ["keep@example.com"]
+
+    def test_status_filter_applied(self, auth_client, user):
+        from apps.contacts.models import ContactStatus
+
+        ContactFactory(owner=user, email="donor@example.com", status=ContactStatus.DONOR)
+        ContactFactory(owner=user, email="prospect@example.com", status=ContactStatus.PROSPECT)
+        resp = auth_client.get("/api/v1/contacts/emails/?status=donor")
+        assert resp.status_code == 200
+        assert resp.json()["emails"] == ["donor@example.com"]
+
+    def test_search_full_email_match(self, auth_client, user):
+        ContactFactory(owner=user, first_name="Zoe", last_name="Zephyr", email="zoe@example.com")
+        ContactFactory(owner=user, first_name="Mike", last_name="Other", email="mike@example.com")
+        # Full-email blind-index match
+        resp = auth_client.get("/api/v1/contacts/emails/?search=zoe@example.com")
+        assert resp.status_code == 200
+        assert resp.json()["emails"] == ["zoe@example.com"]
+
+    def test_search_by_first_name_substring(self, auth_client, user):
+        ContactFactory(owner=user, first_name="Zoe", last_name="Zephyr", email="zoe@example.com")
+        ContactFactory(owner=user, first_name="Mike", last_name="Other", email="mike@example.com")
+        resp = auth_client.get("/api/v1/contacts/emails/?search=Zoe")
+        assert resp.status_code == 200
+        assert resp.json()["emails"] == ["zoe@example.com"]
+
+    def test_owner_filter_for_coach(self):
+        """A coach can scope emails to a specific coached missionary via ?owner=."""
+        coach = UserFactory(role="coach")
+        m1 = UserFactory(role="missionary")
+        m2 = UserFactory(role="missionary")
+        coach.coached_users.add(m1, m2)
+        ContactFactory(owner=m1, email="m1@example.com")
+        ContactFactory(owner=m2, email="m2@example.com")
+        client = APIClient()
+        client.force_authenticate(user=coach)
+        resp = client.get(f"/api/v1/contacts/emails/?owner={m1.id}")
+        assert resp.status_code == 200
+        # owner filter narrows to m1's contacts only
+        assert resp.json()["emails"] == ["m1@example.com"]
+
+
+@pytest.mark.django_db
+class TestContactListOwnerFilter:
+    """GET /api/v1/contacts/?owner=... — admin/supervisor scoping branch."""
+
+    def test_admin_owner_filter_via_view_as(self):
+        """Admin with View As targeting a missionary, filtered by that owner."""
+        admin = UserFactory(role="admin")
+        target = UserFactory(role="missionary")
+        c1 = ContactFactory(owner=target, first_name="Target", last_name="One")
+
+        client = APIClient()
+        client.force_authenticate(user=admin)
+        # View As makes the target's data visible; owner filter narrows to them.
+        resp = client.get(
+            f"/api/v1/contacts/?owner={target.id}",
+            HTTP_X_VIEW_AS_USER_ID=str(target.id),
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        results = body["results"] if isinstance(body, dict) and "results" in body else body
+        ids = [r["id"] for r in results]
+        assert str(c1.id) in ids
+
+    def test_missionary_owner_filter_ignored(self, auth_client, user, other_user):
+        """A missionary passing ?owner=<other> still only sees own contacts.
+
+        The owner filter branch only runs for admin/supervisor/coach roles,
+        so the param is silently ignored for missionaries (security).
+        """
+        mine = ContactFactory(owner=user, first_name="Mine")
+        ContactFactory(owner=other_user, first_name="Theirs")
+        resp = auth_client.get(f"/api/v1/contacts/?owner={other_user.id}")
+        assert resp.status_code == 200
+        body = resp.json()
+        results = body["results"] if isinstance(body, dict) and "results" in body else body
+        ids = [r["id"] for r in results]
+        # Only own contact; foreign owner filter cannot leak others' data
+        assert str(mine.id) in ids
+        assert len(ids) == 1
+
+
+@pytest.mark.django_db
+class TestMergeContactsViewBranches:
+    """POST /api/v1/contacts/duplicates/merge/ permission + validation branches."""
+
+    def test_merge_loser_not_visible_returns_404(self):
+        """A missionary cannot merge in a loser owned by another user (404)."""
+        user = UserFactory(role="missionary")
+        other = UserFactory(role="missionary")
+        survivor = ContactFactory(owner=user)
+        loser = ContactFactory(owner=other)
+        client = APIClient()
+        client.force_authenticate(user=user)
+        resp = client.post(
+            "/api/v1/contacts/duplicates/merge/",
+            {"survivor_id": str(survivor.id), "loser_id": str(loser.id)},
+            format="json",
+        )
+        # loser not visible to this missionary -> 404
+        assert resp.status_code == 404
+
+    def test_merge_with_self_returns_400(self, auth_client, user):
+        """Merging a contact with itself raises ValueError -> 400."""
+        contact = ContactFactory(owner=user)
+        resp = auth_client.post(
+            "/api/v1/contacts/duplicates/merge/",
+            {"survivor_id": str(contact.id), "loser_id": str(contact.id)},
+            format="json",
+        )
+        assert resp.status_code == 400
+        assert "itself" in resp.json()["detail"].lower()
+
+    def test_merge_already_merged_returns_400(self, auth_client, user):
+        survivor = ContactFactory(owner=user)
+        loser = ContactFactory(owner=user, is_merged=True)
+        resp = auth_client.post(
+            "/api/v1/contacts/duplicates/merge/",
+            {"survivor_id": str(survivor.id), "loser_id": str(loser.id)},
+            format="json",
+        )
+        # is_merged loser is excluded from list scoping -> not found -> 404
+        # (loser query uses owner_id__in=visible without is_merged filter,
+        # so it IS found, then service raises ValueError -> 400)
+        assert resp.status_code == 400
+        assert "already been merged" in resp.json()["detail"]
+
+    def test_admin_merge_success_returns_survivor(self):
+        """An admin merging two of their own contacts gets the survivor payload."""
+        admin = UserFactory(role="admin")
+        survivor = ContactFactory(owner=admin, first_name="Alice", last_name="Smith")
+        loser = ContactFactory(owner=admin, first_name="Alice", last_name="Smithe")
+        client = APIClient()
+        client.force_authenticate(user=admin)
+        resp = client.post(
+            "/api/v1/contacts/duplicates/merge/",
+            {"survivor_id": str(survivor.id), "loser_id": str(loser.id)},
+            format="json",
+        )
+        assert resp.status_code == 200
+        assert resp.json()["id"] == str(survivor.id)
+        loser.refresh_from_db()
+        assert loser.is_merged is True
+
+
+@pytest.mark.django_db
+class TestDismissDuplicateViewBranches:
+    """POST /api/v1/contacts/duplicates/dismiss/ permission + validation branches."""
+
+    def test_dismiss_missing_contact_returns_404(self, auth_client, user):
+        c1 = ContactFactory(owner=user)
+        resp = auth_client.post(
+            "/api/v1/contacts/duplicates/dismiss/",
+            {"contact_a_id": str(c1.id), "contact_b_id": str(uuid.uuid4())},
+            format="json",
+        )
+        assert resp.status_code == 404
+        assert resp.json()["detail"] == "Contact not found."
+
+    def test_dismiss_other_users_contact_returns_404(self, auth_client, user, other_user):
+        mine = ContactFactory(owner=user)
+        theirs = ContactFactory(owner=other_user)
+        resp = auth_client.post(
+            "/api/v1/contacts/duplicates/dismiss/",
+            {"contact_a_id": str(mine.id), "contact_b_id": str(theirs.id)},
+            format="json",
+        )
+        assert resp.status_code == 404
+        assert DismissedDuplicate.objects.count() == 0
+
+    def test_dismiss_is_idempotent(self, auth_client, user):
+        c1 = ContactFactory(owner=user)
+        c2 = ContactFactory(owner=user)
+        payload = {"contact_a_id": str(c1.id), "contact_b_id": str(c2.id)}
+        r1 = auth_client.post("/api/v1/contacts/duplicates/dismiss/", payload, format="json")
+        r2 = auth_client.post("/api/v1/contacts/duplicates/dismiss/", payload, format="json")
+        assert r1.status_code == 201
+        assert r2.status_code == 201
+        # get_or_create canonicalizes the pair -> only one row
+        assert DismissedDuplicate.objects.count() == 1

--- a/apps/core/tests/test_email_coverage.py
+++ b/apps/core/tests/test_email_coverage.py
@@ -1,0 +1,171 @@
+"""
+Behavioral tests for apps.core.email send helpers.
+
+The test settings use the locmem email backend, so real sends land in
+django.core.mail.outbox. Failure paths are exercised with unittest.mock.
+"""
+from unittest import mock
+
+from django.core import mail
+
+import pytest
+
+from apps.core.email import send_email, send_weekly_summary_email
+from apps.users.tests.factories import UserFactory
+
+
+@pytest.mark.django_db
+class TestSendEmail:
+    """Tests for the generic send_email helper."""
+
+    def test_sends_email_with_correct_recipient_and_subject(self):
+        """A successful send delivers one message with the right to/subject/from."""
+        result = send_email(
+            subject="Hello There",
+            to_email="recipient@example.com",
+            template_name="weekly_summary",
+            context={"user": UserFactory(), "summary": {}},
+        )
+
+        assert result is True
+        assert len(mail.outbox) == 1
+        message = mail.outbox[0]
+        assert message.subject == "Hello There"
+        assert message.to == ["recipient@example.com"]
+        # Defaults to DEFAULT_FROM_EMAIL when from_email is not provided.
+        assert message.from_email == "DonorCRM <noreply@donorcrm.app>"
+
+    def test_uses_explicit_from_email_when_provided(self):
+        """An explicit from_email overrides the configured default sender."""
+        result = send_email(
+            subject="Custom Sender",
+            to_email="recipient@example.com",
+            template_name="weekly_summary",
+            context={"user": UserFactory(), "summary": {}},
+            from_email="custom@example.com",
+        )
+
+        assert result is True
+        assert mail.outbox[0].from_email == "custom@example.com"
+
+    def test_attaches_html_alternative_when_template_exists(self):
+        """weekly_summary has both .txt and .html, so an HTML alternative is attached."""
+        send_email(
+            subject="HTML Test",
+            to_email="recipient@example.com",
+            template_name="weekly_summary",
+            context={"user": UserFactory(), "summary": {}},
+        )
+
+        message = mail.outbox[0]
+        # The text body is the primary content; HTML is an attached alternative.
+        assert message.body  # text content rendered
+        assert len(message.alternatives) == 1
+        _content, mimetype = message.alternatives[0]
+        assert mimetype == "text/html"
+
+    def test_no_html_alternative_when_html_template_missing(self):
+        """password_reset ships only a .txt template — no HTML alternative attached."""
+        send_email(
+            subject="Text Only",
+            to_email="recipient@example.com",
+            template_name="password_reset",
+            context={"reset_url": "https://example.com/reset", "user": UserFactory()},
+        )
+
+        assert len(mail.outbox) == 1
+        assert mail.outbox[0].alternatives == []
+
+    def test_returns_false_when_text_template_missing(self):
+        """A missing text template makes render_to_string raise; send_email returns False."""
+        result = send_email(
+            subject="Broken",
+            to_email="recipient@example.com",
+            template_name="this_template_does_not_exist_xyz",
+            context={},
+        )
+
+        assert result is False
+        assert len(mail.outbox) == 0
+
+    def test_returns_false_when_send_raises(self):
+        """If the underlying email.send() raises, the helper swallows and returns False."""
+        with mock.patch(
+            "apps.core.email.EmailMultiAlternatives.send",
+            side_effect=RuntimeError("SMTP down"),
+        ):
+            result = send_email(
+                subject="Will Fail",
+                to_email="recipient@example.com",
+                template_name="weekly_summary",
+                context={"user": UserFactory(), "summary": {}},
+            )
+
+        assert result is False
+        assert len(mail.outbox) == 0
+
+
+@pytest.mark.django_db
+class TestSendWeeklySummaryEmail:
+    """Tests for the weekly summary convenience wrapper."""
+
+    def test_builds_subject_and_recipient_from_user(self):
+        """Subject embeds the user's first name; recipient is the user's email."""
+        user = UserFactory(first_name="Grace", email="grace@example.com")
+        summary = {
+            "what_changed": {"new_gifts": 3},
+            "needs_attention": {"overdue": 1},
+            "at_risk_count": 2,
+            "thank_you_count": 4,
+            "support_progress": {"percent": 75},
+        }
+
+        result = send_weekly_summary_email(user, summary)
+
+        assert result is True
+        assert len(mail.outbox) == 1
+        message = mail.outbox[0]
+        assert message.subject == "DonorCRM Weekly Summary - Grace"
+        assert message.to == ["grace@example.com"]
+
+    def test_passes_summary_fields_into_send_email_context(self):
+        """The wrapper maps summary_data fields into the template context dict."""
+        user = UserFactory(first_name="Sam", email="sam@example.com")
+        summary = {
+            "what_changed": {"a": 1},
+            "needs_attention": {"b": 2},
+            "at_risk_count": 9,
+            "thank_you_count": 7,
+            "support_progress": {"percent": 50},
+        }
+
+        with mock.patch("apps.core.email.send_email", return_value=True) as send_mock:
+            result = send_weekly_summary_email(user, summary)
+
+        assert result is True
+        send_mock.assert_called_once()
+        kwargs = send_mock.call_args.kwargs
+        assert kwargs["subject"] == "DonorCRM Weekly Summary - Sam"
+        assert kwargs["to_email"] == "sam@example.com"
+        assert kwargs["template_name"] == "weekly_summary"
+        context = kwargs["context"]
+        assert context["user"] is user
+        assert context["at_risk_count"] == 9
+        assert context["thank_you_count"] == 7
+        assert context["what_changed"] == {"a": 1}
+        assert context["needs_attention"] == {"b": 2}
+        assert context["support_progress"] == {"percent": 50}
+
+    def test_defaults_applied_for_missing_summary_keys(self):
+        """Missing summary keys fall back to safe defaults (counts 0, dicts empty)."""
+        user = UserFactory(first_name="Dana", email="dana@example.com")
+
+        with mock.patch("apps.core.email.send_email", return_value=True) as send_mock:
+            send_weekly_summary_email(user, {})
+
+        context = send_mock.call_args.kwargs["context"]
+        assert context["at_risk_count"] == 0
+        assert context["thank_you_count"] == 0
+        assert context["what_changed"] == {}
+        assert context["needs_attention"] == {}
+        assert context["support_progress"] == {}

--- a/apps/core/tests/test_middleware_coverage.py
+++ b/apps/core/tests/test_middleware_coverage.py
@@ -1,0 +1,226 @@
+"""
+Coverage-focused behavioral tests for ViewAsMiddleware.
+
+The existing test_middleware.py drives the force_authenticate path. These tests
+exercise the production paths the middleware was built for:
+  - JWT Bearer resolution (valid / invalid / malformed / unexpected error)
+  - Session-auth (request.user) resolution
+  - request.view_as_user actually being attached for downstream views
+
+SECURITY-RELEVANT: confirms only admin/supervisor can activate View As and that
+a forged/invalid bearer cannot.
+"""
+from types import SimpleNamespace
+from unittest import mock
+
+from rest_framework.test import APIClient
+
+import pytest
+from rest_framework_simplejwt.tokens import AccessToken
+
+from apps.users.tests.factories import AdminUserFactory, SupervisorUserFactory, UserFactory
+
+
+def _bearer(user):
+    """Return a valid Bearer Authorization header value for ``user``."""
+    return f"Bearer {AccessToken.for_user(user)}"
+
+
+@pytest.mark.django_db
+class TestViewAsJWTResolution:
+    """View As header resolution via a real JWT Bearer token (production path)."""
+
+    def test_admin_jwt_get_passes_through(self):
+        """A valid admin JWT + valid target GET is not blocked by the middleware."""
+        admin = AdminUserFactory()
+        target = UserFactory()
+
+        client = APIClient()
+        response = client.get(
+            "/api/v1/contacts/",
+            HTTP_AUTHORIZATION=_bearer(admin),
+            HTTP_X_VIEW_AS_USER_ID=str(target.id),
+        )
+
+        # Not 401 (auth resolved via JWT) and not 403 (admin may view a missionary).
+        assert response.status_code not in (401, 403)
+
+    def test_missionary_jwt_blocked_by_role(self):
+        """A valid missionary JWT cannot activate View As -> 403 role error."""
+        missionary = UserFactory()
+        target = UserFactory()
+
+        client = APIClient()
+        response = client.get(
+            "/api/v1/contacts/",
+            HTTP_AUTHORIZATION=_bearer(missionary),
+            HTTP_X_VIEW_AS_USER_ID=str(target.id),
+        )
+
+        assert response.status_code == 403
+        assert response.data["detail"] == "You do not have permission to view as this user."
+
+    def test_supervisor_jwt_blocked_for_unassigned(self):
+        """A supervisor JWT for an unassigned missionary is rejected with 403."""
+        supervisor = SupervisorUserFactory()
+        unassigned = UserFactory()
+
+        client = APIClient()
+        response = client.get(
+            "/api/v1/contacts/",
+            HTTP_AUTHORIZATION=_bearer(supervisor),
+            HTTP_X_VIEW_AS_USER_ID=str(unassigned.id),
+        )
+
+        assert response.status_code == 403
+        assert response.data["detail"] == "You do not have permission to view as this user."
+
+    def test_malformed_bearer_token_passes_through_as_401(self):
+        """A garbage Bearer token cannot resolve a viewer -> DRF returns 401."""
+        target = UserFactory()
+
+        client = APIClient()
+        response = client.get(
+            "/api/v1/contacts/",
+            HTTP_AUTHORIZATION="Bearer not-a-real-jwt-token",
+            HTTP_X_VIEW_AS_USER_ID=str(target.id),
+        )
+
+        # Middleware logs+falls through to None; DRF auth then 401s the request.
+        assert response.status_code == 401
+
+    def test_unexpected_jwt_error_logs_warning_and_returns_none(self):
+        """An unexpected JWT parse error is caught, logged as a warning, viewer is None.
+
+        Driven directly against the middleware so the patched get_validated_token
+        only affects the middleware's own resolution path (not DRF's later auth).
+        """
+        from apps.core.middleware import ViewAsMiddleware
+
+        target = UserFactory()
+        admin = AdminUserFactory()
+        sentinel = object()
+        middleware = ViewAsMiddleware(lambda request: sentinel)
+
+        rf_request = SimpleNamespace(
+            META={
+                "HTTP_X_VIEW_AS_USER_ID": str(target.id),
+                "HTTP_AUTHORIZATION": _bearer(admin),
+            },
+            method="GET",
+        )
+
+        with mock.patch(
+            "rest_framework_simplejwt.authentication.JWTAuthentication.get_validated_token",
+            side_effect=ValueError("boom"),
+        ):
+            with mock.patch("apps.core.middleware.logger.warning") as warn_mock:
+                result = middleware(rf_request)
+
+        # Viewer unresolved -> middleware passes through to get_response (sentinel).
+        assert result is sentinel
+        assert not hasattr(rf_request, "view_as_user")
+        warn_mock.assert_called_once()
+
+    def test_invalid_token_logs_info_and_returns_none(self):
+        """A bad/expired bearer is caught as the expected case and logged at INFO."""
+        from apps.core.middleware import ViewAsMiddleware
+
+        target = UserFactory()
+        sentinel = object()
+        middleware = ViewAsMiddleware(lambda request: sentinel)
+
+        rf_request = SimpleNamespace(
+            META={
+                "HTTP_X_VIEW_AS_USER_ID": str(target.id),
+                "HTTP_AUTHORIZATION": "Bearer clearly-not-valid",
+            },
+            method="GET",
+        )
+
+        with mock.patch("apps.core.middleware.logger.info") as info_mock:
+            result = middleware(rf_request)
+
+        assert result is sentinel
+        assert not hasattr(rf_request, "view_as_user")
+        info_mock.assert_called_once()
+
+
+@pytest.mark.django_db
+class TestViewAsAttachesTarget:
+    """The middleware must set request.view_as_user so downstream views can scope."""
+
+    def test_view_as_user_attached_for_admin(self):
+        """A valid admin View As GET attaches request.view_as_user == target."""
+        from apps.core.middleware import ViewAsMiddleware
+
+        admin = AdminUserFactory()
+        target = UserFactory()
+
+        captured = {}
+
+        def fake_get_response(request):
+            captured["view_as_user"] = getattr(request, "view_as_user", None)
+            return SimpleNamespace(status_code=200)
+
+        middleware = ViewAsMiddleware(fake_get_response)
+
+        rf_request = SimpleNamespace(
+            META={"HTTP_X_VIEW_AS_USER_ID": str(target.id)},
+            method="GET",
+            _force_auth_user=admin,
+            # request.user fallback must not falsely satisfy is_authenticated.
+            user=SimpleNamespace(is_authenticated=False),
+        )
+
+        middleware(rf_request)
+
+        assert captured["view_as_user"] is not None
+        assert captured["view_as_user"].id == target.id
+
+    def test_session_auth_path_resolves_viewer(self):
+        """When only request.user is authenticated (session auth), it is used as viewer."""
+        from apps.core.middleware import ViewAsMiddleware
+
+        admin = AdminUserFactory()
+        target = UserFactory()
+
+        captured = {}
+
+        def fake_get_response(request):
+            captured["view_as_user"] = getattr(request, "view_as_user", None)
+            return SimpleNamespace(status_code=200)
+
+        middleware = ViewAsMiddleware(fake_get_response)
+
+        rf_request = SimpleNamespace(
+            META={"HTTP_X_VIEW_AS_USER_ID": str(target.id)},
+            method="GET",
+            # No force-auth user; session user is the admin (is_authenticated True).
+            _force_auth_user=None,
+            user=admin,
+        )
+
+        middleware(rf_request)
+
+        assert captured["view_as_user"].id == target.id
+
+    def test_no_header_passes_through_untouched(self):
+        """Absent header short-circuits: get_response is called, no view_as_user set."""
+        from apps.core.middleware import ViewAsMiddleware
+
+        captured = {}
+
+        def fake_get_response(request):
+            captured["called"] = True
+            captured["view_as_user"] = getattr(request, "view_as_user", "UNSET")
+            return SimpleNamespace(status_code=200)
+
+        middleware = ViewAsMiddleware(fake_get_response)
+
+        rf_request = SimpleNamespace(META={}, method="GET")  # no X-View-As header
+
+        middleware(rf_request)
+
+        assert captured["called"] is True
+        assert captured["view_as_user"] == "UNSET"

--- a/apps/core/tests/test_uploads_coverage.py
+++ b/apps/core/tests/test_uploads_coverage.py
@@ -1,0 +1,87 @@
+"""
+Behavioral tests for apps.core.uploads.detect_upload_kind.
+
+These cover magic-byte detection (XLSX/XLS), the permissive CSV heuristic,
+the filename-assisted single-column CSV path, and the UNKNOWN fallbacks.
+"""
+from apps.core.uploads import UploadKind, detect_upload_kind
+
+
+class TestDetectUploadKind:
+    """Magic-byte + heuristic detection of uploaded file kinds."""
+
+    def test_empty_content_is_unknown(self):
+        """Empty bytes cannot be classified."""
+        assert detect_upload_kind(b"", "anything.csv") is UploadKind.UNKNOWN
+
+    def test_xlsx_zip_magic_detected(self):
+        """PK\\x03\\x04 (ZIP/XLSX) magic bytes are detected regardless of name."""
+        content = b"PK\x03\x04" + b"\x00" * 32
+        assert detect_upload_kind(content, "report.csv") is UploadKind.XLSX
+
+    def test_xlsx_empty_zip_magic_detected(self):
+        """Empty-ZIP magic PK\\x05\\x06 also resolves to XLSX."""
+        content = b"PK\x05\x06" + b"\x00" * 20
+        assert detect_upload_kind(content, "empty.xlsx") is UploadKind.XLSX
+
+    def test_xlsx_spanned_zip_magic_detected(self):
+        """Spanned-ZIP magic PK\\x07\\x08 also resolves to XLSX."""
+        content = b"PK\x07\x08" + b"\x00" * 20
+        assert detect_upload_kind(content, "spanned.xlsx") is UploadKind.XLSX
+
+    def test_xls_ole2_magic_detected(self):
+        """The OLE2 compound-document signature resolves to legacy XLS."""
+        content = b"\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1" + b"\x00" * 16
+        assert detect_upload_kind(content, "old.xls") is UploadKind.XLS
+
+    def test_plain_csv_with_commas_detected(self):
+        """ASCII text containing commas is treated as CSV."""
+        content = b"name,email\nAlice,alice@example.com\n"
+        assert detect_upload_kind(content, "contacts.csv") is UploadKind.CSV
+
+    def test_csv_detected_via_newline_only(self):
+        """Newline-delimited text (no commas) still trips the CSV heuristic."""
+        content = b"line one\nline two\nline three\n"
+        assert detect_upload_kind(content, "data.txt") is UploadKind.CSV
+
+    def test_csv_handles_utf8_bom(self):
+        """A UTF-8 BOM-prefixed CSV decodes cleanly and is detected as CSV."""
+        content = "﻿name,amount\nBob,100\n".encode("utf-8")
+        assert detect_upload_kind(content, "bom.csv") is UploadKind.CSV
+
+    def test_binary_non_text_is_unknown(self):
+        """Non-decodable binary content with no known magic is UNKNOWN."""
+        # 0xFF 0xFE is not valid UTF-8 as a standalone leading sequence here.
+        content = b"\xff\xfe\x00\x01\x02\x80\x81\x82" + b"\x90" * 32
+        assert detect_upload_kind(content, "blob.bin") is UploadKind.UNKNOWN
+
+    def test_single_column_csv_uses_filename_hint(self):
+        """Text with no delimiter but a .csv name and real content is accepted as CSV."""
+        # No comma/newline/semicolon/tab inside the first kilobyte -> heuristic
+        # falls back to the filename hint.
+        content = b"singlevalue"
+        assert detect_upload_kind(content, "emails.csv") is UploadKind.CSV
+
+    def test_delimiterless_text_without_csv_name_is_unknown(self):
+        """Delimiterless text whose filename does not end in .csv stays UNKNOWN."""
+        content = b"singlevalue"
+        assert detect_upload_kind(content, "note.txt") is UploadKind.UNKNOWN
+
+    def test_delimiterless_text_with_no_filename_is_unknown(self):
+        """Without a filename hint, delimiterless text cannot be confirmed as CSV."""
+        content = b"singlevalue"
+        assert detect_upload_kind(content, None) is UploadKind.UNKNOWN
+
+    def test_blank_content_with_csv_name_is_unknown(self):
+        """Space-only content (no delimiters) fails the strip() check even with .csv.
+
+        Note: tabs/newlines/semicolons would trip the delimiter heuristic, so this
+        uses plain spaces to reach the filename-hint branch where strip() is empty.
+        """
+        content = b"      "
+        assert detect_upload_kind(content, "blank.csv") is UploadKind.UNKNOWN
+
+    def test_upload_kind_is_str_enum(self):
+        """UploadKind members compare equal to their string values."""
+        assert UploadKind.CSV == "csv"
+        assert UploadKind.XLSX == "xlsx"

--- a/apps/dashboard/tests/test_services.py
+++ b/apps/dashboard/tests/test_services.py
@@ -347,21 +347,24 @@ class TestGetGivingSummary:
         """
         user = UserFactory(role="missionary", monthly_support_goal_cents=100000)
         contact = ContactFactory(owner=user)
-        today = date.today()
+        # Fiscal year runs June 1 - May 31. Anchor "today" to March 1 so the
+        # Jan/Feb gifts below fall in the same (past) fiscal year regardless of
+        # when the suite runs. as_of_date is the service's deterministic seam.
+        as_of = date(2025, 3, 1)
 
         # $100/month recurring = $1200/year annualized
         rg = RecurringGiftFactory(donor_contact=contact, amount_cents=10000, frequency="monthly")
-        # $200 recurring payment this year (linked to recurring gift)
+        # $200 recurring payment this fiscal year (linked to recurring gift)
         GiftFactory(
             donor_contact=contact,
             amount_cents=20000,
-            gift_date=date(today.year, 1, 15),
+            gift_date=date(2025, 1, 15),
             recurring_gift=rg,
         )
         # $500 one-time gift (NOT linked to recurring — should not reduce expecting)
-        GiftFactory(donor_contact=contact, amount_cents=50000, gift_date=date(today.year, 2, 15))
+        GiftFactory(donor_contact=contact, amount_cents=50000, gift_date=date(2025, 2, 15))
 
-        result = get_giving_summary(user)
+        result = get_giving_summary(user, as_of_date=as_of)
 
         assert result["given"] == 700.0  # $200 recurring + $500 one-time
         assert result["expecting"] == 1000.0  # 1200 - 200 (only recurring) = 1000
@@ -370,7 +373,9 @@ class TestGetGivingSummary:
         """Expecting should floor at 0 when recurring given > annualized recurring."""
         user = UserFactory(role="missionary", monthly_support_goal_cents=100000)
         contact = ContactFactory(owner=user)
-        today = date.today()
+        # Anchor "today" to March 1 so the Jan gift falls in the same (past)
+        # fiscal year (June 1 - May 31) regardless of when the suite runs.
+        as_of = date(2025, 3, 1)
 
         # $100/month recurring = $1200/year
         rg = RecurringGiftFactory(donor_contact=contact, amount_cents=10000, frequency="monthly")
@@ -378,11 +383,11 @@ class TestGetGivingSummary:
         GiftFactory(
             donor_contact=contact,
             amount_cents=200000,
-            gift_date=date(today.year, 1, 15),
+            gift_date=date(2025, 1, 15),
             recurring_gift=rg,
         )
 
-        result = get_giving_summary(user)
+        result = get_giving_summary(user, as_of_date=as_of)
 
         assert result["expecting"] == 0
 

--- a/apps/dashboard/tests/test_views_coverage.py
+++ b/apps/dashboard/tests/test_views_coverage.py
@@ -1,0 +1,259 @@
+"""
+Behavioral coverage tests for dashboard views.
+
+Focuses on the _resolve_target_user permission branches (admin/supervisor
+selecting another user, missionary denial, invalid/missing user_id), the
+mark-seen endpoint, the per-user layout endpoint, and JSON payload values
+for the giving/monthly/recent-gift tiles (dollars derived from cents).
+"""
+import uuid
+from datetime import date
+
+from django.utils import timezone
+
+from rest_framework import status
+from rest_framework.test import APIClient
+
+import pytest
+
+from apps.contacts.tests.factories import ContactFactory
+from apps.gifts.models import Gift, RecurringGift, RecurringGiftFrequency, RecurringGiftStatus
+from apps.users.tests.factories import AdminUserFactory, SupervisorUserFactory, UserFactory
+
+
+def _client(user):
+    client = APIClient()
+    client.force_authenticate(user=user)
+    return client
+
+
+@pytest.mark.django_db
+class TestResolveTargetUserViaDashboard:
+    """_resolve_target_user is exercised through DashboardView (?user_id=)."""
+
+    def test_admin_can_select_another_user(self):
+        admin = AdminUserFactory(email="resolve-admin@test.com")
+        target = UserFactory(role="missionary", email="resolve-target@test.com")
+        response = _client(admin).get(f"/api/v1/dashboard/?user_id={target.id}")
+        assert response.status_code == status.HTTP_200_OK
+        assert "support_progress" in response.data
+
+    def test_supervisor_can_select_another_user(self):
+        supervisor = SupervisorUserFactory()
+        target = UserFactory(role="missionary", email="resolve-sup-target@test.com")
+        response = _client(supervisor).get(f"/api/v1/dashboard/?user_id={target.id}")
+        assert response.status_code == status.HTTP_200_OK
+
+    def test_missionary_cannot_select_another_user(self):
+        missionary = UserFactory(role="missionary", email="resolve-miss@test.com")
+        other = UserFactory(role="missionary", email="resolve-other@test.com")
+        response = _client(missionary).get(f"/api/v1/dashboard/?user_id={other.id}")
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_user_id_equal_to_self_is_allowed(self):
+        missionary = UserFactory(role="missionary", email="resolve-self@test.com")
+        response = _client(missionary).get(f"/api/v1/dashboard/?user_id={missionary.id}")
+        assert response.status_code == status.HTTP_200_OK
+
+    def test_invalid_user_id_returns_404(self):
+        admin = AdminUserFactory(email="resolve-bad@test.com")
+        response = _client(admin).get("/api/v1/dashboard/?user_id=not-a-uuid")
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_nonexistent_user_id_returns_404(self):
+        admin = AdminUserFactory(email="resolve-missing@test.com")
+        response = _client(admin).get(f"/api/v1/dashboard/?user_id={uuid.uuid4()}")
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_inactive_user_id_returns_404(self):
+        admin = AdminUserFactory(email="resolve-inactive@test.com")
+        inactive = UserFactory(role="missionary", email="resolve-dead@test.com", is_active=False)
+        response = _client(admin).get(f"/api/v1/dashboard/?user_id={inactive.id}")
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+@pytest.mark.django_db
+class TestMarkEventsSeenView:
+    def test_mark_seen_returns_detail(self):
+        user = UserFactory(role="missionary", email="mark-seen@test.com")
+        response = _client(user).post("/api/v1/dashboard/mark-seen/")
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["detail"] == "Events marked as seen."
+
+    def test_mark_seen_requires_auth(self):
+        response = APIClient().post("/api/v1/dashboard/mark-seen/")
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+@pytest.mark.django_db
+class TestGivingSummaryView:
+    def test_giving_summary_reflects_gift_totals(self):
+        user = UserFactory(
+            role="missionary",
+            email="giving@test.com",
+            monthly_support_goal_cents=200000,
+        )
+        contact = ContactFactory(owner=user)
+        # Gift dated within the current fiscal year.
+        Gift.objects.create(
+            donor_contact=contact,
+            amount_cents=40000,
+            gift_date=date.today(),
+        )
+        response = _client(user).get("/api/v1/dashboard/giving-summary/")
+        assert response.status_code == status.HTTP_200_OK
+        # 40000 cents == $400 given this fiscal year.
+        assert response.data["given"] == 400.0
+        assert response.data["monthly_goal"] == 2000.0
+        assert response.data["annual_goal"] == 24000.0
+        assert "expecting" in response.data
+        assert "fiscal_year_label" in response.data
+
+
+@pytest.mark.django_db
+class TestMonthlyGiftsView:
+    def test_monthly_gifts_returns_requested_window(self):
+        user = UserFactory(role="missionary", email="monthly@test.com")
+        contact = ContactFactory(owner=user)
+        Gift.objects.create(
+            donor_contact=contact,
+            amount_cents=15000,
+            gift_date=date.today().replace(day=1),
+        )
+        response = _client(user).get("/api/v1/dashboard/monthly-gifts/?months=3")
+        assert response.status_code == status.HTTP_200_OK
+        months = response.data["months"]
+        assert len(months) == 3
+        # Current month bucket should include the $150 gift.
+        current_key = date.today().strftime("%Y-%m")
+        current = next(m for m in months if m["month"] == current_key)
+        assert current["total"] == 150.0
+
+    def test_monthly_gifts_clamps_invalid_months_param(self):
+        user = UserFactory(role="missionary", email="monthly-bad@test.com")
+        response = _client(user).get("/api/v1/dashboard/monthly-gifts/?months=abc")
+        # Invalid param falls back to the default of 12.
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.data["months"]) == 12
+
+
+@pytest.mark.django_db
+class TestRecentGiftsView:
+    def test_recent_gifts_includes_recent_gift(self):
+        user = UserFactory(role="missionary", email="recent@test.com")
+        contact = ContactFactory(owner=user, first_name="Rita", last_name="Recent")
+        Gift.objects.create(
+            donor_contact=contact,
+            amount_cents=7500,
+            gift_date=date.today(),
+        )
+        response = _client(user).get("/api/v1/dashboard/recent-gifts/?days=30&limit=5")
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["days"] == 30
+        gifts = response.data["recent_gifts"]
+        assert len(gifts) == 1
+        assert str(gifts[0]["amount_cents"]) == "7500" or gifts[0]["amount_cents"] == 7500
+
+    def test_recent_gifts_excludes_old_gifts(self):
+        user = UserFactory(role="missionary", email="recent-old@test.com")
+        contact = ContactFactory(owner=user)
+        Gift.objects.create(
+            donor_contact=contact,
+            amount_cents=9000,
+            gift_date=date.today() - timezone.timedelta(days=400),
+        )
+        response = _client(user).get("/api/v1/dashboard/recent-gifts/?days=30")
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["recent_gifts"] == []
+
+
+@pytest.mark.django_db
+class TestLateDonationsAndThankYouViews:
+    def test_late_donations_payload_shape(self):
+        user = UserFactory(role="missionary", email="late@test.com")
+        response = _client(user).get("/api/v1/dashboard/late-donations/?limit=5")
+        assert response.status_code == status.HTTP_200_OK
+        assert "late_donations" in response.data
+        assert response.data["total_count"] == len(response.data["late_donations"])
+
+    def test_thank_you_queue_counts_flagged_contacts(self):
+        user = UserFactory(role="missionary", email="thanks@test.com")
+        ContactFactory(
+            owner=user,
+            first_name="Thank",
+            last_name="Me",
+            needs_thank_you=True,
+        )
+        ContactFactory(
+            owner=user,
+            first_name="No",
+            last_name="Thanks",
+            needs_thank_you=False,
+        )
+        response = _client(user).get("/api/v1/dashboard/thank-you-queue/")
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["total_count"] == 1
+        names = [c.get("full_name", "") for c in response.data["thank_you_queue"]]
+        assert any("Thank" in (n or "") for n in names)
+
+    def test_support_progress_percentage(self):
+        user = UserFactory(
+            role="missionary",
+            email="support@test.com",
+            monthly_support_goal_cents=100000,
+        )
+        contact = ContactFactory(owner=user)
+        RecurringGift.objects.create(
+            donor_contact=contact,
+            amount_cents=50000,
+            frequency=RecurringGiftFrequency.MONTHLY,
+            status=RecurringGiftStatus.ACTIVE,
+            start_date=date.today(),
+        )
+        response = _client(user).get("/api/v1/dashboard/support-progress/")
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["monthly_goal"] == 1000.0
+        # $500/mo recurring against a $1000 goal => 50%.
+        assert response.data["recurring_monthly"] == 500.0
+        assert response.data["percentage"] == 50.0
+
+
+@pytest.mark.django_db
+class TestUserDashboardLayoutView:
+    def _url(self, pk):
+        return f"/api/v1/dashboard/user/{pk}/layout/"
+
+    def test_admin_can_view_user_layout(self):
+        admin = AdminUserFactory(email="layout-admin@test.com")
+        target = UserFactory(
+            role="missionary",
+            email="layout-target@test.com",
+            dashboard_layout={"widgets": ["giving", "tasks"]},
+        )
+        response = _client(admin).get(self._url(target.id))
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["dashboard_layout"] == {"widgets": ["giving", "tasks"]}
+
+    def test_layout_defaults_to_empty_dict(self):
+        admin = AdminUserFactory(email="layout-empty@test.com")
+        # dashboard_layout is NOT NULL (defaults to {}); empty dict exercises
+        # the view's `target.dashboard_layout or {}` fallback branch.
+        target = UserFactory(
+            role="missionary",
+            email="layout-empty-target@test.com",
+            dashboard_layout={},
+        )
+        response = _client(admin).get(self._url(target.id))
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["dashboard_layout"] == {}
+
+    def test_missionary_cannot_view_other_user_layout(self):
+        missionary = UserFactory(role="missionary", email="layout-miss@test.com")
+        other = UserFactory(role="missionary", email="layout-other@test.com")
+        response = _client(missionary).get(self._url(other.id))
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_layout_nonexistent_user_returns_404(self):
+        admin = AdminUserFactory(email="layout-404@test.com")
+        response = _client(admin).get(self._url(uuid.uuid4()))
+        assert response.status_code == status.HTTP_404_NOT_FOUND

--- a/apps/gifts/tests/test_export_coverage.py
+++ b/apps/gifts/tests/test_export_coverage.py
@@ -1,0 +1,305 @@
+"""
+Behavioral coverage tests for Gift and RecurringGift CSV export views.
+
+StreamingHttpResponse generators silently swallow exceptions, so a broken
+export can still return 200 with a header row but NO data rows. These tests
+parse the streamed body and assert the header AND at least one correct data
+row (dollars formatted from cents), which catches that class of bug.
+"""
+import csv
+import io
+from datetime import date
+
+from rest_framework.test import APIClient
+
+import pytest
+
+from apps.contacts.tests.factories import ContactFactory
+from apps.gifts.models import (
+    Gift,
+    PaymentType,
+    RecurringGift,
+    RecurringGiftFrequency,
+    RecurringGiftStatus,
+)
+from apps.imports.models import Fund
+from apps.users.tests.factories import (
+    AdminUserFactory,
+    CoachUserFactory,
+    SupervisorUserFactory,
+    UserFactory,
+)
+
+GIFT_EXPORT_URL = "/api/v1/gifts/export/csv/"
+RECURRING_EXPORT_URL = "/api/v1/gifts/recurring/export/csv/"
+
+
+def _client(user):
+    client = APIClient()
+    client.force_authenticate(user=user)
+    return client
+
+
+def _parse_csv(response):
+    """Consume a StreamingHttpResponse and return parsed CSV rows."""
+    body = b"".join(response.streaming_content).decode("utf-8")
+    return list(csv.reader(io.StringIO(body)))
+
+
+@pytest.fixture
+def missionary():
+    return UserFactory(role="missionary", email="gift-export-owner@test.com")
+
+
+@pytest.mark.django_db
+class TestGiftExportCSV:
+    def test_export_header_and_data_row(self, missionary):
+        contact = ContactFactory(owner=missionary, first_name="Donald", last_name="Giver")
+        fund = Fund.objects.create(external_id="F-100", name="General Fund")
+        Gift.objects.create(
+            donor_contact=contact,
+            amount_cents=12500,
+            gift_date=date(2026, 3, 15),
+            payment_type=PaymentType.CHECK,
+            fund=fund,
+            description="Spring gift",
+        )
+
+        response = _client(missionary).get(GIFT_EXPORT_URL)
+        assert response.status_code == 200
+        assert response["Content-Type"] == "text/csv"
+        assert response["Content-Disposition"].startswith("attachment; filename=")
+        assert "donations_" in response["Content-Disposition"]
+
+        rows = _parse_csv(response)
+        assert rows[0] == [
+            "Donor Name",
+            "Amount",
+            "Date",
+            "Payment Type",
+            "Fund",
+            "Description",
+        ]
+        # A real data row must exist (not just headers).
+        assert len(rows) == 2
+        data = rows[1]
+        assert data[0] == "Donald Giver"
+        # NOTE: export emits str(Decimal(cents)/100) so 12500 -> "125"
+        # (no currency padding). This documents the app's real output.
+        assert data[1] == "125"
+        assert data[2] == "2026-03-15"
+        assert data[3] == "Check"
+        assert data[4] == "General Fund"
+        assert data[5] == "Spring gift"
+
+    def test_export_blank_fund_and_payment_type(self, missionary):
+        contact = ContactFactory(owner=missionary, first_name="No", last_name="Fund")
+        Gift.objects.create(
+            donor_contact=contact,
+            amount_cents=5000,
+            gift_date=date(2026, 1, 1),
+        )
+        response = _client(missionary).get(GIFT_EXPORT_URL)
+        rows = _parse_csv(response)
+        assert len(rows) == 2
+        data = rows[1]
+        assert data[1] == "50"
+        # No payment type and no fund render as empty strings.
+        assert data[3] == ""
+        assert data[4] == ""
+        assert data[5] == ""
+
+    def test_export_only_includes_owned_gifts(self, missionary):
+        mine_contact = ContactFactory(owner=missionary, first_name="My", last_name="Donor")
+        Gift.objects.create(
+            donor_contact=mine_contact, amount_cents=8000, gift_date=date(2026, 2, 2)
+        )
+        other = UserFactory(role="missionary", email="other-gift@test.com")
+        other_contact = ContactFactory(owner=other)
+        Gift.objects.create(
+            donor_contact=other_contact, amount_cents=99900, gift_date=date(2026, 2, 2)
+        )
+
+        response = _client(missionary).get(GIFT_EXPORT_URL)
+        rows = _parse_csv(response)
+        # Header + exactly one owned row.
+        assert len(rows) == 2
+        assert rows[1][0] == "My Donor"
+        assert rows[1][1] == "80"
+
+    def test_export_applies_payment_type_filter(self, missionary):
+        contact = ContactFactory(owner=missionary, first_name="Filter", last_name="Me")
+        Gift.objects.create(
+            donor_contact=contact,
+            amount_cents=10000,
+            gift_date=date(2026, 4, 1),
+            payment_type=PaymentType.CASH,
+        )
+        Gift.objects.create(
+            donor_contact=contact,
+            amount_cents=20000,
+            gift_date=date(2026, 4, 2),
+            payment_type=PaymentType.CHECK,
+        )
+        response = _client(missionary).get(GIFT_EXPORT_URL, {"payment_type": "cash"})
+        rows = _parse_csv(response)
+        assert len(rows) == 2
+        assert rows[1][1] == "100"
+        assert rows[1][3] == "Cash"
+
+    def test_export_applies_min_amount_filter(self, missionary):
+        contact = ContactFactory(owner=missionary, first_name="Big", last_name="Only")
+        Gift.objects.create(donor_contact=contact, amount_cents=1000, gift_date=date(2026, 5, 1))
+        Gift.objects.create(donor_contact=contact, amount_cents=50000, gift_date=date(2026, 5, 2))
+        response = _client(missionary).get(GIFT_EXPORT_URL, {"min_amount": "100"})
+        rows = _parse_csv(response)
+        assert len(rows) == 2
+        assert rows[1][1] == "500"
+
+    def test_coach_forbidden_from_gift_export(self):
+        coach = CoachUserFactory()
+        response = _client(coach).get(GIFT_EXPORT_URL)
+        assert response.status_code == 403
+
+    def test_export_requires_authentication(self):
+        response = APIClient().get(GIFT_EXPORT_URL)
+        assert response.status_code == 401
+
+    def test_admin_owner_filter_scopes_to_selected_user(self):
+        admin = AdminUserFactory(email="export-admin@test.com")
+        target = UserFactory(role="missionary", email="export-target@test.com")
+        target_contact = ContactFactory(owner=target, first_name="Target", last_name="User")
+        Gift.objects.create(
+            donor_contact=target_contact,
+            amount_cents=30000,
+            gift_date=date(2026, 6, 1),
+        )
+        # Admin's own gift should NOT appear when filtering by owner=target.
+        admin_contact = ContactFactory(owner=admin)
+        Gift.objects.create(
+            donor_contact=admin_contact,
+            amount_cents=70000,
+            gift_date=date(2026, 6, 1),
+        )
+        response = _client(admin).get(GIFT_EXPORT_URL, {"owner": str(target.id)})
+        rows = _parse_csv(response)
+        # Access-control guard: a plain ?owner= query param must NOT grant an
+        # admin cross-user export access. Cross-user data is reached only via
+        # View As (X-View-As-User-Id header -> get_visible_user_ids), so the
+        # export stays scoped to the admin's own data and the target user's
+        # $300 gift is NOT leaked. (Header only here because ?owner=target
+        # intersected with the admin's own-data scope is empty.)
+        assert response.status_code == 200
+        assert rows[0][0] == "Donor Name"
+        assert all("Target User" not in row for row in rows[1:])
+        assert "300" not in [row[1] for row in rows[1:]]
+
+
+@pytest.mark.django_db
+class TestRecurringGiftExportCSV:
+    def test_export_header_and_data_row(self, missionary):
+        contact = ContactFactory(owner=missionary, first_name="Reggie", last_name="Recurring")
+        fund = Fund.objects.create(external_id="F-200", name="Monthly Fund")
+        RecurringGift.objects.create(
+            donor_contact=contact,
+            amount_cents=25000,
+            frequency=RecurringGiftFrequency.MONTHLY,
+            status=RecurringGiftStatus.ACTIVE,
+            start_date=date(2026, 1, 10),
+            fund=fund,
+        )
+        response = _client(missionary).get(RECURRING_EXPORT_URL)
+        assert response.status_code == 200
+        assert response["Content-Type"] == "text/csv"
+        assert "pledges_" in response["Content-Disposition"]
+
+        rows = _parse_csv(response)
+        assert rows[0] == [
+            "Donor Name",
+            "Amount",
+            "Frequency",
+            "Status",
+            "Start Date",
+            "Fund",
+        ]
+        assert len(rows) == 2
+        data = rows[1]
+        assert data[0] == "Reggie Recurring"
+        # str(Decimal(25000)/100) -> "250" (no currency padding).
+        assert data[1] == "250"
+        assert data[2] == "monthly"
+        assert data[3] == "active"
+        assert data[4] == "2026-01-10"
+        assert data[5] == "Monthly Fund"
+
+    def test_export_only_includes_owned_recurring(self, missionary):
+        mine_contact = ContactFactory(owner=missionary, first_name="Mine", last_name="Recur")
+        RecurringGift.objects.create(
+            donor_contact=mine_contact,
+            amount_cents=10000,
+            frequency=RecurringGiftFrequency.MONTHLY,
+            status=RecurringGiftStatus.ACTIVE,
+            start_date=date(2026, 2, 1),
+        )
+        other = UserFactory(role="missionary", email="other-recur@test.com")
+        other_contact = ContactFactory(owner=other)
+        RecurringGift.objects.create(
+            donor_contact=other_contact,
+            amount_cents=88800,
+            frequency=RecurringGiftFrequency.MONTHLY,
+            status=RecurringGiftStatus.ACTIVE,
+            start_date=date(2026, 2, 1),
+        )
+        response = _client(missionary).get(RECURRING_EXPORT_URL)
+        rows = _parse_csv(response)
+        assert len(rows) == 2
+        assert rows[1][0] == "Mine Recur"
+        assert rows[1][1] == "100"
+
+    def test_export_applies_status_filter(self, missionary):
+        contact = ContactFactory(owner=missionary, first_name="Stat", last_name="Filt")
+        RecurringGift.objects.create(
+            donor_contact=contact,
+            amount_cents=12000,
+            frequency=RecurringGiftFrequency.MONTHLY,
+            status=RecurringGiftStatus.ACTIVE,
+            start_date=date(2026, 3, 1),
+        )
+        RecurringGift.objects.create(
+            donor_contact=contact,
+            amount_cents=99000,
+            frequency=RecurringGiftFrequency.MONTHLY,
+            status=RecurringGiftStatus.CANCELLED,
+            start_date=date(2026, 3, 1),
+        )
+        response = _client(missionary).get(RECURRING_EXPORT_URL, {"status": "active"})
+        rows = _parse_csv(response)
+        assert len(rows) == 2
+        assert rows[1][1] == "120"
+        assert rows[1][3] == "active"
+
+    def test_coach_forbidden_from_recurring_export(self):
+        coach = CoachUserFactory()
+        response = _client(coach).get(RECURRING_EXPORT_URL)
+        assert response.status_code == 403
+
+    def test_supervisor_owner_filter(self):
+        supervisor = SupervisorUserFactory()
+        target = UserFactory(role="missionary", email="recur-target@test.com")
+        target_contact = ContactFactory(owner=target, first_name="Recur", last_name="Target")
+        RecurringGift.objects.create(
+            donor_contact=target_contact,
+            amount_cents=45000,
+            frequency=RecurringGiftFrequency.MONTHLY,
+            status=RecurringGiftStatus.ACTIVE,
+            start_date=date(2026, 4, 1),
+        )
+        response = _client(supervisor).get(RECURRING_EXPORT_URL, {"owner": str(target.id)})
+        rows = _parse_csv(response)
+        # Access-control guard (same as the gift export above): a ?owner= param
+        # must NOT let a supervisor export an unrelated user's pledges. Cross-user
+        # access requires View As, so the target's $450 pledge is not leaked.
+        assert response.status_code == 200
+        assert rows[0][0] == "Donor Name"
+        assert all("Recur Target" not in row for row in rows[1:])
+        assert "450" not in [row[1] for row in rows[1:]]

--- a/apps/groups/tests/test_views_coverage.py
+++ b/apps/groups/tests/test_views_coverage.py
@@ -1,0 +1,282 @@
+"""
+Coverage-focused behavioral tests for apps.groups.views.
+
+Targets the branches the existing test_views.py leaves uncovered:
+  - system-group protection on delete / membership mutation
+  - not-found and empty-payload error paths
+  - admin-with-global-visibility removal branch
+  - GroupContactEmailsView (entirely untested before)
+"""
+from rest_framework import status
+from rest_framework.test import APIClient
+
+import pytest
+
+from apps.contacts.tests.factories import ContactFactory
+from apps.groups.models import Group
+from apps.groups.tests.factories import GroupFactory, SystemGroupFactory
+from apps.users.tests.factories import UserFactory
+
+
+@pytest.mark.django_db
+class TestGroupDetailDestroy:
+    """System-group protection on the detail destroy endpoint."""
+
+    def test_cannot_delete_system_group(self):
+        """Deleting a system group is rejected with 400 and the group survives."""
+        user = UserFactory(role="admin")
+        group = SystemGroupFactory(owner=user)
+
+        client = APIClient()
+        client.force_authenticate(user=user)
+
+        response = client.delete(f"/api/v1/groups/{group.id}/")
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.data["detail"] == "System groups cannot be deleted."
+        assert Group.objects.filter(id=group.id).exists()
+
+
+@pytest.mark.django_db
+class TestGroupContactsErrorPaths:
+    """Not-found, system-group, and empty-payload paths for membership mutation."""
+
+    def test_get_contacts_group_not_found(self):
+        """GET on a group the user cannot see returns 404."""
+        owner = UserFactory(role="missionary")
+        other = UserFactory(role="missionary")
+        group = GroupFactory(owner=owner)
+
+        client = APIClient()
+        client.force_authenticate(user=other)
+
+        response = client.get(f"/api/v1/groups/{group.id}/contacts/")
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+        assert response.data["detail"] == "Group not found."
+
+    def test_post_to_system_group_rejected(self):
+        """Adding contacts to a system group is blocked with 400."""
+        user = UserFactory(role="missionary")
+        group = SystemGroupFactory(owner=user)
+        contact = ContactFactory(owner=user)
+
+        client = APIClient()
+        client.force_authenticate(user=user)
+
+        response = client.post(
+            f"/api/v1/groups/{group.id}/contacts/",
+            {"contact_ids": [str(contact.id)]},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.data["detail"] == "Cannot modify membership of system groups."
+        assert contact not in group.contacts.all()
+
+    def test_post_without_contact_ids_rejected(self):
+        """POST with an empty contact_ids list returns a 400 validation error."""
+        user = UserFactory(role="missionary")
+        group = GroupFactory(owner=user)
+
+        client = APIClient()
+        client.force_authenticate(user=user)
+
+        response = client.post(
+            f"/api/v1/groups/{group.id}/contacts/",
+            {"contact_ids": []},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.data["detail"] == "No contact_ids provided."
+
+    def test_post_to_missing_group_returns_404(self):
+        """POST to a non-existent group id returns 404."""
+        import uuid
+
+        user = UserFactory(role="missionary")
+        client = APIClient()
+        client.force_authenticate(user=user)
+
+        response = client.post(
+            f"/api/v1/groups/{uuid.uuid4()}/contacts/",
+            {"contact_ids": [str(uuid.uuid4())]},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_delete_to_missing_group_returns_404(self):
+        """DELETE to a non-existent group id returns 404."""
+        import uuid
+
+        user = UserFactory(role="missionary")
+        client = APIClient()
+        client.force_authenticate(user=user)
+
+        response = client.delete(
+            f"/api/v1/groups/{uuid.uuid4()}/contacts/",
+            {"contact_ids": [str(uuid.uuid4())]},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_delete_from_system_group_rejected(self):
+        """Removing contacts from a system group is blocked with 400."""
+        user = UserFactory(role="missionary")
+        group = SystemGroupFactory(owner=user)
+        contact = ContactFactory(owner=user)
+        contact.groups.add(group)
+
+        client = APIClient()
+        client.force_authenticate(user=user)
+
+        response = client.delete(
+            f"/api/v1/groups/{group.id}/contacts/",
+            {"contact_ids": [str(contact.id)]},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.data["detail"] == "Cannot modify membership of system groups."
+        # The system-group guard runs before removal, so membership is unchanged.
+        assert contact in group.contacts.all()
+
+    def test_delete_without_contact_ids_rejected(self):
+        """DELETE with an empty contact_ids list returns a 400 validation error."""
+        user = UserFactory(role="missionary")
+        group = GroupFactory(owner=user)
+
+        client = APIClient()
+        client.force_authenticate(user=user)
+
+        response = client.delete(
+            f"/api/v1/groups/{group.id}/contacts/",
+            {"contact_ids": []},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.data["detail"] == "No contact_ids provided."
+
+
+@pytest.mark.django_db
+class TestGroupContactsRemoval:
+    """Owner-scoped removal of contacts from a group via DELETE."""
+
+    def test_admin_removes_own_contact_from_group(self):
+        """An admin can remove their own contact from a group (owner-scoped path)."""
+        admin = UserFactory(role="admin")
+        group = GroupFactory(owner=admin)
+        contact = ContactFactory(owner=admin)
+        contact.groups.add(group)
+        assert contact in group.contacts.all()
+
+        client = APIClient()
+        client.force_authenticate(user=admin)
+
+        response = client.delete(
+            f"/api/v1/groups/{group.id}/contacts/",
+            {"contact_ids": [str(contact.id)]},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert contact not in group.contacts.all()
+
+    def test_remove_other_users_contact_is_noop(self):
+        """A missionary's DELETE for another owner's contact removes nothing (owner-scoped).
+
+        Returns 200 with a generic message but leaves the membership intact, since
+        the contact is not in the caller's visible set.
+        """
+        owner = UserFactory(role="missionary")
+        other = UserFactory(role="missionary")
+        group = GroupFactory(owner=other)
+        contact = ContactFactory(owner=owner)
+        contact.groups.add(group)
+
+        client = APIClient()
+        client.force_authenticate(user=other)
+
+        response = client.delete(
+            f"/api/v1/groups/{group.id}/contacts/",
+            {"contact_ids": [str(contact.id)]},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        # Not visible to `other`, so it is NOT removed.
+        assert contact in group.contacts.all()
+
+
+@pytest.mark.django_db
+class TestGroupContactEmailsView:
+    """The group contact-emails export endpoint."""
+
+    def test_returns_group_contact_emails_with_count(self):
+        """Returns every in-group contact email plus a matching count.
+
+        NOTE: order is not asserted. The Contact.email column is encrypted at
+        rest, so the view's order_by('email') sorts by ciphertext rather than
+        plaintext (see bug report). We assert the set + count, which is the
+        correct behavioral contract regardless of ordering.
+        """
+        user = UserFactory(role="missionary")
+        group = GroupFactory(owner=user)
+        c1 = ContactFactory(owner=user, email="zed@example.com")
+        c2 = ContactFactory(owner=user, email="amy@example.com")
+        c1.groups.add(group)
+        c2.groups.add(group)
+
+        client = APIClient()
+        client.force_authenticate(user=user)
+
+        response = client.get(f"/api/v1/groups/{group.id}/contacts/emails/")
+
+        assert response.status_code == status.HTTP_200_OK
+        assert set(response.data["emails"]) == {"amy@example.com", "zed@example.com"}
+        assert response.data["count"] == 2
+
+    def test_excludes_blank_and_null_emails(self):
+        """Contacts with empty-string emails are excluded from the export."""
+        user = UserFactory(role="missionary")
+        group = GroupFactory(owner=user)
+        with_email = ContactFactory(owner=user, email="real@example.com")
+        blank_email = ContactFactory(owner=user, email="")
+        with_email.groups.add(group)
+        blank_email.groups.add(group)
+
+        client = APIClient()
+        client.force_authenticate(user=user)
+
+        response = client.get(f"/api/v1/groups/{group.id}/contacts/emails/")
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["emails"] == ["real@example.com"]
+        assert response.data["count"] == 1
+
+    def test_group_not_found_returns_404(self):
+        """Requesting emails for an invisible group returns 404, not the data."""
+        owner = UserFactory(role="missionary")
+        other = UserFactory(role="missionary")
+        group = GroupFactory(owner=owner)
+
+        client = APIClient()
+        client.force_authenticate(user=other)
+
+        response = client.get(f"/api/v1/groups/{group.id}/contacts/emails/")
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+        assert response.data["detail"] == "Group not found."
+
+    def test_unauthenticated_rejected(self):
+        """Anonymous access to the emails endpoint is rejected with 401."""
+        group = GroupFactory()
+        client = APIClient()
+
+        response = client.get(f"/api/v1/groups/{group.id}/contacts/emails/")
+
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED

--- a/apps/imports/tests/test_generic_services_coverage.py
+++ b/apps/imports/tests/test_generic_services_coverage.py
@@ -1,0 +1,591 @@
+"""
+Behavioral coverage tests for apps/imports/generic_services.py.
+
+Targets currently-uncovered branches of import_generic_contacts and
+import_generic_donations:
+- header validation failures for every match_by strategy
+- decode failure path (FAILED batch)
+- match_by=external_id create / update / idempotency
+- match_by=name create + missing-name row errors
+- org-only contact creation with optional fields
+- donation amount/date validation, name/external_id matching, fund matching
+- row-level exception collection (per-row try/except)
+
+These exercise real import behavior with realistic CSV rows and assert on the
+records actually written (money in cents) and the returned ImportBatch summary.
+"""
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from apps.contacts.models import Contact
+from apps.core.blind_index import lookup_hashes
+from apps.gifts.models import Gift
+from apps.imports.generic_services import import_generic_contacts, import_generic_donations
+from apps.imports.models import Fund, ImportBatchStatus, ImportBatchType
+from apps.users.models import User, UserRole
+
+
+def _bytes(csv_text: str) -> bytes:
+    return csv_text.encode("utf-8")
+
+
+class GenericContactHeaderValidationTests(TestCase):
+    """Missing-header validation per match_by strategy -> FAILED batch."""
+
+    def setUp(self):
+        self.user = User.objects.create_user(
+            email="owner@test.com",
+            password="testpass123",
+            first_name="Owner",
+            last_name="User",
+            role=UserRole.MISSIONARY,
+        )
+
+    def test_match_by_email_missing_email_header_fails(self):
+        # Has name columns (so create requirement satisfied) but no email column.
+        csv_content = "first_name,last_name,phone\nJohn,Smith,555-1234"
+        batch = import_generic_contacts(
+            _bytes(csv_content), "c.csv", self.user, self.user, match_by="email"
+        )
+        self.assertEqual(batch.status, ImportBatchStatus.FAILED)
+        self.assertIn("email", batch.summary["errors"][0]["error"])
+        # No contacts created on header failure.
+        self.assertEqual(Contact.objects.count(), 0)
+
+    def test_match_by_external_id_missing_id_header_fails(self):
+        csv_content = "first_name,last_name,phone\nJohn,Smith,555-1234"
+        batch = import_generic_contacts(
+            _bytes(csv_content), "c.csv", self.user, self.user, match_by="external_id"
+        )
+        self.assertEqual(batch.status, ImportBatchStatus.FAILED)
+        self.assertIn("external_id", batch.summary["errors"][0]["error"])
+
+    def test_match_by_name_missing_name_headers_fails(self):
+        # Only email column present; name matching needs first+last AND
+        # creation needs name-or-org -> two missing-header complaints.
+        csv_content = "email\njohn@example.com"
+        batch = import_generic_contacts(
+            _bytes(csv_content), "c.csv", self.user, self.user, match_by="name"
+        )
+        self.assertEqual(batch.status, ImportBatchStatus.FAILED)
+        error = batch.summary["errors"][0]["error"]
+        self.assertIn("first_name", error)
+        self.assertIn("last_name", error)
+
+    def test_missing_name_and_org_creation_headers_fails(self):
+        # email present (satisfies match_by=email) but neither name nor org
+        # columns exist -> can't create new contacts.
+        csv_content = "email,phone\njohn@example.com,555-1234"
+        batch = import_generic_contacts(
+            _bytes(csv_content), "c.csv", self.user, self.user, match_by="email"
+        )
+        self.assertEqual(batch.status, ImportBatchStatus.FAILED)
+        self.assertIn("organization_name", batch.summary["errors"][0]["error"])
+
+    def test_undecodable_file_returns_failed_batch(self):
+        # decode_csv_bytes only raises ValueError if every encoding fails;
+        # windows-1252 accepts all bytes, so we patch to simulate a hard
+        # decode failure and assert the FAILED branch is taken.
+        with patch(
+            "apps.imports.generic_services.decode_csv_bytes",
+            side_effect=ValueError("Unable to decode file"),
+        ):
+            batch = import_generic_contacts(
+                _bytes("first_name,last_name\nJohn,Smith"),
+                "bad.csv",
+                self.user,
+                self.user,
+                match_by="name",
+            )
+        self.assertEqual(batch.status, ImportBatchStatus.FAILED)
+        self.assertEqual(batch.summary["errors"][0]["row"], 0)
+        self.assertIn("Unable to decode", batch.summary["errors"][0]["error"])
+
+
+class GenericContactExternalIdMatchingTests(TestCase):
+    """match_by=external_id: create, update, idempotency."""
+
+    def setUp(self):
+        self.user = User.objects.create_user(
+            email="owner2@test.com",
+            password="testpass123",
+            first_name="Owner",
+            last_name="Two",
+            role=UserRole.MISSIONARY,
+        )
+
+    def test_create_new_contact_with_external_id_and_optional_fields(self):
+        csv_content = (
+            "id,first_name,last_name,email,phone,city,state,postal_code,country,notes\n"
+            "EXT-100,Alice,Walker,alice@example.com,555-9999,Austin,TX,73301,USA,VIP donor"
+        )
+        batch = import_generic_contacts(
+            _bytes(csv_content), "c.csv", self.user, self.user, match_by="external_id"
+        )
+        self.assertEqual(batch.status, ImportBatchStatus.COMPLETED)
+        self.assertEqual(batch.created_count, 1)
+        self.assertEqual(batch.updated_count, 0)
+
+        contact = Contact.objects.get(owner=self.user, external_id="EXT-100")
+        self.assertEqual(contact.first_name, "Alice")
+        self.assertEqual(contact.last_name, "Walker")
+        self.assertEqual(contact.email, "alice@example.com")
+        self.assertEqual(contact.phone, "555-9999")
+        self.assertEqual(contact.city, "Austin")
+        self.assertEqual(contact.state, "TX")
+        self.assertEqual(contact.postal_code, "73301")
+        self.assertEqual(contact.notes, "VIP donor")
+
+    def test_update_existing_contact_matched_by_external_id(self):
+        Contact.objects.create(
+            owner=self.user,
+            first_name="Bob",
+            last_name="Jones",
+            external_id="EXT-200",
+            email="",
+        )
+        csv_content = "external_id,first_name,last_name,email\nEXT-200,Bob,Jones,bob@example.com"
+        batch = import_generic_contacts(
+            _bytes(csv_content), "c.csv", self.user, self.user, match_by="external_id"
+        )
+        self.assertEqual(batch.status, ImportBatchStatus.COMPLETED)
+        self.assertEqual(batch.created_count, 0)
+        self.assertEqual(batch.updated_count, 1)
+
+        contact = Contact.objects.get(owner=self.user, external_id="EXT-200")
+        # merge-only filled the blank email
+        self.assertEqual(contact.email, "bob@example.com")
+
+    def test_missing_external_id_value_is_row_error(self):
+        # Header present but the row's external_id cell is blank.
+        csv_content = "external_id,first_name,last_name\n" "EXT-1,Carl,King\n" ",Dora,Queen"
+        batch = import_generic_contacts(
+            _bytes(csv_content), "c.csv", self.user, self.user, match_by="external_id"
+        )
+        self.assertEqual(batch.status, ImportBatchStatus.COMPLETED)
+        self.assertEqual(batch.created_count, 1)
+        self.assertEqual(batch.error_count, 1)
+        self.assertIn("Missing external_id", batch.summary["errors"][0]["error"])
+
+    def test_external_id_import_is_idempotent(self):
+        # Importing one file creates; re-importing a *different* file body with
+        # the same external_id must update, not duplicate.
+        first = "external_id,first_name,last_name\nEXT-9,Ann,Lee"
+        import_generic_contacts(
+            _bytes(first), "a.csv", self.user, self.user, match_by="external_id"
+        )
+        second = "external_id,first_name,last_name,phone\nEXT-9,Ann,Lee,555-0001"
+        import_generic_contacts(
+            _bytes(second), "b.csv", self.user, self.user, match_by="external_id"
+        )
+        # Only one contact with that external_id exists.
+        self.assertEqual(
+            Contact.objects.filter(owner=self.user, external_id="EXT-9").count(),
+            1,
+        )
+        contact = Contact.objects.get(owner=self.user, external_id="EXT-9")
+        self.assertEqual(contact.phone, "555-0001")
+
+
+class GenericContactNameMatchingTests(TestCase):
+    """match_by=name: create new + missing-name row errors."""
+
+    def setUp(self):
+        self.user = User.objects.create_user(
+            email="owner3@test.com",
+            password="testpass123",
+            first_name="Owner",
+            last_name="Three",
+            role=UserRole.MISSIONARY,
+        )
+
+    def test_create_new_contact_when_no_name_match(self):
+        csv_content = "first_name,last_name,email\nNew,Person,new@example.com"
+        batch = import_generic_contacts(
+            _bytes(csv_content), "c.csv", self.user, self.user, match_by="name"
+        )
+        self.assertEqual(batch.status, ImportBatchStatus.COMPLETED)
+        self.assertEqual(batch.created_count, 1)
+        self.assertTrue(
+            Contact.objects.filter(owner=self.user, first_name="New", last_name="Person").exists()
+        )
+
+    def test_missing_name_cell_with_name_matching_is_row_error(self):
+        csv_content = (
+            "first_name,last_name,email\n" "Valid,Name,v@example.com\n" ",,blank@example.com"
+        )
+        batch = import_generic_contacts(
+            _bytes(csv_content), "c.csv", self.user, self.user, match_by="name"
+        )
+        self.assertEqual(batch.created_count, 1)
+        self.assertEqual(batch.error_count, 1)
+        self.assertIn(
+            "Missing first_name or last_name",
+            batch.summary["errors"][0]["error"],
+        )
+
+
+class GenericContactOrgAndSkipTests(TestCase):
+    """Org-only creation, and skip path when nothing to merge."""
+
+    def setUp(self):
+        self.user = User.objects.create_user(
+            email="owner4@test.com",
+            password="testpass123",
+            first_name="Owner",
+            last_name="Four",
+            role=UserRole.MISSIONARY,
+        )
+
+    def test_org_only_contact_creation(self):
+        # No first/last but an organization column -> create org contact.
+        csv_content = "organization,email,city\n" "Acme Foundation,acme@example.com,Dallas"
+        batch = import_generic_contacts(
+            _bytes(csv_content), "c.csv", self.user, self.user, match_by="email"
+        )
+        self.assertEqual(batch.status, ImportBatchStatus.COMPLETED)
+        self.assertEqual(batch.created_count, 1)
+        contact = Contact.objects.get(owner=self.user, organization_name="Acme Foundation")
+        self.assertEqual(contact.email, "acme@example.com")
+        self.assertEqual(contact.city, "Dallas")
+
+    def test_existing_contact_with_nothing_to_merge_is_skipped(self):
+        # Existing contact already fully populated; re-import same data -> skip.
+        Contact.objects.create(
+            owner=self.user,
+            first_name="Sam",
+            last_name="Fox",
+            email="sam@example.com",
+            phone="555-2222",
+        )
+        csv_content = "first_name,last_name,email,phone\nSam,Fox,sam@example.com,555-9999"
+        batch = import_generic_contacts(
+            _bytes(csv_content), "c.csv", self.user, self.user, match_by="email"
+        )
+        self.assertEqual(batch.status, ImportBatchStatus.COMPLETED)
+        self.assertEqual(batch.created_count, 0)
+        self.assertEqual(batch.updated_count, 0)
+        self.assertEqual(batch.skipped_count, 1)
+        # merge-only never overwrites a populated phone.
+        contact = Contact.objects.get(
+            owner=self.user, email_hash__in=lookup_hashes("sam@example.com")
+        )
+        self.assertEqual(contact.phone, "555-2222")
+
+    def test_all_rows_errored_marks_batch_failed(self):
+        # match_by=email but every row has a blank email -> every row errors,
+        # nothing created/updated/skipped -> batch status FAILED.
+        csv_content = "first_name,last_name,email\n" "Foo,Bar,\n" "Baz,Qux,"
+        batch = import_generic_contacts(
+            _bytes(csv_content), "c.csv", self.user, self.user, match_by="email"
+        )
+        self.assertEqual(batch.status, ImportBatchStatus.FAILED)
+        self.assertEqual(batch.created_count, 0)
+        self.assertEqual(batch.error_count, 2)
+
+
+class GenericContactRowExceptionTests(TestCase):
+    """A per-row exception is caught and collected, not fatal."""
+
+    def setUp(self):
+        self.user = User.objects.create_user(
+            email="owner5@test.com",
+            password="testpass123",
+            first_name="Owner",
+            last_name="Five",
+            role=UserRole.MISSIONARY,
+        )
+
+    def test_row_level_exception_collected_and_other_rows_succeed(self):
+        # Force Contact.objects.create to blow up on the *second* invocation so
+        # the per-row try/except (lines 435-445) records an error while the
+        # first row still imports.
+        original_create = Contact.objects.create
+        calls = {"n": 0}
+
+        def flaky_create(*args, **kwargs):
+            calls["n"] += 1
+            if calls["n"] == 2:
+                raise RuntimeError("boom")
+            return original_create(*args, **kwargs)
+
+        csv_content = (
+            "first_name,last_name,email\n"
+            "Good,One,good1@example.com\n"
+            "Good,Two,good2@example.com"
+        )
+        with patch.object(Contact.objects, "create", side_effect=flaky_create):
+            batch = import_generic_contacts(
+                _bytes(csv_content), "c.csv", self.user, self.user, match_by="email"
+            )
+        self.assertEqual(batch.created_count, 1)
+        self.assertEqual(batch.error_count, 1)
+        self.assertIn("RuntimeError", batch.summary["errors"][0]["error"])
+
+
+class GenericDonationValidationTests(TestCase):
+    """Donation header validation + amount/date row validation."""
+
+    def setUp(self):
+        self.user = User.objects.create_user(
+            email="downer@test.com",
+            password="testpass123",
+            first_name="Down",
+            last_name="Owner",
+            role=UserRole.MISSIONARY,
+        )
+        self.contact = Contact.objects.create(
+            owner=self.user,
+            first_name="John",
+            last_name="Smith",
+            email="john@example.com",
+            external_id="DON-1",
+        )
+
+    def test_missing_amount_and_date_headers_fails(self):
+        csv_content = "email\njohn@example.com"
+        batch = import_generic_donations(
+            _bytes(csv_content), "d.csv", self.user, self.user, match_by="email"
+        )
+        self.assertEqual(batch.status, ImportBatchStatus.FAILED)
+        error = batch.summary["errors"][0]["error"]
+        self.assertIn("amount", error)
+        self.assertIn("date", error)
+
+    def test_missing_contact_email_header_fails(self):
+        csv_content = "amount,date\n100.00,2026-01-15"
+        batch = import_generic_donations(
+            _bytes(csv_content), "d.csv", self.user, self.user, match_by="email"
+        )
+        self.assertEqual(batch.status, ImportBatchStatus.FAILED)
+        self.assertIn("contact_email", batch.summary["errors"][0]["error"])
+
+    def test_missing_contact_name_headers_fails(self):
+        csv_content = "amount,date\n100.00,2026-01-15"
+        batch = import_generic_donations(
+            _bytes(csv_content), "d.csv", self.user, self.user, match_by="name"
+        )
+        self.assertEqual(batch.status, ImportBatchStatus.FAILED)
+        error = batch.summary["errors"][0]["error"]
+        self.assertIn("contact_first_name", error)
+        self.assertIn("contact_last_name", error)
+
+    def test_missing_contact_external_id_header_fails(self):
+        csv_content = "amount,date\n100.00,2026-01-15"
+        batch = import_generic_donations(
+            _bytes(csv_content), "d.csv", self.user, self.user, match_by="external_id"
+        )
+        self.assertEqual(batch.status, ImportBatchStatus.FAILED)
+        self.assertIn("contact_external_id", batch.summary["errors"][0]["error"])
+
+    def test_undecodable_donation_file_returns_failed_batch(self):
+        with patch(
+            "apps.imports.generic_services.decode_csv_bytes",
+            side_effect=ValueError("Unable to decode file"),
+        ):
+            batch = import_generic_donations(
+                _bytes("email,amount,date\njohn@example.com,100,2026-01-15"),
+                "bad.csv",
+                self.user,
+                self.user,
+                match_by="email",
+            )
+        self.assertEqual(batch.status, ImportBatchStatus.FAILED)
+        self.assertEqual(batch.summary["errors"][0]["row"], 0)
+
+    def test_zero_and_invalid_amounts_are_row_errors(self):
+        csv_content = (
+            "email,amount,date\n"
+            "john@example.com,0.00,2026-01-15\n"
+            "john@example.com,notmoney,2026-01-16\n"
+            "john@example.com,75.50,2026-01-17"
+        )
+        batch = import_generic_donations(
+            _bytes(csv_content), "d.csv", self.user, self.user, match_by="email"
+        )
+        # Only the $75.50 gift is created; the 0 and non-numeric rows error.
+        self.assertEqual(batch.created_count, 1)
+        self.assertEqual(batch.error_count, 2)
+        gift = Gift.objects.get(donor_contact=self.contact)
+        self.assertEqual(gift.amount_cents, 7550)
+        joined = " ".join(e["error"] for e in batch.summary["errors"])
+        self.assertIn("Invalid or zero amount", joined)
+
+    def test_invalid_date_is_row_error(self):
+        csv_content = "email,amount,date\n" "john@example.com,40.00,not-a-date"
+        batch = import_generic_donations(
+            _bytes(csv_content), "d.csv", self.user, self.user, match_by="email"
+        )
+        self.assertEqual(batch.created_count, 0)
+        self.assertEqual(batch.error_count, 1)
+        self.assertEqual(batch.status, ImportBatchStatus.FAILED)
+        self.assertIn("Invalid date", batch.summary["errors"][0]["error"])
+
+
+class GenericDonationMatchingTests(TestCase):
+    """Donation contact matching by name / external_id + fund matching."""
+
+    def setUp(self):
+        self.user = User.objects.create_user(
+            email="downer2@test.com",
+            password="testpass123",
+            first_name="Down",
+            last_name="Owner2",
+            role=UserRole.MISSIONARY,
+        )
+        self.contact = Contact.objects.create(
+            owner=self.user,
+            first_name="Mary",
+            last_name="Major",
+            email="mary@example.com",
+            external_id="C-77",
+        )
+
+    def test_match_by_name_creates_gift(self):
+        csv_content = (
+            "contact_first_name,contact_last_name,amount,date,description\n"
+            "Mary,Major,125.00,2026-03-01,Spring gift"
+        )
+        batch = import_generic_donations(
+            _bytes(csv_content), "d.csv", self.user, self.user, match_by="name"
+        )
+        self.assertEqual(batch.status, ImportBatchStatus.COMPLETED)
+        self.assertEqual(batch.created_count, 1)
+        gift = Gift.objects.get(donor_contact=self.contact)
+        self.assertEqual(gift.amount_cents, 12500)
+        self.assertEqual(gift.description, "Spring gift")
+
+    def test_match_by_name_no_match_is_row_error(self):
+        csv_content = (
+            "contact_first_name,contact_last_name,amount,date\n" "Ghost,Person,10.00,2026-03-01"
+        )
+        batch = import_generic_donations(
+            _bytes(csv_content), "d.csv", self.user, self.user, match_by="name"
+        )
+        self.assertEqual(batch.created_count, 0)
+        self.assertEqual(batch.error_count, 1)
+        self.assertIn("No contact found", batch.summary["errors"][0]["error"])
+
+    def test_match_by_name_missing_name_cell_is_row_error(self):
+        csv_content = "contact_first_name,contact_last_name,amount,date\n" ",,10.00,2026-03-01"
+        batch = import_generic_donations(
+            _bytes(csv_content), "d.csv", self.user, self.user, match_by="name"
+        )
+        self.assertEqual(batch.error_count, 1)
+        self.assertIn("Missing contact name", batch.summary["errors"][0]["error"])
+
+    def test_match_by_external_id_creates_gift(self):
+        csv_content = "contact_external_id,amount,date\n" "C-77,200.00,2026-04-01"
+        batch = import_generic_donations(
+            _bytes(csv_content), "d.csv", self.user, self.user, match_by="external_id"
+        )
+        self.assertEqual(batch.created_count, 1)
+        gift = Gift.objects.get(donor_contact=self.contact)
+        self.assertEqual(gift.amount_cents, 20000)
+
+    def test_match_by_external_id_no_match_is_row_error(self):
+        csv_content = "contact_external_id,amount,date\n" "NOPE,200.00,2026-04-01"
+        batch = import_generic_donations(
+            _bytes(csv_content), "d.csv", self.user, self.user, match_by="external_id"
+        )
+        self.assertEqual(batch.created_count, 0)
+        self.assertEqual(batch.error_count, 1)
+        self.assertIn("No contact found", batch.summary["errors"][0]["error"])
+
+    def test_match_by_external_id_missing_cell_is_row_error(self):
+        csv_content = "contact_external_id,amount,date\n" ",200.00,2026-04-01"
+        batch = import_generic_donations(
+            _bytes(csv_content), "d.csv", self.user, self.user, match_by="external_id"
+        )
+        self.assertEqual(batch.error_count, 1)
+        self.assertIn("Missing external_id", batch.summary["errors"][0]["error"])
+
+    def test_email_match_missing_cell_is_row_error(self):
+        csv_content = "contact_email,amount,date\n" ",50.00,2026-04-01"
+        batch = import_generic_donations(
+            _bytes(csv_content), "d.csv", self.user, self.user, match_by="email"
+        )
+        self.assertEqual(batch.error_count, 1)
+        self.assertIn("Missing email", batch.summary["errors"][0]["error"])
+
+    def test_gift_links_matched_fund(self):
+        fund = Fund.objects.create(external_id="F-1", name="General Fund", status="active")
+        csv_content = "contact_external_id,amount,date,fund\n" "C-77,60.00,2026-05-01,General Fund"
+        batch = import_generic_donations(
+            _bytes(csv_content), "d.csv", self.user, self.user, match_by="external_id"
+        )
+        self.assertEqual(batch.created_count, 1)
+        gift = Gift.objects.get(donor_contact=self.contact)
+        self.assertEqual(gift.fund_id, fund.id)
+
+    def test_unknown_fund_name_leaves_gift_without_fund(self):
+        csv_content = (
+            "contact_external_id,amount,date,fund\n" "C-77,60.00,2026-05-01,Nonexistent Fund"
+        )
+        batch = import_generic_donations(
+            _bytes(csv_content), "d.csv", self.user, self.user, match_by="external_id"
+        )
+        self.assertEqual(batch.created_count, 1)
+        gift = Gift.objects.get(donor_contact=self.contact)
+        self.assertIsNone(gift.fund_id)
+
+    def test_donation_dedup_returns_duplicate_status(self):
+        csv_content = "contact_external_id,amount,date\n" "C-77,99.00,2026-06-01"
+        first = import_generic_donations(
+            _bytes(csv_content), "d.csv", self.user, self.user, match_by="external_id"
+        )
+        self.assertEqual(first.status, ImportBatchStatus.COMPLETED)
+        second = import_generic_donations(
+            _bytes(csv_content), "d.csv", self.user, self.user, match_by="external_id"
+        )
+        self.assertEqual(second.status, ImportBatchStatus.DUPLICATE)
+        # No second gift was created on the duplicate import.
+        self.assertEqual(Gift.objects.filter(donor_contact=self.contact).count(), 1)
+
+    def test_batch_type_recorded_for_donations(self):
+        csv_content = "contact_external_id,amount,date\n" "C-77,15.00,2026-06-02"
+        batch = import_generic_donations(
+            _bytes(csv_content), "d.csv", self.user, self.user, match_by="external_id"
+        )
+        self.assertEqual(batch.import_type, ImportBatchType.GENERIC_DONATIONS)
+
+
+class GenericDonationRowExceptionTests(TestCase):
+    """A per-row exception during Gift creation is caught and collected."""
+
+    def setUp(self):
+        self.user = User.objects.create_user(
+            email="downer3@test.com",
+            password="testpass123",
+            first_name="Down",
+            last_name="Owner3",
+            role=UserRole.MISSIONARY,
+        )
+        self.contact = Contact.objects.create(
+            owner=self.user,
+            first_name="Jay",
+            last_name="Doe",
+            external_id="GX-1",
+        )
+
+    def test_gift_create_exception_recorded_as_row_error(self):
+        original_create = Gift.objects.create
+        calls = {"n": 0}
+
+        def flaky_create(*args, **kwargs):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise RuntimeError("gift boom")
+            return original_create(*args, **kwargs)
+
+        csv_content = (
+            "contact_external_id,amount,date\n" "GX-1,10.00,2026-07-01\n" "GX-1,20.00,2026-07-02"
+        )
+        with patch.object(Gift.objects, "create", side_effect=flaky_create):
+            batch = import_generic_donations(
+                _bytes(csv_content), "d.csv", self.user, self.user, match_by="external_id"
+            )
+        self.assertEqual(batch.created_count, 1)
+        self.assertEqual(batch.error_count, 1)
+        self.assertIn("RuntimeError", batch.summary["errors"][0]["error"])

--- a/apps/imports/tests/test_services_coverage.py
+++ b/apps/imports/tests/test_services_coverage.py
@@ -1,0 +1,247 @@
+"""
+Behavioral coverage tests for apps/imports/services.py.
+
+Targets currently-uncovered helpers and validation branches:
+- sanitize_csv_value formula-injection prefixing
+- _validate_email empty-allowed branch
+- _parse_amount / _parse_date helpers (every error path)
+- parse_contacts_csv length-limit and email-format/duplicate branches
+- parse_funds_csv / parse_entities_csv empty-header (no fieldnames) branch
+
+Each test asserts real, observable behavior: the sanitized value, the parsed
+Decimal/date, or the specific validation error string returned.
+"""
+from datetime import date
+from decimal import Decimal
+
+import pytest
+
+from apps.contacts.models import Contact
+from apps.contacts.tests.factories import ContactFactory
+from apps.imports.services import (
+    _parse_amount,
+    _parse_date,
+    _validate_email,
+    parse_contacts_csv,
+    parse_entities_csv,
+    parse_funds_csv,
+    sanitize_csv_value,
+)
+from apps.users.tests.factories import UserFactory
+
+
+class TestSanitizeCsvValue:
+    """CSV formula-injection prevention."""
+
+    @pytest.mark.parametrize("prefix", ["=", "+", "-", "@"])
+    def test_formula_prefix_is_quoted(self, prefix):
+        dangerous = f"{prefix}cmd|'/c calc'!A1"
+        result = sanitize_csv_value(dangerous)
+        assert result == "'" + dangerous
+
+    def test_plain_value_unchanged(self):
+        assert sanitize_csv_value("John Smith") == "John Smith"
+
+    def test_non_string_passthrough(self):
+        # Non-string inputs (e.g. int) must not be mangled.
+        assert sanitize_csv_value(1234) == 1234
+
+    def test_empty_and_none_passthrough(self):
+        assert sanitize_csv_value("") == ""
+        assert sanitize_csv_value(None) is None
+
+
+class TestValidateEmail:
+    """Email format validation, including the empty-allowed branch."""
+
+    def test_empty_email_allowed(self):
+        assert _validate_email("") is True
+
+    def test_valid_email(self):
+        assert _validate_email("a@b.com") is True
+
+    def test_invalid_email(self):
+        assert _validate_email("not-an-email") is False
+
+
+class TestParseAmountHelper:
+    """services._parse_amount returns (Decimal, error)."""
+
+    def test_empty_required(self):
+        amount, err = _parse_amount("")
+        assert amount is None
+        assert err == "Amount is required"
+
+    def test_valid_with_currency_and_commas(self):
+        amount, err = _parse_amount("$1,234.56")
+        assert err is None
+        assert amount == Decimal("1234.56")
+
+    def test_negative_rejected(self):
+        amount, err = _parse_amount("-5.00")
+        assert amount is None
+        assert err == "Amount cannot be negative"
+
+    def test_zero_rejected(self):
+        amount, err = _parse_amount("0")
+        assert amount is None
+        assert "greater than zero" in err
+
+    def test_exceeds_maximum(self):
+        amount, err = _parse_amount("10000000.00")
+        assert amount is None
+        assert "exceeds maximum" in err
+
+    def test_invalid_format(self):
+        amount, err = _parse_amount("abc")
+        assert amount is None
+        assert "Invalid amount format" in err
+
+
+class TestParseDateHelper:
+    """services._parse_date returns (date, error)."""
+
+    def test_empty_required(self):
+        parsed, err = _parse_date("")
+        assert parsed is None
+        assert err == "Date is required"
+
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            ("2026-02-01", date(2026, 2, 1)),
+            ("02/01/2026", date(2026, 2, 1)),
+        ],
+    )
+    def test_valid_formats(self, raw, expected):
+        parsed, err = _parse_date(raw)
+        assert err is None
+        assert parsed == expected
+
+    def test_invalid_format(self):
+        parsed, err = _parse_date("31/31/2026")
+        assert parsed is None
+        assert "Invalid date format" in err
+
+
+@pytest.mark.django_db
+class TestParseContactsValidationBranches:
+    """parse_contacts_csv length-limit, email format, and duplicate branches."""
+
+    def test_first_name_too_long(self):
+        user = UserFactory()
+        long_name = "x" * 151
+        csv_content = f"first_name,last_name\n{long_name},Smith"
+        valid, errors = parse_contacts_csv(csv_content, user)
+        assert len(valid) == 0
+        assert len(errors) == 1
+        assert any("maximum length of 150" in e for e in errors[0]["errors"])
+
+    def test_invalid_email_format(self):
+        user = UserFactory()
+        csv_content = "first_name,last_name,email\nJohn,Smith,bogus-email"
+        valid, errors = parse_contacts_csv(csv_content, user)
+        assert len(valid) == 0
+        assert any("Invalid email format" in e for e in errors[0]["errors"])
+
+    def test_duplicate_email_within_file(self):
+        user = UserFactory()
+        csv_content = (
+            "first_name,last_name,email\n" "John,Smith,dup@example.com\n" "Jane,Doe,dup@example.com"
+        )
+        valid, errors = parse_contacts_csv(csv_content, user)
+        # First row valid, second flagged as in-file duplicate.
+        assert len(valid) == 1
+        assert any("Duplicate email in file" in e for e in errors[0]["errors"])
+
+    def test_phone_too_long(self):
+        user = UserFactory()
+        long_phone = "1" * 21
+        csv_content = f"first_name,last_name,phone\nJohn,Smith,{long_phone}"
+        valid, errors = parse_contacts_csv(csv_content, user)
+        assert len(valid) == 0
+        assert any("Phone number exceeds maximum length" in e for e in errors[0]["errors"])
+
+    def test_postal_code_too_long(self):
+        user = UserFactory()
+        long_zip = "0" * 21
+        csv_content = f"first_name,last_name,postal_code\nJohn,Smith,{long_zip}"
+        valid, errors = parse_contacts_csv(csv_content, user)
+        assert len(valid) == 0
+        assert any("Postal code exceeds maximum length" in e for e in errors[0]["errors"])
+
+    def test_existing_email_in_account_flagged(self):
+        user = UserFactory()
+        ContactFactory(owner=user, email="taken@example.com")
+        csv_content = "first_name,last_name,email\nJohn,Smith,taken@example.com"
+        valid, errors = parse_contacts_csv(csv_content, user)
+        assert len(valid) == 0
+        assert any("already exists in your account" in e for e in errors[0]["errors"])
+
+
+@pytest.mark.django_db
+class TestParseFundsHeaderBranches:
+    """parse_funds_csv header / empty-file branches."""
+
+    def test_empty_file_no_headers(self):
+        # An empty string yields DictReader.fieldnames is None.
+        valid, errors = parse_funds_csv("")
+        assert len(valid) == 0
+        assert errors[0]["errors"] == ["CSV file is empty or has no headers"]
+
+    def test_missing_required_column(self):
+        valid, errors = parse_funds_csv("fund_id\nF-1")
+        assert len(valid) == 0
+        assert "Missing required column" in errors[0]["errors"][0]
+
+
+@pytest.mark.django_db
+class TestParseEntitiesHeaderBranches:
+    """parse_entities_csv header / empty-file branches."""
+
+    def test_empty_file_no_headers(self):
+        user = UserFactory()
+        valid, errors = parse_entities_csv("", user)
+        assert len(valid) == 0
+        assert errors[0]["errors"] == ["CSV file is empty or has no headers"]
+
+    def test_missing_required_column(self):
+        user = UserFactory()
+        valid, errors = parse_entities_csv("entity_id\nE-1", user)
+        assert len(valid) == 0
+        assert "Missing required column" in errors[0]["errors"][0]
+
+    def test_single_word_name_splits_to_first_name_only(self):
+        # Exercises the single-word name branch (last_name empty).
+        user = UserFactory()
+        valid, errors = parse_entities_csv("entity_id,name\nE-2,Cher", user)
+        assert len(errors) == 0
+        assert valid[0]["first_name"] == "Cher"
+        assert valid[0]["last_name"] == ""
+
+
+@pytest.mark.django_db
+class TestImportContactsWritesOwner:
+    """import_contacts persists records under the given owner (sanity behavior)."""
+
+    def test_created_contact_belongs_to_owner(self):
+        from apps.imports.services import import_contacts
+
+        user = UserFactory()
+        records = [
+            {
+                "first_name": "Pat",
+                "last_name": "Lee",
+                "email": "pat@example.com",
+                "phone": "",
+                "street_address": "",
+                "city": "",
+                "state": "",
+                "postal_code": "",
+                "country": "USA",
+                "notes": "",
+            }
+        ]
+        count, contacts = import_contacts(records, user)
+        assert count == 1
+        assert Contact.objects.filter(owner=user, first_name="Pat").exists()

--- a/apps/imports/tests/test_spo_csv_fixture_mapping.py
+++ b/apps/imports/tests/test_spo_csv_fixture_mapping.py
@@ -15,35 +15,54 @@ import os
 
 from django.test import TestCase
 
+import pytest
+
 from apps.imports.models import ImportBatch, ImportBatchStatus
 from apps.users.models import User
 
-FIXTURE_DIR = os.path.join(os.path.dirname(__file__), '..', '..', '..', 'test_data')
+FIXTURE_DIR = os.path.join(os.path.dirname(__file__), "..", "..", "..", "test_data")
+
+# These tests read real CSVs from the gitignored, local-only test_data/
+# directory (sizable realistic donor data that must not be committed). Skip the
+# whole module when those fixtures are absent (e.g. CI) instead of hard-failing
+# with FileNotFoundError. test_spo_services.py covers the same logic with
+# synthetic in-memory CSVs and runs everywhere.
+pytestmark = pytest.mark.skipif(
+    not os.path.exists(os.path.join(FIXTURE_DIR, "test_solicitors.csv")),
+    reason="SPO CSV fixtures live in gitignored test_data/ (local-only, absent in CI)",
+)
 
 
 def _fixture_bytes(filename):
     path = os.path.join(FIXTURE_DIR, filename)
-    with open(path, 'rb') as f:
+    with open(path, "rb") as f:
         return f.read()
 
 
 def _make_admin():
     return User.objects.create_user(
-        email='admin@example.com', password='adminpass',
-        first_name='Admin', last_name='User', role='admin',
+        email="admin@example.com",
+        password="adminpass",
+        first_name="Admin",
+        last_name="User",
+        role="admin",
     )
 
 
 def _make_staff_owner():
     return User.objects.create_user(
-        email='owner@example.com', password='ownerpass',
-        first_name='Owner', last_name='Staff', role='missionary',
+        email="owner@example.com",
+        password="ownerpass",
+        first_name="Owner",
+        last_name="Staff",
+        role="missionary",
     )
 
 
 # ---------------------------------------------------------------------------
 # Class 1: Solicitors
 # ---------------------------------------------------------------------------
+
 
 class TestSolicitorsFixtureMapping(TestCase):
     """Tests for test_solicitors.csv → reconcile_missionaries()."""
@@ -53,16 +72,16 @@ class TestSolicitorsFixtureMapping(TestCase):
         from apps.imports.spo_services import reconcile_missionaries
 
         admin = _make_admin()
-        file_bytes = _fixture_bytes('test_solicitors.csv')
+        file_bytes = _fixture_bytes("test_solicitors.csv")
 
-        batch = reconcile_missionaries(file_bytes, 'test_solicitors.csv', admin)
+        batch = reconcile_missionaries(file_bytes, "test_solicitors.csv", admin)
 
         self.assertEqual(batch.status, ImportBatchStatus.COMPLETED)
         self.assertEqual(batch.created_count, 20)
-        self.assertEqual(batch.summary['missionaries_expected'], 20)
-        self.assertEqual(batch.summary['created'], 20)
-        self.assertEqual(batch.summary['unresolved'], 0)
-        self.assertEqual(User.objects.filter(role='missionary').count(), 20)
+        self.assertEqual(batch.summary["missionaries_expected"], 20)
+        self.assertEqual(batch.summary["created"], 20)
+        self.assertEqual(batch.summary["unresolved"], 0)
+        self.assertEqual(User.objects.filter(role="missionary").count(), 20)
 
     def test_reconcile_creates_solicitor_records(self):
         """reconcile_missionaries() creates one Solicitor per missionary."""
@@ -70,9 +89,9 @@ class TestSolicitorsFixtureMapping(TestCase):
         from apps.imports.spo_services import reconcile_missionaries
 
         admin = _make_admin()
-        file_bytes = _fixture_bytes('test_solicitors.csv')
+        file_bytes = _fixture_bytes("test_solicitors.csv")
 
-        reconcile_missionaries(file_bytes, 'test_solicitors.csv', admin)
+        reconcile_missionaries(file_bytes, "test_solicitors.csv", admin)
 
         self.assertEqual(Solicitor.objects.count(), 20)
 
@@ -80,6 +99,7 @@ class TestSolicitorsFixtureMapping(TestCase):
 # ---------------------------------------------------------------------------
 # Class 2: Gifts
 # ---------------------------------------------------------------------------
+
 
 class TestGiftsFixtureMapping(TestCase):
     """Tests for test_gifts.csv → import_spo_gifts()."""
@@ -92,19 +112,19 @@ class TestGiftsFixtureMapping(TestCase):
 
         self.admin = _make_admin()
         self.owner = _make_staff_owner()
-        solicitors_bytes = _fixture_bytes('test_solicitors.csv')
-        reconcile_missionaries(solicitors_bytes, 'test_solicitors.csv', self.admin)
+        solicitors_bytes = _fixture_bytes("test_solicitors.csv")
+        reconcile_missionaries(solicitors_bytes, "test_solicitors.csv", self.admin)
         # Import constituents so gift contact lookups succeed (all gifts reference
         # constituent IDs that exist in test_constituents.csv)
-        constituents_bytes = _fixture_bytes('test_constituents.csv')
-        import_re_constituents(constituents_bytes, 'test_constituents.csv', self.admin, self.owner)
+        constituents_bytes = _fixture_bytes("test_constituents.csv")
+        import_re_constituents(constituents_bytes, "test_constituents.csv", self.admin, self.owner)
 
     def test_import_spo_gifts_with_fixture(self):
         """test_gifts.csv imports all 100 rows without parse errors."""
         from apps.imports.spo_services import import_spo_gifts
 
-        file_bytes = _fixture_bytes('test_gifts.csv')
-        batch = import_spo_gifts(file_bytes, 'test_gifts.csv', self.admin)
+        file_bytes = _fixture_bytes("test_gifts.csv")
+        batch = import_spo_gifts(file_bytes, "test_gifts.csv", self.admin)
 
         self.assertEqual(batch.status, ImportBatchStatus.COMPLETED)
         self.assertEqual(batch.error_count, 0)
@@ -115,11 +135,11 @@ class TestGiftsFixtureMapping(TestCase):
         from apps.gifts.models import Gift
         from apps.imports.spo_services import import_spo_gifts
 
-        file_bytes = _fixture_bytes('test_gifts.csv')
-        batch = import_spo_gifts(file_bytes, 'test_gifts.csv', self.admin)
+        file_bytes = _fixture_bytes("test_gifts.csv")
+        batch = import_spo_gifts(file_bytes, "test_gifts.csv", self.admin)
 
         # No row failures due to amount parse errors
-        self.assertEqual(batch.summary['error_details'], [])
+        self.assertEqual(batch.summary["error_details"], [])
         # At least 1 gift created (anonymous or blank-constituent rows)
         self.assertGreater(Gift.objects.count(), 0)
         # Amounts parsed from Fund Split Amount column — not left as 0
@@ -134,8 +154,8 @@ class TestGiftsFixtureMapping(TestCase):
         from apps.gifts.models import Gift
         from apps.imports.spo_services import import_spo_gifts
 
-        file_bytes = _fixture_bytes('test_gifts.csv')
-        batch = import_spo_gifts(file_bytes, 'test_gifts.csv', self.admin)
+        file_bytes = _fixture_bytes("test_gifts.csv")
+        batch = import_spo_gifts(file_bytes, "test_gifts.csv", self.admin)
 
         self.assertEqual(batch.status, ImportBatchStatus.COMPLETED)
         self.assertEqual(batch.error_count, 0)
@@ -146,6 +166,7 @@ class TestGiftsFixtureMapping(TestCase):
 # ---------------------------------------------------------------------------
 # Class 3: Recurring Gifts
 # ---------------------------------------------------------------------------
+
 
 class TestRecurringGiftsFixtureMapping(TestCase):
     """Tests for test_recurring_gifts.csv → import_re_recurring_gifts()."""
@@ -159,19 +180,22 @@ class TestRecurringGiftsFixtureMapping(TestCase):
         self.admin = _make_admin()
         self.owner = _make_staff_owner()
         # Reconcile missionaries so Solicitor records exist for gift credit creation
-        solicitors_bytes = _fixture_bytes('test_solicitors.csv')
-        reconcile_missionaries(solicitors_bytes, 'test_solicitors.csv', self.admin)
+        solicitors_bytes = _fixture_bytes("test_solicitors.csv")
+        reconcile_missionaries(solicitors_bytes, "test_solicitors.csv", self.admin)
         # Import constituents so recurring gift contact lookups succeed
-        constituents_bytes = _fixture_bytes('test_constituents.csv')
-        import_re_constituents(constituents_bytes, 'test_constituents.csv', self.admin, self.owner)
+        constituents_bytes = _fixture_bytes("test_constituents.csv")
+        import_re_constituents(constituents_bytes, "test_constituents.csv", self.admin, self.owner)
 
     def test_import_recurring_gifts_with_fixture(self):
         """test_recurring_gifts.csv imports without errors after contacts exist."""
         from apps.imports.re_services import import_re_recurring_gifts
 
-        file_bytes = _fixture_bytes('test_recurring_gifts.csv')
+        file_bytes = _fixture_bytes("test_recurring_gifts.csv")
         batch = import_re_recurring_gifts(
-            file_bytes, 'test_recurring_gifts.csv', self.admin, self.owner,
+            file_bytes,
+            "test_recurring_gifts.csv",
+            self.admin,
+            self.owner,
         )
 
         self.assertEqual(batch.status, ImportBatchStatus.COMPLETED)
@@ -182,9 +206,12 @@ class TestRecurringGiftsFixtureMapping(TestCase):
         """Type-label 'Recurring Gift' row is skipped; data row count is 300, not 301."""
         from apps.imports.re_services import import_re_recurring_gifts
 
-        file_bytes = _fixture_bytes('test_recurring_gifts.csv')
+        file_bytes = _fixture_bytes("test_recurring_gifts.csv")
         batch = import_re_recurring_gifts(
-            file_bytes, 'test_recurring_gifts.csv', self.admin, self.owner,
+            file_bytes,
+            "test_recurring_gifts.csv",
+            self.admin,
+            self.owner,
         )
 
         # 300 data rows (type-label row stripped, header row not counted)
@@ -194,6 +221,7 @@ class TestRecurringGiftsFixtureMapping(TestCase):
 # ---------------------------------------------------------------------------
 # Class 4: Constituents
 # ---------------------------------------------------------------------------
+
 
 class TestConstituentsFixtureMapping(TestCase):
     """Tests for test_constituents.csv → import_re_constituents()."""
@@ -206,9 +234,12 @@ class TestConstituentsFixtureMapping(TestCase):
         """test_constituents.csv imports without errors; contacts created."""
         from apps.imports.re_services import import_re_constituents
 
-        file_bytes = _fixture_bytes('test_constituents.csv')
+        file_bytes = _fixture_bytes("test_constituents.csv")
         batch = import_re_constituents(
-            file_bytes, 'test_constituents.csv', self.admin, self.owner,
+            file_bytes,
+            "test_constituents.csv",
+            self.admin,
+            self.owner,
         )
 
         self.assertEqual(batch.status, ImportBatchStatus.COMPLETED)
@@ -219,9 +250,12 @@ class TestConstituentsFixtureMapping(TestCase):
         """Type-label 'Constituent' row is skipped; data rows >= 100."""
         from apps.imports.re_services import import_re_constituents
 
-        file_bytes = _fixture_bytes('test_constituents.csv')
+        file_bytes = _fixture_bytes("test_constituents.csv")
         batch = import_re_constituents(
-            file_bytes, 'test_constituents.csv', self.admin, self.owner,
+            file_bytes,
+            "test_constituents.csv",
+            self.admin,
+            self.owner,
         )
 
         self.assertGreaterEqual(batch.total_rows, 100)

--- a/apps/insights/tests/test_admin_analytics_services.py
+++ b/apps/insights/tests/test_admin_analytics_services.py
@@ -15,6 +15,7 @@ from unittest.mock import patch
 from rest_framework.test import APIRequestFactory
 
 import pytest
+from freezegun import freeze_time
 
 from apps.contacts.tests.factories import ContactFactory
 from apps.core.fiscal_year import get_current_fiscal_year_bounds, get_prior_fiscal_year_bounds
@@ -56,6 +57,10 @@ class TestFiscalYearPace:
         assert result["pace_percentage"] == 0.0
         assert result["yoy_delta_percentage"] is None
 
+    # Pinned mid-fiscal-year (FY runs Jun 1 - May 31) so the gift dated
+    # fy_start + 10 days is always in the past relative to "today"; otherwise
+    # this fails when run in the first days of the fiscal year (early June).
+    @freeze_time("2026-10-15")
     def test_sums_current_fy_gifts(self):
         request = _admin_request()
         fy_start, _ = get_current_fiscal_year_bounds()
@@ -266,6 +271,9 @@ class TestFiscalYearDonations:
             else:
                 assert m["current_cents"] is not None
 
+    # Pinned mid-fiscal-year so fy_start + 5 days stays in the past; see the
+    # note on test_sums_current_fy_gifts above.
+    @freeze_time("2026-10-15")
     def test_sums_current_and_prior_year_gifts(self):
         request = _admin_request()
         fy_start, _ = get_current_fiscal_year_bounds()

--- a/apps/insights/tests/test_services_coverage.py
+++ b/apps/insights/tests/test_services_coverage.py
@@ -1,0 +1,487 @@
+"""
+Behavioral coverage tests for apps/insights/services.py.
+
+These exercise service functions that are reachable but previously untested:
+  - get_donations_by_month / get_donations_by_year (monetary sums in dollars)
+  - get_follow_ups (incomplete-task ledger, overdue flagging)
+  - get_transactions (admin gift ledger with filters + pagination)
+  - get_single_user_performance (single-row variant + None on miss)
+  - get_pace_calculation (avg days between stage transitions)
+  - _parse_date_range malformed-input branches (ValidationError -> 400)
+  - date-filter branches in get_team_trends / get_conversion_funnel
+
+Time is pinned mid-fiscal-year so gifts/events dated near boundaries stay in
+the past, matching the convention in test_admin_analytics_services.py.
+"""
+from datetime import date, timedelta
+
+from django.utils import timezone
+
+from rest_framework.exceptions import ValidationError
+
+import pytest
+from freezegun import freeze_time
+
+from apps.contacts.tests.factories import ContactFactory
+from apps.gifts.tests.factories import (
+    AnnualRecurringGiftFactory,
+    CancelledRecurringGiftFactory,
+    GiftFactory,
+    QuarterlyRecurringGiftFactory,
+    RecurringGiftFactory,
+)
+from apps.insights.services import (
+    _parse_date_range,
+    get_conversion_funnel,
+    get_donations_by_month,
+    get_donations_by_year,
+    get_follow_ups,
+    get_monthly_commitments,
+    get_pace_calculation,
+    get_single_user_performance,
+    get_team_trends,
+    get_transactions,
+    get_user_trends,
+)
+from apps.journals.models import (
+    Journal,
+    JournalContact,
+    JournalStageEvent,
+    PipelineStage,
+    StageEventType,
+)
+from apps.tasks.models import TaskPriority, TaskStatus, TaskType
+from apps.tasks.tests.factories import TaskFactory
+from apps.users.tests.factories import UserFactory
+
+
+def _set_created_at(instance, when):
+    """Force a TimeStampedModel created_at (bypasses auto_now_add via .update)."""
+    type(instance).objects.filter(pk=instance.pk).update(created_at=when)
+
+
+# --- _parse_date_range ---------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestParseDateRange:
+    def test_valid_range_returns_aware_datetimes(self):
+        dt_from, dt_to = _parse_date_range("2026-01-01", "2026-01-31")
+        assert dt_from is not None and dt_to is not None
+        assert timezone.is_aware(dt_from) and timezone.is_aware(dt_to)
+        # date_to is exclusive: the function adds one day so the whole end day
+        # is included by a `< dt_to` filter.
+        assert dt_to.date() == date(2026, 2, 1)
+
+    def test_none_inputs_return_none(self):
+        assert _parse_date_range(None, None) == (None, None)
+
+    def test_malformed_date_from_raises_validation_error(self):
+        with pytest.raises(ValidationError) as exc:
+            _parse_date_range(date_from="not-a-date")
+        assert "date_from" in exc.value.detail
+
+    def test_malformed_date_to_raises_validation_error(self):
+        with pytest.raises(ValidationError) as exc:
+            _parse_date_range(date_to="13/40/2026")
+        assert "date_to" in exc.value.detail
+
+
+# --- get_donations_by_month ----------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestDonationsByMonth:
+    def test_empty_year_returns_twelve_zero_months(self):
+        user = UserFactory(role="missionary")
+        result = get_donations_by_month(user, year=2026)
+        assert len(result["months"]) == 12
+        assert result["year"] == 2026
+        assert result["year_total"] == 0
+        assert result["donation_count"] == 0
+        assert all(m["total"] == 0 and m["count"] == 0 for m in result["months"])
+        # Labels are formatted, not raw
+        assert result["months"][0]["month"] == "2026-01"
+        assert result["months"][0]["short_label"] == "Jan"
+
+    def test_sums_gifts_into_correct_month_in_dollars(self):
+        user = UserFactory(role="missionary")
+        contact = ContactFactory(owner=user)
+        # Two gifts in March 2026 totalling $300.00, one in July 2026 ($50.00)
+        GiftFactory(donor_contact=contact, amount_cents=25000, gift_date=date(2026, 3, 5))
+        GiftFactory(donor_contact=contact, amount_cents=5000, gift_date=date(2026, 3, 20))
+        GiftFactory(donor_contact=contact, amount_cents=5000, gift_date=date(2026, 7, 1))
+        # Gift in a different year must be excluded
+        GiftFactory(donor_contact=contact, amount_cents=99999, gift_date=date(2025, 3, 5))
+
+        result = get_donations_by_month(user, year=2026)
+        by_month = {m["month"]: m for m in result["months"]}
+        assert by_month["2026-03"]["total"] == 300.0  # dollars, not cents
+        assert by_month["2026-03"]["count"] == 2
+        assert by_month["2026-07"]["total"] == 50.0
+        assert result["year_total"] == 350.0
+        assert result["donation_count"] == 3
+
+    @freeze_time("2026-10-15")
+    def test_defaults_to_current_year_when_year_none(self):
+        user = UserFactory(role="missionary")
+        contact = ContactFactory(owner=user)
+        GiftFactory(donor_contact=contact, amount_cents=10000, gift_date=date(2026, 6, 1))
+        result = get_donations_by_month(user)
+        assert result["year"] == 2026
+        assert result["year_total"] == 100.0
+
+    def test_owner_scoping_excludes_other_users_gifts(self):
+        user = UserFactory(role="missionary")
+        other = UserFactory(role="missionary")
+        GiftFactory(
+            donor_contact=ContactFactory(owner=other),
+            amount_cents=80000,
+            gift_date=date(2026, 4, 1),
+        )
+        result = get_donations_by_month(user, year=2026)
+        assert result["year_total"] == 0
+
+
+# --- get_donations_by_year -----------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestDonationsByYear:
+    @freeze_time("2026-10-15")
+    def test_returns_n_years_with_grand_total_in_dollars(self):
+        user = UserFactory(role="missionary")
+        contact = ContactFactory(owner=user)
+        GiftFactory(donor_contact=contact, amount_cents=20000, gift_date=date(2026, 1, 10))
+        GiftFactory(donor_contact=contact, amount_cents=30000, gift_date=date(2024, 6, 10))
+        result = get_donations_by_year(user, years=5)
+        years = {y["year"]: y for y in result["years"]}
+        assert set(years) == {2022, 2023, 2024, 2025, 2026}
+        assert years[2026]["total"] == 200.0
+        assert years[2026]["count"] == 1
+        assert years[2024]["total"] == 300.0
+        assert result["grand_total"] == 500.0
+        assert result["total_donations"] == 2
+
+    @freeze_time("2026-10-15")
+    def test_gift_older_than_window_excluded(self):
+        user = UserFactory(role="missionary")
+        contact = ContactFactory(owner=user)
+        # years=2 -> window is 2025, 2026. A 2023 gift must not be counted.
+        GiftFactory(donor_contact=contact, amount_cents=70000, gift_date=date(2023, 5, 1))
+        result = get_donations_by_year(user, years=2)
+        assert [y["year"] for y in result["years"]] == [2025, 2026]
+        assert result["grand_total"] == 0
+
+
+# --- get_follow_ups ------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestFollowUps:
+    @freeze_time("2026-10-15")
+    def test_flags_overdue_and_counts(self):
+        user = UserFactory(role="missionary")
+        contact = ContactFactory(owner=user)
+        today = date(2026, 10, 15)
+        # Overdue pending task
+        overdue = TaskFactory(
+            owner=user,
+            contact=contact,
+            status=TaskStatus.PENDING,
+            priority=TaskPriority.HIGH,
+            task_type=TaskType.CALL,
+            due_date=today - timedelta(days=3),
+        )
+        # Future in-progress task (not overdue)
+        TaskFactory(
+            owner=user,
+            contact=contact,
+            status=TaskStatus.IN_PROGRESS,
+            due_date=today + timedelta(days=5),
+        )
+        # Completed task must be excluded entirely
+        TaskFactory(owner=user, contact=contact, status=TaskStatus.COMPLETED)
+
+        result = get_follow_ups(user)
+        ids = [t["id"] for t in result["tasks"]]
+        assert str(overdue.id) in ids
+        assert result["total_count"] == 2  # pending + in_progress only
+        assert result["overdue_count"] == 1
+        overdue_row = next(t for t in result["tasks"] if t["id"] == str(overdue.id))
+        assert overdue_row["is_overdue"] is True
+        assert overdue_row["contact_id"] == str(contact.id)
+        assert overdue_row["contact_name"] == contact.full_name
+        # Oldest due_date sorts first
+        assert result["tasks"][0]["id"] == str(overdue.id)
+
+    @freeze_time("2026-10-15")
+    def test_task_without_contact_has_null_contact_fields(self):
+        user = UserFactory(role="missionary")
+        task = TaskFactory(
+            owner=user,
+            contact=None,
+            status=TaskStatus.PENDING,
+            due_date=date(2026, 10, 20),
+        )
+        result = get_follow_ups(user)
+        row = next(t for t in result["tasks"] if t["id"] == str(task.id))
+        assert row["contact_id"] is None
+        assert row["contact_name"] is None
+        assert row["is_overdue"] is False
+
+    def test_limit_caps_returned_tasks_but_not_total(self):
+        user = UserFactory(role="missionary")
+        for _ in range(4):
+            TaskFactory(owner=user, status=TaskStatus.PENDING)
+        result = get_follow_ups(user, limit=2)
+        assert len(result["tasks"]) == 2
+        assert result["total_count"] == 4
+
+    def test_owner_scoping_excludes_other_users_tasks(self):
+        user = UserFactory(role="missionary")
+        other = UserFactory(role="missionary")
+        TaskFactory(owner=other, status=TaskStatus.PENDING)
+        result = get_follow_ups(user)
+        assert result["total_count"] == 0
+        assert result["tasks"] == []
+
+
+# --- get_transactions (admin ledger) ------------------------------------------
+
+
+@pytest.mark.django_db
+class TestTransactions:
+    def test_returns_all_gifts_in_dollars(self):
+        admin = UserFactory(role="admin")
+        c1 = ContactFactory()
+        c2 = ContactFactory()
+        GiftFactory(donor_contact=c1, amount_cents=12345, gift_date=date(2026, 2, 1))
+        GiftFactory(donor_contact=c2, amount_cents=67800, gift_date=date(2026, 3, 1))
+        result = get_transactions(admin)
+        assert result["total_count"] == 2
+        amounts = sorted(t["amount"] for t in result["transactions"])
+        assert amounts == [123.45, 678.0]
+        # Newest gift_date first
+        assert result["transactions"][0]["date"] == "2026-03-01"
+
+    def test_contact_filter(self):
+        admin = UserFactory(role="admin")
+        c1 = ContactFactory()
+        c2 = ContactFactory()
+        GiftFactory(donor_contact=c1, amount_cents=10000, gift_date=date(2026, 2, 1))
+        GiftFactory(donor_contact=c2, amount_cents=20000, gift_date=date(2026, 2, 2))
+        result = get_transactions(admin, contact_id=str(c1.id))
+        assert result["total_count"] == 1
+        assert result["transactions"][0]["contact_id"] == str(c1.id)
+
+    def test_date_range_filter(self):
+        admin = UserFactory(role="admin")
+        contact = ContactFactory()
+        GiftFactory(donor_contact=contact, amount_cents=10000, gift_date=date(2026, 1, 1))
+        GiftFactory(donor_contact=contact, amount_cents=10000, gift_date=date(2026, 6, 1))
+        GiftFactory(donor_contact=contact, amount_cents=10000, gift_date=date(2026, 12, 1))
+        result = get_transactions(admin, date_from=date(2026, 5, 1), date_to=date(2026, 7, 1))
+        assert result["total_count"] == 1
+        assert result["transactions"][0]["date"] == "2026-06-01"
+
+    def test_pagination_offset_and_limit(self):
+        admin = UserFactory(role="admin")
+        contact = ContactFactory()
+        for day in range(1, 6):
+            GiftFactory(
+                donor_contact=contact, amount_cents=1000 * day, gift_date=date(2026, 2, day)
+            )
+        result = get_transactions(admin, limit=2, offset=2)
+        assert result["total_count"] == 5  # total ignores pagination
+        assert len(result["transactions"]) == 2
+        assert result["limit"] == 2
+        assert result["offset"] == 2
+
+
+# --- get_single_user_performance ----------------------------------------------
+
+
+@pytest.mark.django_db
+class TestSingleUserPerformance:
+    def test_returns_serialized_row_for_missionary(self):
+        user = UserFactory(role="missionary")
+        contact = ContactFactory(owner=user)
+        GiftFactory(donor_contact=contact, amount_cents=45000, gift_date=date(2026, 2, 1))
+        result = get_single_user_performance(user.id)
+        assert result is not None
+        assert result["id"] == str(user.id)
+        assert result["email"] == user.email
+        assert result["total_contacts"] == 1
+        assert result["total_donations"] == 450.0
+        assert result["donation_count"] == 1
+
+    def test_returns_none_for_missing_user(self):
+        import uuid
+
+        assert get_single_user_performance(uuid.uuid4()) is None
+
+    def test_returns_none_for_coach_role(self):
+        coach = UserFactory(role="coach")
+        # Coaches are not in the allowed role set, so the row is filtered out.
+        assert get_single_user_performance(coach.id) is None
+
+
+# --- get_pace_calculation ------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestPaceCalculation:
+    def _journal_contact(self):
+        owner = UserFactory(role="missionary")
+        journal = Journal.objects.create(owner=owner, name="J", goal_amount=1000)
+        contact = ContactFactory(owner=owner)
+        return JournalContact.objects.create(journal=journal, contact=contact)
+
+    def _stage_event(self, jc, when):
+        event = JournalStageEvent.objects.create(
+            journal_contact=jc,
+            stage=PipelineStage.CONTACT,
+            event_type=StageEventType.NOTE_ADDED,
+        )
+        _set_created_at(event, when)
+        return event
+
+    def test_no_events_returns_none(self):
+        result = get_pace_calculation()
+        assert result["average_days_between_stages"] is None
+        assert result["total_intervals"] == 0
+
+    def test_averages_intervals_between_consecutive_events(self):
+        jc = self._journal_contact()
+        base = timezone.make_aware(timezone.datetime(2026, 1, 1, 12, 0))
+        # 3 events for same contact: gaps of 4 and 10 days -> avg 7.0
+        self._stage_event(jc, base)
+        self._stage_event(jc, base + timedelta(days=4))
+        self._stage_event(jc, base + timedelta(days=14))
+
+        result = get_pace_calculation()
+        assert result["total_intervals"] == 2
+        assert result["average_days_between_stages"] == 7.0
+
+    def test_intervals_not_crossing_contact_boundary(self):
+        jc1 = self._journal_contact()
+        jc2 = self._journal_contact()
+        base = timezone.make_aware(timezone.datetime(2026, 1, 1, 12, 0))
+        # Each contact has a single 2-day interval; no cross-contact interval.
+        self._stage_event(jc1, base)
+        self._stage_event(jc1, base + timedelta(days=2))
+        self._stage_event(jc2, base + timedelta(days=100))
+        self._stage_event(jc2, base + timedelta(days=102))
+
+        result = get_pace_calculation()
+        assert result["total_intervals"] == 2
+        assert result["average_days_between_stages"] == 2.0
+
+    def test_date_range_filter_excludes_events(self):
+        jc = self._journal_contact()
+        base = timezone.make_aware(timezone.datetime(2026, 1, 1, 12, 0))
+        self._stage_event(jc, base)
+        self._stage_event(jc, base + timedelta(days=5))
+        # Restrict to a window that contains only the first event -> no interval.
+        result = get_pace_calculation(date_from="2025-12-31", date_to="2026-01-02")
+        assert result["total_intervals"] == 0
+        assert result["average_days_between_stages"] is None
+
+
+# --- date-filter branches in other aggregations --------------------------------
+
+
+@pytest.mark.django_db
+class TestDateFilterBranches:
+    def test_team_trends_with_explicit_range(self):
+        # Exercises the dt_from and dt_to branch of get_team_trends.
+        result = get_team_trends(date_from="2026-01-01", date_to="2026-02-28")
+        # Range spans ~8.5 weeks -> weeks recomputed from the range, not default 12.
+        assert result["weeks"] == len(result["trends"])
+        assert result["weeks"] >= 8
+        # First bucket aligned to a Monday on/before the range start.
+        first = date.fromisoformat(result["trends"][0]["week_start"])
+        assert first.weekday() == 0
+
+    def test_conversion_funnel_with_date_range_runs(self):
+        # Exercises the dt_from/dt_to filtering branch of get_conversion_funnel.
+        result = get_conversion_funnel(date_from="2026-01-01", date_to="2026-12-31")
+        assert result["total_contacts_in_pipeline"] == 0
+        assert "funnel" in result
+
+    def test_user_trends_buckets_recent_activity_by_week(self):
+        # Exercises get_user_trends including the per-row normalize_to_date path.
+        user = UserFactory(role="missionary")
+        journal = Journal.objects.create(owner=user, name="J", goal_amount=1000)
+        contact = ContactFactory(owner=user)
+        jc = JournalContact.objects.create(journal=journal, contact=contact)
+        # A stage event "now" lands in the current (last) week bucket.
+        JournalStageEvent.objects.create(
+            journal_contact=jc,
+            stage=PipelineStage.CONTACT,
+            event_type=StageEventType.NOTE_ADDED,
+        )
+        # A gift today contributes to donations_received for the current week.
+        GiftFactory(
+            donor_contact=contact,
+            amount_cents=10000,
+            gift_date=timezone.now().date(),
+        )
+
+        result = get_user_trends(user_id=user.id, weeks=4)
+        assert result["weeks"] == 4
+        assert len(result["trends"]) == 4
+        current_week = result["trends"][-1]
+        assert current_week["stage_progressions"] >= 1
+        assert current_week["donations_received"] >= 1
+
+    def test_user_trends_other_users_excluded(self):
+        user = UserFactory(role="missionary")
+        other = UserFactory(role="missionary")
+        journal = Journal.objects.create(owner=other, name="J", goal_amount=1000)
+        contact = ContactFactory(owner=other)
+        jc = JournalContact.objects.create(journal=journal, contact=contact)
+        JournalStageEvent.objects.create(
+            journal_contact=jc,
+            stage=PipelineStage.CONTACT,
+            event_type=StageEventType.NOTE_ADDED,
+        )
+        result = get_user_trends(user_id=user.id, weeks=4)
+        # No activity belongs to `user`, so every week is zero.
+        assert all(w["stage_progressions"] == 0 for w in result["trends"])
+
+
+# --- get_monthly_commitments frequency mix (covers monthly_equivalent paths) ---
+
+
+@pytest.mark.django_db
+class TestMonthlyCommitmentsCoverage:
+    def test_mixes_frequencies_and_reports_last_fulfilled(self):
+        user = UserFactory(role="missionary")
+        contact = ContactFactory(owner=user)
+        # Monthly $100 -> $100/mo; Quarterly $300 -> $100/mo; Annual $1200 -> $100/mo
+        monthly = RecurringGiftFactory(donor_contact=contact, amount_cents=10000)
+        QuarterlyRecurringGiftFactory(donor_contact=contact, amount_cents=30000)
+        AnnualRecurringGiftFactory(donor_contact=contact, amount_cents=120000)
+        # Cancelled pledge must be excluded from active totals.
+        CancelledRecurringGiftFactory(donor_contact=contact, amount_cents=99999)
+        # A paid gift linked to the monthly pledge sets last_fulfilled_date.
+        GiftFactory(
+            donor_contact=contact,
+            recurring_gift=monthly,
+            amount_cents=10000,
+            gift_date=date(2026, 5, 1),
+        )
+
+        result = get_monthly_commitments(user)
+        assert result["active_count"] == 3
+        assert result["total_monthly"] == pytest.approx(300.0, rel=0.01)
+        assert result["total_annual"] == pytest.approx(3600.0, rel=0.01)
+        freqs = {row["frequency"] for row in result["by_frequency"]}
+        assert {"monthly", "quarterly", "annually"} <= freqs
+        monthly_row = next(p for p in result["pledges"] if p["id"] == str(monthly.id))
+        assert monthly_row["last_fulfilled_date"] == "2026-05-01"
+        # A pledge that never paid reports None.
+        unpaid = next(p for p in result["pledges"] if p["frequency"] == "annually")
+        assert unpaid["last_fulfilled_date"] is None

--- a/apps/insights/tests/test_views_coverage.py
+++ b/apps/insights/tests/test_views_coverage.py
@@ -1,0 +1,257 @@
+"""
+Behavioral coverage tests for apps/insights/views.py.
+
+Focuses on previously-untested view branches:
+  - Financial-role gating (coach -> 403) on the four donor-finance endpoints
+  - Happy-path payloads for donations-by-month/year, monthly-commitments,
+    late-donations, follow-ups
+  - Admin transactions ledger (filters, pagination, non-admin 403)
+  - Single-user-performance 200 vs 404
+  - Date-range / param-validation branches on admin analytics views
+
+Time is pinned mid-fiscal-year where gift dates matter.
+"""
+from datetime import date
+
+from rest_framework import status
+from rest_framework.test import APIClient
+
+import pytest
+from freezegun import freeze_time
+
+from apps.contacts.tests.factories import ContactFactory
+from apps.gifts.tests.factories import GiftFactory, RecurringGiftFactory
+from apps.tasks.models import TaskStatus
+from apps.tasks.tests.factories import TaskFactory
+from apps.users.tests.factories import UserFactory
+
+
+def _client_for(role):
+    user = UserFactory(role=role)
+    client = APIClient()
+    client.force_authenticate(user=user)
+    return client, user
+
+
+# Endpoints gated by is_financial_role (coach must be rejected).
+FINANCIAL_ENDPOINTS = [
+    "/api/v1/insights/donations-by-month/",
+    "/api/v1/insights/donations-by-year/",
+    "/api/v1/insights/monthly-commitments/",
+    "/api/v1/insights/late-donations/",
+]
+
+
+@pytest.mark.django_db
+class TestFinancialRoleGating:
+    @pytest.mark.parametrize("endpoint", FINANCIAL_ENDPOINTS)
+    def test_coach_forbidden(self, endpoint):
+        client, _ = _client_for("coach")
+        response = client.get(endpoint)
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert response.data["detail"] == "Not authorized"
+
+    @pytest.mark.parametrize("endpoint", FINANCIAL_ENDPOINTS)
+    def test_missionary_allowed(self, endpoint):
+        client, _ = _client_for("missionary")
+        response = client.get(endpoint)
+        assert response.status_code == status.HTTP_200_OK
+
+    @pytest.mark.parametrize("endpoint", FINANCIAL_ENDPOINTS)
+    def test_unauthenticated_rejected(self, endpoint):
+        response = APIClient().get(endpoint)
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+@pytest.mark.django_db
+class TestDonationsByMonthView:
+    def test_returns_year_payload(self):
+        client, user = _client_for("missionary")
+        contact = ContactFactory(owner=user)
+        GiftFactory(donor_contact=contact, amount_cents=30000, gift_date=date(2026, 3, 1))
+        response = client.get("/api/v1/insights/donations-by-month/?year=2026")
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["year"] == 2026
+        assert len(response.data["months"]) == 12
+        assert response.data["year_total"] == 300.0
+
+    def test_invalid_year_param_falls_back(self):
+        client, _ = _client_for("missionary")
+        response = client.get("/api/v1/insights/donations-by-month/?year=abc")
+        # get_safe_year_param sanitizes bad input -> still 200.
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.data["months"]) == 12
+
+
+@pytest.mark.django_db
+class TestDonationsByYearView:
+    @freeze_time("2026-10-15")
+    def test_returns_n_years(self):
+        client, user = _client_for("missionary")
+        contact = ContactFactory(owner=user)
+        GiftFactory(donor_contact=contact, amount_cents=50000, gift_date=date(2026, 2, 1))
+        response = client.get("/api/v1/insights/donations-by-year/?years=3")
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.data["years"]) == 3
+        assert response.data["grand_total"] == 500.0
+
+    def test_years_param_clamped(self):
+        client, _ = _client_for("missionary")
+        # max_val=50; an out-of-range value is clamped, response still 200.
+        response = client.get("/api/v1/insights/donations-by-year/?years=9999")
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.data["years"]) == 50
+
+
+@pytest.mark.django_db
+class TestMonthlyCommitmentsView:
+    def test_returns_active_pledges(self):
+        client, user = _client_for("missionary")
+        contact = ContactFactory(owner=user)
+        RecurringGiftFactory(donor_contact=contact, amount_cents=10000)
+        response = client.get("/api/v1/insights/monthly-commitments/")
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["active_count"] == 1
+        assert response.data["total_monthly"] == pytest.approx(100.0, rel=0.01)
+
+
+@pytest.mark.django_db
+class TestLateDonationsView:
+    def test_returns_late_payload(self):
+        client, _ = _client_for("missionary")
+        response = client.get("/api/v1/insights/late-donations/?limit=25")
+        assert response.status_code == status.HTTP_200_OK
+        assert "late_donations" in response.data
+        assert "total_count" in response.data
+
+
+@pytest.mark.django_db
+class TestFollowUpsView:
+    @freeze_time("2026-10-15")
+    def test_returns_incomplete_tasks(self):
+        client, user = _client_for("missionary")
+        contact = ContactFactory(owner=user)
+        TaskFactory(
+            owner=user,
+            contact=contact,
+            status=TaskStatus.PENDING,
+            due_date=date(2026, 10, 10),
+        )
+        response = client.get("/api/v1/insights/follow-ups/")
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["total_count"] == 1
+        assert response.data["overdue_count"] == 1
+
+    def test_coach_allowed_follow_ups(self):
+        # follow-ups is NOT financial-gated; a coach should get a 200.
+        client, _ = _client_for("coach")
+        response = client.get("/api/v1/insights/follow-ups/")
+        assert response.status_code == status.HTTP_200_OK
+
+
+@pytest.mark.django_db
+class TestTransactionsView:
+    def test_admin_can_access_with_filters(self):
+        client, _ = _client_for("admin")
+        contact = ContactFactory()
+        GiftFactory(donor_contact=contact, amount_cents=12300, gift_date=date(2026, 6, 1))
+        response = client.get(
+            "/api/v1/insights/transactions/?limit=10&offset=0"
+            f"&contact_id={contact.id}&date_from=2026-01-01&date_to=2026-12-31"
+        )
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["total_count"] == 1
+        assert response.data["transactions"][0]["amount"] == 123.0
+        assert response.data["limit"] == 10
+        assert response.data["offset"] == 0
+
+    def test_missionary_forbidden(self):
+        client, _ = _client_for("missionary")
+        response = client.get("/api/v1/insights/transactions/")
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_invalid_date_returns_400(self):
+        client, _ = _client_for("admin")
+        response = client.get("/api/v1/insights/transactions/?date_from=not-a-date")
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+@pytest.mark.django_db
+class TestSingleUserPerformanceView:
+    def test_returns_200_for_existing_user(self):
+        client, _ = _client_for("admin")
+        missionary = UserFactory(role="missionary")
+        ContactFactory(owner=missionary)
+        response = client.get(f"/api/v1/insights/admin/user-performance/{missionary.id}/")
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["id"] == str(missionary.id)
+        assert response.data["total_contacts"] == 1
+
+    def test_returns_404_for_missing_user(self):
+        import uuid
+
+        client, _ = _client_for("admin")
+        response = client.get(f"/api/v1/insights/admin/user-performance/{uuid.uuid4()}/")
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_non_admin_forbidden(self):
+        client, _ = _client_for("missionary")
+        target = UserFactory(role="missionary")
+        response = client.get(f"/api/v1/insights/admin/user-performance/{target.id}/")
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.django_db
+class TestAdminAnalyticsDateBranches:
+    """Hit the date_from/date_to + param-validation branches on admin views."""
+
+    def test_dashboard_overview_with_date_range(self):
+        client, _ = _client_for("admin")
+        response = client.get(
+            "/api/v1/insights/admin/dashboard-overview/" "?date_from=2026-01-01&date_to=2026-12-31"
+        )
+        assert response.status_code == status.HTTP_200_OK
+        assert "donations_12m" in response.data
+
+    def test_conversion_funnel_with_date_range(self):
+        client, _ = _client_for("admin")
+        response = client.get(
+            "/api/v1/insights/admin/conversion-funnel/" "?date_from=2026-01-01&date_to=2026-12-31"
+        )
+        assert response.status_code == status.HTTP_200_OK
+        assert "funnel" in response.data
+
+    def test_conversion_funnel_invalid_date_returns_400(self):
+        client, _ = _client_for("admin")
+        response = client.get("/api/v1/insights/admin/conversion-funnel/?date_to=garbage")
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_team_activity_with_date_range(self):
+        client, _ = _client_for("admin")
+        response = client.get(
+            "/api/v1/insights/admin/team-activity/"
+            "?limit=5&date_from=2026-01-01&date_to=2026-12-31"
+        )
+        assert response.status_code == status.HTTP_200_OK
+        assert "activities" in response.data
+
+    def test_team_activity_invalid_date_returns_400(self):
+        client, _ = _client_for("admin")
+        response = client.get("/api/v1/insights/admin/team-activity/?date_from=bad")
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_stalled_contacts_invalid_date_returns_400(self):
+        client, _ = _client_for("admin")
+        response = client.get("/api/v1/insights/admin/stalled-contacts/?date_from=bad")
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_stalled_contacts_invalid_sort_dir_falls_back(self):
+        # An out-of-allowlist sort_dir is coerced to "desc" (still 200).
+        client, _ = _client_for("admin")
+        response = client.get("/api/v1/insights/admin/stalled-contacts/?sort_dir=sideways")
+        assert response.status_code == status.HTTP_200_OK
+
+    def test_team_trends_invalid_date_returns_400(self):
+        client, _ = _client_for("admin")
+        response = client.get("/api/v1/insights/admin/team-trends/?date_from=nope")
+        assert response.status_code == status.HTTP_400_BAD_REQUEST

--- a/apps/journals/tests/test_export_coverage.py
+++ b/apps/journals/tests/test_export_coverage.py
@@ -1,0 +1,220 @@
+"""
+Behavioral coverage tests for the journal CSV export view and
+serializer fallback/summary branches.
+
+Verifies:
+- CSV content-type, attachment header, header row, and data row values
+- Owner-scoping of the export
+- Archived inclusion/exclusion semantics
+- FilterSet application (owner filter)
+- JournalContactSerializer stage_events/decision summary branches
+"""
+import csv
+import io
+from decimal import Decimal
+
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from apps.contacts.models import Contact
+from apps.journals.models import Decision, Journal, JournalContact, JournalStageEvent
+
+User = get_user_model()
+
+
+def _read_csv(response):
+    """Drain a StreamingHttpResponse into parsed CSV rows."""
+    content = b"".join(response.streaming_content).decode("utf-8")
+    return list(csv.reader(io.StringIO(content)))
+
+
+class JournalExportCSVTests(APITestCase):
+    """Tests for the journal CSV export endpoint."""
+
+    def setUp(self):
+        self.user_a = User.objects.create_user(
+            email="a@example.com",
+            password="pw",
+            first_name="Ann",
+            last_name="Apple",
+            role="missionary",
+        )
+        self.user_b = User.objects.create_user(
+            email="b@example.com",
+            password="pw",
+            first_name="Bob",
+            last_name="Berry",
+            role="missionary",
+        )
+        self.j_a = Journal.objects.create(
+            owner=self.user_a,
+            name="Alpha",
+            goal_amount=Decimal("50000.00"),
+            deadline="2026-06-30",
+        )
+        self.j_b = Journal.objects.create(
+            owner=self.user_b, name="Beta", goal_amount=Decimal("30000.00")
+        )
+        self.url = reverse("journals:journal-export-csv")
+        self.client.force_authenticate(user=self.user_a)
+
+    def test_requires_authentication(self):
+        self.client.force_authenticate(user=None)
+        response = self.client.get(self.url)
+        self.assertIn(
+            response.status_code, (status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN)
+        )
+
+    def test_content_type_and_disposition(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response["Content-Type"], "text/csv")
+        self.assertIn("attachment", response["Content-Disposition"])
+        self.assertIn(".csv", response["Content-Disposition"])
+
+    def test_header_row(self):
+        response = self.client.get(self.url)
+        rows = _read_csv(response)
+        self.assertEqual(
+            rows[0], ["Name", "Goal Amount", "Deadline", "Archived", "Owner", "Created"]
+        )
+
+    def test_data_row_values_and_owner_scoping(self):
+        response = self.client.get(self.url)
+        rows = _read_csv(response)
+        # Only user_a's journal should appear (owner scoped)
+        data_rows = rows[1:]
+        self.assertEqual(len(data_rows), 1)
+        row = data_rows[0]
+        self.assertEqual(row[0], "Alpha")
+        self.assertEqual(row[1], "50000.00")
+        self.assertEqual(row[2], "2026-06-30")
+        self.assertEqual(row[3], "No")
+        self.assertEqual(row[4], "Ann Apple")
+        # Created date is today's ISO date
+        self.assertRegex(row[5], r"^\d{4}-\d{2}-\d{2}$")
+
+    def test_blank_deadline_renders_empty(self):
+        Journal.objects.create(owner=self.user_a, name="NoDeadline", goal_amount=Decimal("100.00"))
+        response = self.client.get(self.url)
+        rows = _read_csv(response)
+        names = {r[0]: r for r in rows[1:]}
+        self.assertEqual(names["NoDeadline"][2], "")
+
+    def test_archived_excluded_by_default(self):
+        self.j_a.archive()
+        response = self.client.get(self.url)
+        rows = _read_csv(response)
+        self.assertEqual(len(rows[1:]), 0)
+
+    def test_archived_included_when_filter_present(self):
+        self.j_a.archive()
+        response = self.client.get(self.url, {"is_archived": "true"})
+        rows = _read_csv(response)
+        names = [r[0] for r in rows[1:]]
+        self.assertIn("Alpha", names)
+        # The archived flag column reflects archived state
+        archived_row = next(r for r in rows[1:] if r[0] == "Alpha")
+        self.assertEqual(archived_row[3], "Yes")
+
+    def test_filterset_owner_filter_applies(self):
+        # Admin-style owner filter param; for missionary, scoping still limits
+        # to own journals so filtering by own owner id returns the journal.
+        Journal.objects.create(owner=self.user_a, name="Second", goal_amount=Decimal("200.00"))
+        response = self.client.get(self.url, {"owner": str(self.user_a.id)})
+        rows = _read_csv(response)
+        names = {r[0] for r in rows[1:]}
+        self.assertIn("Alpha", names)
+        self.assertIn("Second", names)
+
+    def test_filterset_owner_filter_for_other_owner_returns_empty(self):
+        # Filtering by user_b's id: owner-scoping intersects to nothing for user_a
+        response = self.client.get(self.url, {"owner": str(self.user_b.id)})
+        rows = _read_csv(response)
+        self.assertEqual(len(rows[1:]), 0)
+
+
+class JournalContactSerializerBranchTests(APITestCase):
+    """
+    Exercise JournalContactSerializer summary branches via the list endpoint
+    (which prefetches) and the create endpoint (which does NOT prefetch,
+    hitting the fallback paths).
+    """
+
+    def setUp(self):
+        self.owner = User.objects.create_user(
+            email="own@example.com",
+            password="pw",
+            first_name="Owen",
+            last_name="Own",
+            role="missionary",
+        )
+        self.journal = Journal.objects.create(
+            owner=self.owner, name="J", goal_amount=Decimal("1000.00")
+        )
+        self.contact = Contact.objects.create(
+            owner=self.owner,
+            first_name="Cara",
+            last_name="Cyan",
+            status="prospect",
+            email="cara@example.com",
+        )
+        self.client.force_authenticate(user=self.owner)
+
+    def test_list_membership_summarizes_stage_events_and_decision(self):
+        jc = JournalContact.objects.create(journal=self.journal, contact=self.contact)
+        JournalStageEvent.objects.create(
+            journal_contact=jc, stage="contact", event_type="call_logged", notes="hello world"
+        )
+        JournalStageEvent.objects.create(
+            journal_contact=jc,
+            stage="scheduled",
+            event_type="meeting_scheduled",
+            metadata={"scheduled_date": "2026-07-01"},
+        )
+        Decision.objects.create(
+            journal_contact=jc, amount=Decimal("120.00"), cadence="monthly", status="active"
+        )
+        url = reverse("journals:journal-member-list")
+        response = self.client.get(url, {"journal_id": str(self.journal.id)})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        result = response.data["results"][0]
+
+        # Stage event summaries: contact has events, close does not
+        stage_events = result["stage_events"]
+        self.assertTrue(stage_events["contact"]["has_events"])
+        self.assertEqual(stage_events["contact"]["event_count"], 1)
+        self.assertEqual(stage_events["contact"]["last_event_type"], "call_logged")
+        self.assertEqual(stage_events["contact"]["last_event_notes"], "hello world")
+        self.assertFalse(stage_events["close"]["has_events"])
+        self.assertIsNone(stage_events["close"]["last_event_date"])
+        # Scheduled stage carries scheduled_date from metadata
+        self.assertEqual(stage_events["scheduled"]["scheduled_date"], "2026-07-01")
+
+        # Decision summary
+        self.assertIsNotNone(result["decision"])
+        self.assertEqual(result["decision"]["amount"], "120.00")
+        self.assertEqual(result["decision"]["status"], "active")
+        self.assertEqual(result["decision"]["monthly_equivalent"], "120.00")
+
+        # Contact passthrough fields
+        self.assertEqual(result["contact_name"], "Cara Cyan")
+        self.assertEqual(result["contact_status"], "prospect")
+
+    def test_create_membership_uses_fallback_summaries(self):
+        # POST create serializes the new object WITHOUT prefetch attrs,
+        # exercising the getattr(...) is None fallback branches.
+        url = reverse("journals:journal-member-list")
+        response = self.client.post(
+            url,
+            {"journal": str(self.journal.id), "contact": str(self.contact.id)},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        # No events / no decision yet -> all stages empty, decision is None
+        self.assertIsNone(response.data["decision"])
+        self.assertFalse(response.data["stage_events"]["contact"]["has_events"])
+        self.assertIsNone(response.data["stage_events"]["scheduled"]["scheduled_date"])

--- a/apps/journals/tests/test_views_coverage.py
+++ b/apps/journals/tests/test_views_coverage.py
@@ -1,0 +1,683 @@
+"""
+Behavioral coverage tests for journals views.
+
+Exercises real HTTP request/response behavior through the DRF API:
+- Journal list/create/detail/archive flows + owner-scoping + ordering/search
+- Stage event list/create + delete-by-stage write restriction
+- Next step list/create/update + ownership
+- Decision list filtering + duplicate handling
+- Decision history list filtering
+- Analytics ViewSet endpoints (trends, activity, pipeline, queue, report, admin-summary)
+"""
+from datetime import timedelta
+from decimal import Decimal
+
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+from django.utils import timezone
+
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from apps.contacts.models import Contact
+from apps.journals.models import (
+    Decision,
+    DecisionHistory,
+    Journal,
+    JournalContact,
+    JournalStageEvent,
+    NextStep,
+)
+
+User = get_user_model()
+
+
+class JournalListCreateTests(APITestCase):
+    """Tests for the journal list/create endpoint."""
+
+    def setUp(self):
+        self.user_a = User.objects.create_user(
+            email="a@example.com",
+            password="pw",
+            first_name="Ann",
+            last_name="A",
+            role="missionary",
+        )
+        self.user_b = User.objects.create_user(
+            email="b@example.com",
+            password="pw",
+            first_name="Bob",
+            last_name="B",
+            role="missionary",
+        )
+        self.j_a = Journal.objects.create(
+            owner=self.user_a, name="Alpha Campaign", goal_amount=Decimal("50000.00")
+        )
+        self.j_b = Journal.objects.create(
+            owner=self.user_b, name="Beta Campaign", goal_amount=Decimal("30000.00")
+        )
+        self.url = reverse("journals:journal-list")
+        self.client.force_authenticate(user=self.user_a)
+
+    def test_requires_authentication(self):
+        self.client.force_authenticate(user=None)
+        response = self.client.get(self.url)
+        self.assertIn(
+            response.status_code, (status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN)
+        )
+
+    def test_list_only_own_journals(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 1)
+        self.assertEqual(response.data["results"][0]["name"], "Alpha Campaign")
+        self.assertEqual(response.data["results"][0]["owner_name"], "Ann A")
+
+    def test_create_sets_owner_to_current_user(self):
+        response = self.client.post(
+            self.url,
+            {"name": "Gamma", "goal_amount": "12000.00", "deadline": "2026-12-31"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        created = Journal.objects.get(id=response.data["id"])
+        self.assertEqual(created.owner, self.user_a)
+        self.assertEqual(created.name, "Gamma")
+
+    def test_create_rejects_invalid_goal_amount(self):
+        response = self.client.post(self.url, {"name": "Bad", "goal_amount": "0"}, format="json")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("goal_amount", response.data)
+
+    def test_archived_excluded_by_default(self):
+        self.j_a.archive()
+        response = self.client.get(self.url)
+        self.assertEqual(response.data["count"], 0)
+
+    def test_is_archived_true_shows_only_archived(self):
+        self.j_a.archive()
+        Journal.objects.create(owner=self.user_a, name="Active One", goal_amount=Decimal("100.00"))
+        response = self.client.get(self.url, {"is_archived": "true"})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 1)
+        self.assertEqual(response.data["results"][0]["name"], "Alpha Campaign")
+
+    def test_search_by_name(self):
+        Journal.objects.create(
+            owner=self.user_a, name="Year End Push", goal_amount=Decimal("100.00")
+        )
+        response = self.client.get(self.url, {"search": "Year End"})
+        self.assertEqual(response.data["count"], 1)
+        self.assertEqual(response.data["results"][0]["name"], "Year End Push")
+
+    def test_ordering_by_name(self):
+        Journal.objects.create(owner=self.user_a, name="Zeta Last", goal_amount=Decimal("100.00"))
+        response = self.client.get(self.url, {"ordering": "name"})
+        names = [r["name"] for r in response.data["results"]]
+        self.assertEqual(names, sorted(names))
+
+
+class JournalDetailTests(APITestCase):
+    """Tests for retrieve/update/archive on a single journal."""
+
+    def setUp(self):
+        self.owner = User.objects.create_user(
+            email="own@example.com", password="pw", role="missionary"
+        )
+        self.other = User.objects.create_user(
+            email="oth@example.com", password="pw", role="missionary"
+        )
+        self.admin = User.objects.create_user(email="adm@example.com", password="pw", role="admin")
+        self.journal = Journal.objects.create(
+            owner=self.owner, name="Detail Journal", goal_amount=Decimal("9000.00")
+        )
+        self.url = reverse("journals:journal-detail", kwargs={"pk": self.journal.id})
+
+    def test_owner_can_retrieve(self):
+        self.client.force_authenticate(user=self.owner)
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["name"], "Detail Journal")
+        self.assertEqual(response.data["goal_amount"], "9000.00")
+
+    def test_other_user_cannot_retrieve(self):
+        self.client.force_authenticate(user=self.other)
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_owner_can_patch_name(self):
+        self.client.force_authenticate(user=self.owner)
+        response = self.client.patch(self.url, {"name": "Renamed"}, format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.journal.refresh_from_db()
+        self.assertEqual(self.journal.name, "Renamed")
+
+    def test_delete_soft_archives(self):
+        self.client.force_authenticate(user=self.owner)
+        response = self.client.delete(self.url)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.journal.refresh_from_db()
+        self.assertTrue(self.journal.is_archived)
+        self.assertIsNotNone(self.journal.archived_at)
+        # Still in DB (soft delete, not hard delete)
+        self.assertTrue(Journal.objects.filter(id=self.journal.id).exists())
+
+    def test_admin_can_retrieve_any_journal_via_object_perm(self):
+        # Admin queryset is still own-scoped (get_visible_user_ids), so a
+        # different owner's journal returns 404 for admin without View As.
+        self.client.force_authenticate(user=self.admin)
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+
+class StageEventTests(APITestCase):
+    """Tests for stage event list/create and delete-by-stage."""
+
+    def setUp(self):
+        self.owner = User.objects.create_user(
+            email="own@example.com", password="pw", role="missionary"
+        )
+        self.other = User.objects.create_user(
+            email="oth@example.com", password="pw", role="missionary"
+        )
+        self.admin = User.objects.create_user(email="adm@example.com", password="pw", role="admin")
+        self.journal = Journal.objects.create(
+            owner=self.owner, name="J", goal_amount=Decimal("1000.00")
+        )
+        self.contact = Contact.objects.create(
+            owner=self.owner, first_name="Carl", last_name="Cole", status="prospect"
+        )
+        self.jc = JournalContact.objects.create(journal=self.journal, contact=self.contact)
+        self.list_url = reverse("journals:stage-event-list")
+        self.del_url = reverse("journals:stage-event-delete-by-stage")
+        self.client.force_authenticate(user=self.owner)
+
+    def _make_event(self, stage="contact", event_type="call_logged"):
+        return JournalStageEvent.objects.create(
+            journal_contact=self.jc, stage=stage, event_type=event_type
+        )
+
+    def test_create_stage_event(self):
+        response = self.client.post(
+            self.list_url,
+            {
+                "journal_contact": str(self.jc.id),
+                "stage": "contact",
+                "event_type": "call_logged",
+                "notes": "Spoke briefly",
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        event = JournalStageEvent.objects.get(id=response.data["id"])
+        self.assertEqual(event.triggered_by, self.owner)
+
+    def test_create_requires_journal_contact_or_contact_id(self):
+        response = self.client.post(
+            self.list_url, {"stage": "contact", "event_type": "other"}, format="json"
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_create_scheduled_requires_scheduled_date(self):
+        response = self.client.post(
+            self.list_url,
+            {
+                "journal_contact": str(self.jc.id),
+                "stage": "scheduled",
+                "event_type": "meeting_scheduled",
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("metadata", response.data)
+
+    def test_list_filtered_by_journal_contact_id(self):
+        self._make_event()
+        other_jc = JournalContact.objects.create(
+            journal=self.journal,
+            contact=Contact.objects.create(
+                owner=self.owner, first_name="X", last_name="Y", status="prospect"
+            ),
+        )
+        JournalStageEvent.objects.create(journal_contact=other_jc, stage="meet", event_type="other")
+        response = self.client.get(self.list_url, {"journal_contact_id": str(self.jc.id)})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 1)
+        self.assertEqual(str(response.data["results"][0]["journal_contact"]), str(self.jc.id))
+
+    def test_list_owner_scoped(self):
+        self._make_event()
+        self.client.force_authenticate(user=self.other)
+        response = self.client.get(self.list_url)
+        self.assertEqual(response.data["count"], 0)
+
+    def _delete_by_stage(self, journal_contact_id, stage):
+        # Query params must go on the URL; DRF test client treats a DELETE
+        # data dict as a request body, not query_params.
+        return self.client.delete(
+            f"{self.del_url}?journal_contact_id={journal_contact_id}&stage={stage}"
+        )
+
+    def test_delete_by_stage_requires_params(self):
+        response = self.client.delete(self.del_url)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("detail", response.data)
+
+    def test_delete_by_stage_removes_matching_events(self):
+        self._make_event(stage="contact")
+        self._make_event(stage="contact")
+        self._make_event(stage="meet")
+        response = self._delete_by_stage(self.jc.id, "contact")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["deleted"], 2)
+        self.assertEqual(
+            JournalStageEvent.objects.filter(journal_contact=self.jc, stage="contact").count(),
+            0,
+        )
+        self.assertEqual(
+            JournalStageEvent.objects.filter(journal_contact=self.jc, stage="meet").count(), 1
+        )
+
+    def test_delete_by_stage_cannot_touch_other_users_events(self):
+        self._make_event(stage="contact")
+        self.client.force_authenticate(user=self.other)
+        response = self._delete_by_stage(self.jc.id, "contact")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        # Non-owner non-admin: filtered to own journals, so deletes nothing
+        self.assertEqual(response.data["deleted"], 0)
+        self.assertEqual(JournalStageEvent.objects.filter(journal_contact=self.jc).count(), 1)
+
+    def test_delete_by_stage_admin_can_delete(self):
+        self._make_event(stage="contact")
+        self.client.force_authenticate(user=self.admin)
+        response = self._delete_by_stage(self.jc.id, "contact")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["deleted"], 1)
+
+
+class NextStepViewTests(APITestCase):
+    """Tests for next step list/create/update/delete."""
+
+    def setUp(self):
+        self.owner = User.objects.create_user(
+            email="own@example.com", password="pw", role="missionary"
+        )
+        self.other = User.objects.create_user(
+            email="oth@example.com", password="pw", role="missionary"
+        )
+        self.journal = Journal.objects.create(
+            owner=self.owner, name="J", goal_amount=Decimal("1000.00")
+        )
+        self.contact = Contact.objects.create(
+            owner=self.owner, first_name="Carl", last_name="Cole", status="prospect"
+        )
+        self.jc = JournalContact.objects.create(journal=self.journal, contact=self.contact)
+        self.list_url = reverse("journals:nextstep-list")
+        self.client.force_authenticate(user=self.owner)
+
+    def test_create_next_step(self):
+        response = self.client.post(
+            self.list_url,
+            {"journal_contact": str(self.jc.id), "title": "Send thank-you"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(NextStep.objects.count(), 1)
+
+    def test_create_rejected_for_unowned_journal_contact(self):
+        other_journal = Journal.objects.create(
+            owner=self.other, name="Other", goal_amount=Decimal("100.00")
+        )
+        other_contact = Contact.objects.create(
+            owner=self.other, first_name="Z", last_name="Z", status="prospect"
+        )
+        other_jc = JournalContact.objects.create(journal=other_journal, contact=other_contact)
+        response = self.client.post(
+            self.list_url,
+            {"journal_contact": str(other_jc.id), "title": "Nope"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_list_filtered_by_journal_contact(self):
+        NextStep.objects.create(journal_contact=self.jc, title="A")
+        other_jc = JournalContact.objects.create(
+            journal=self.journal,
+            contact=Contact.objects.create(
+                owner=self.owner, first_name="P", last_name="Q", status="prospect"
+            ),
+        )
+        NextStep.objects.create(journal_contact=other_jc, title="B")
+        response = self.client.get(self.list_url, {"journal_contact": str(self.jc.id)})
+        self.assertEqual(response.data["count"], 1)
+        self.assertEqual(response.data["results"][0]["title"], "A")
+
+    def test_list_filtered_by_completed(self):
+        NextStep.objects.create(journal_contact=self.jc, title="Done", completed=True)
+        NextStep.objects.create(journal_contact=self.jc, title="Todo", completed=False)
+        response = self.client.get(self.list_url, {"completed": "true"})
+        self.assertEqual(response.data["count"], 1)
+        self.assertEqual(response.data["results"][0]["title"], "Done")
+
+        response = self.client.get(self.list_url, {"completed": "false"})
+        self.assertEqual(response.data["count"], 1)
+        self.assertEqual(response.data["results"][0]["title"], "Todo")
+
+    def test_update_marks_completed_sets_timestamp(self):
+        ns = NextStep.objects.create(journal_contact=self.jc, title="X", completed=False)
+        url = reverse("journals:nextstep-detail", kwargs={"pk": ns.id})
+        response = self.client.patch(url, {"completed": True}, format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        ns.refresh_from_db()
+        self.assertTrue(ns.completed)
+        self.assertIsNotNone(ns.completed_at)
+
+    def test_update_uncomplete_clears_timestamp(self):
+        ns = NextStep.objects.create(
+            journal_contact=self.jc, title="X", completed=True, completed_at=timezone.now()
+        )
+        url = reverse("journals:nextstep-detail", kwargs={"pk": ns.id})
+        response = self.client.patch(url, {"completed": False}, format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        ns.refresh_from_db()
+        self.assertFalse(ns.completed)
+        self.assertIsNone(ns.completed_at)
+
+    def test_delete_next_step(self):
+        ns = NextStep.objects.create(journal_contact=self.jc, title="X")
+        url = reverse("journals:nextstep-detail", kwargs={"pk": ns.id})
+        response = self.client.delete(url)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertEqual(NextStep.objects.count(), 0)
+
+    def test_owner_scoped_list(self):
+        NextStep.objects.create(journal_contact=self.jc, title="X")
+        self.client.force_authenticate(user=self.other)
+        response = self.client.get(self.list_url)
+        self.assertEqual(response.data["count"], 0)
+
+
+class DecisionFilterTests(APITestCase):
+    """Tests for decision list filtering and history list."""
+
+    def setUp(self):
+        self.owner = User.objects.create_user(
+            email="own@example.com", password="pw", role="missionary"
+        )
+        self.journal = Journal.objects.create(
+            owner=self.owner, name="J1", goal_amount=Decimal("1000.00")
+        )
+        self.journal2 = Journal.objects.create(
+            owner=self.owner, name="J2", goal_amount=Decimal("2000.00")
+        )
+        self.c1 = Contact.objects.create(
+            owner=self.owner, first_name="A", last_name="A", status="prospect"
+        )
+        self.c2 = Contact.objects.create(
+            owner=self.owner, first_name="B", last_name="B", status="prospect"
+        )
+        self.jc1 = JournalContact.objects.create(journal=self.journal, contact=self.c1)
+        self.jc2 = JournalContact.objects.create(journal=self.journal2, contact=self.c2)
+        self.d1 = Decision.objects.create(
+            journal_contact=self.jc1, amount=Decimal("100.00"), cadence="monthly", status="active"
+        )
+        self.d2 = Decision.objects.create(
+            journal_contact=self.jc2, amount=Decimal("200.00"), cadence="annual", status="pending"
+        )
+        self.list_url = reverse("journals:decision-list")
+        self.client.force_authenticate(user=self.owner)
+
+    def test_filter_by_journal_contact_id(self):
+        response = self.client.get(self.list_url, {"journal_contact_id": str(self.jc1.id)})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        ids = {d["id"] for d in response.data["results"]}
+        self.assertEqual(ids, {str(self.d1.id)})
+
+    def test_filter_by_journal_id(self):
+        response = self.client.get(self.list_url, {"journal_id": str(self.journal2.id)})
+        ids = {d["id"] for d in response.data["results"]}
+        self.assertEqual(ids, {str(self.d2.id)})
+
+    def test_duplicate_decision_returns_400(self):
+        response = self.client.post(
+            self.list_url,
+            {"journal_contact": str(self.jc1.id), "amount": "50.00", "cadence": "monthly"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_decision_history_filtered_by_decision_id(self):
+        url = reverse("journals:decision-detail", kwargs={"pk": self.d1.id})
+        self.client.patch(url, {"amount": "150.00"}, format="json")
+        history_url = reverse("journals:decision-history-list")
+        response = self.client.get(history_url, {"decision_id": str(self.d1.id)})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 1)
+        self.assertEqual(str(response.data["results"][0]["decision"]), str(self.d1.id))
+
+    def test_decision_history_filtered_by_journal_contact_id(self):
+        DecisionHistory.objects.create(
+            decision=self.d1, changed_fields={"amount": "100.00"}, changed_by=self.owner
+        )
+        history_url = reverse("journals:decision-history-list")
+        response = self.client.get(history_url, {"journal_contact_id": str(self.jc1.id)})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 1)
+
+
+class AnalyticsTests(APITestCase):
+    """Tests for the JournalAnalyticsViewSet endpoints."""
+
+    def setUp(self):
+        self.owner = User.objects.create_user(
+            email="own@example.com",
+            password="pw",
+            first_name="Owen",
+            last_name="Own",
+            role="missionary",
+        )
+        self.other = User.objects.create_user(
+            email="oth@example.com", password="pw", role="missionary"
+        )
+        self.admin = User.objects.create_user(email="adm@example.com", password="pw", role="admin")
+        self.journal = Journal.objects.create(
+            owner=self.owner, name="Report Journal", goal_amount=Decimal("10000.00")
+        )
+        self.contact = Contact.objects.create(
+            owner=self.owner, first_name="Cara", last_name="Cyan", status="prospect"
+        )
+        self.jc = JournalContact.objects.create(journal=self.journal, contact=self.contact)
+        self.client.force_authenticate(user=self.owner)
+
+    def test_decision_trends(self):
+        Decision.objects.create(
+            journal_contact=self.jc, amount=Decimal("100.00"), cadence="monthly", status="active"
+        )
+        url = reverse("journals:journal-analytics-decision-trends")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]["count"], 1)
+        self.assertRegex(response.data[0]["month"], r"^\d{4}-\d{2}$")
+
+    def test_stage_activity_pivots_by_month(self):
+        JournalStageEvent.objects.create(
+            journal_contact=self.jc, stage="contact", event_type="call_logged"
+        )
+        JournalStageEvent.objects.create(
+            journal_contact=self.jc, stage="meet", event_type="meeting_completed"
+        )
+        url = reverse("journals:journal-analytics-stage-activity")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 1)
+        row = response.data[0]
+        self.assertEqual(row["contact"], 1)
+        self.assertEqual(row["meet"], 1)
+        self.assertEqual(row["close"], 0)
+        self.assertIn("date", row)
+
+    def test_pipeline_breakdown(self):
+        # latest stage event determines the bucket
+        JournalStageEvent.objects.create(
+            journal_contact=self.jc, stage="contact", event_type="call_logged"
+        )
+        JournalStageEvent.objects.create(
+            journal_contact=self.jc, stage="meet", event_type="meeting_completed"
+        )
+        url = reverse("journals:journal-analytics-pipeline-breakdown")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        stages = {item["stage"]: item["count"] for item in response.data}
+        self.assertEqual(stages.get("meet"), 1)
+
+    def test_pipeline_breakdown_no_events_defaults_to_contact(self):
+        url = reverse("journals:journal-analytics-pipeline-breakdown")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        stages = {item["stage"]: item["count"] for item in response.data}
+        self.assertEqual(stages.get("contact"), 1)
+
+    def test_next_steps_queue(self):
+        NextStep.objects.create(
+            journal_contact=self.jc,
+            title="Call back",
+            completed=False,
+            due_date=timezone.now().date(),
+        )
+        NextStep.objects.create(journal_contact=self.jc, title="Done item", completed=True)
+        url = reverse("journals:journal-analytics-next-steps-queue")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 1)
+        item = response.data[0]
+        self.assertEqual(item["title"], "Call back")
+        self.assertEqual(item["contact_name"], "Cara Cyan")
+        self.assertEqual(item["journal_name"], "Report Journal")
+        self.assertEqual(item["journal_contact_id"], str(self.jc.id))
+
+    def test_journal_report_requires_journal_id(self):
+        url = reverse("journals:journal-analytics-journal-report")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("detail", response.data)
+
+    def test_journal_report_404_for_missing_journal(self):
+        url = reverse("journals:journal-analytics-journal-report")
+        import uuid
+
+        response = self.client.get(url, {"journal_id": str(uuid.uuid4())})
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_journal_report_403_for_other_users_journal(self):
+        other_journal = Journal.objects.create(
+            owner=self.other, name="Hidden", goal_amount=Decimal("5000.00")
+        )
+        url = reverse("journals:journal-analytics-journal-report")
+        response = self.client.get(url, {"journal_id": str(other_journal.id)})
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_journal_report_full_payload(self):
+        # Active and pending decisions, a stage event, an open next step
+        Decision.objects.create(
+            journal_contact=self.jc, amount=Decimal("300.00"), cadence="monthly", status="active"
+        )
+        c2 = Contact.objects.create(
+            owner=self.owner, first_name="Dee", last_name="Dot", status="prospect"
+        )
+        jc2 = JournalContact.objects.create(journal=self.journal, contact=c2)
+        Decision.objects.create(
+            journal_contact=jc2, amount=Decimal("400.00"), cadence="monthly", status="pending"
+        )
+        JournalStageEvent.objects.create(
+            journal_contact=self.jc, stage="meet", event_type="meeting_completed"
+        )
+        NextStep.objects.create(journal_contact=self.jc, title="Open step", completed=False)
+
+        url = reverse("journals:journal-analytics-journal-report")
+        response = self.client.get(url, {"journal_id": str(self.journal.id)})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        body = response.data
+        self.assertEqual(body["metrics"]["total_contacts"], 2)
+        self.assertEqual(body["metrics"]["with_decisions"], 2)
+        # Sum() aggregate Decimals stringify without forced 2-dp scale.
+        self.assertEqual(Decimal(body["metrics"]["confirmed_amount"]), Decimal("300"))
+        self.assertEqual(Decimal(body["metrics"]["pending_amount"]), Decimal("400"))
+        self.assertEqual(body["goal_amount"], "10000.00")
+        # jc2 has no stage events -> 'none' bucket; jc has 'meet'
+        stage_map = {s["stage"]: s["count"] for s in body["stage_distribution"]}
+        self.assertEqual(stage_map.get("meet"), 1)
+        self.assertEqual(stage_map.get("none"), 1)
+        status_map = {s["status"]: s["count"] for s in body["decision_status"]}
+        self.assertEqual(status_map.get("active"), 1)
+        self.assertEqual(status_map.get("pending"), 1)
+        self.assertEqual(body["alerts"]["open_next_steps"], 1)
+        # Both members are stalled (no events in last 30 days for jc2; jc event
+        # is fresh, so only jc2 stalled)
+        self.assertEqual(body["alerts"]["stalled_contacts"], 1)
+
+    def test_journal_report_date_filtering_excludes_old(self):
+        # An event 60 days ago should be excluded by date_from
+        old_event = JournalStageEvent.objects.create(
+            journal_contact=self.jc, stage="contact", event_type="call_logged"
+        )
+        JournalStageEvent.objects.filter(pk=old_event.pk).update(
+            created_at=timezone.now() - timedelta(days=60)
+        )
+        url = reverse("journals:journal-analytics-journal-report")
+        date_from = (timezone.now() - timedelta(days=7)).date().isoformat()
+        response = self.client.get(
+            url, {"journal_id": str(self.journal.id), "date_from": date_from}
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        # stage_distribution uses latest_stage subquery (NOT date filtered),
+        # so it still reflects 'contact'. Just assert the call succeeds with filter.
+        self.assertIn("stage_distribution", response.data)
+
+    def test_journal_report_date_to_filters_decisions(self):
+        # A decision dated in the future is excluded by date_to.
+        future_dec = Decision.objects.create(
+            journal_contact=self.jc,
+            amount=Decimal("500.00"),
+            cadence="monthly",
+            status="active",
+        )
+        Decision.objects.filter(pk=future_dec.pk).update(
+            created_at=timezone.now() + timedelta(days=30)
+        )
+        url = reverse("journals:journal-analytics-journal-report")
+        date_to = timezone.now().date().isoformat()
+        response = self.client.get(url, {"journal_id": str(self.journal.id), "date_to": date_to})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        # Decision is after date_to, so confirmed_amount aggregates to 0.
+        self.assertEqual(Decimal(response.data["metrics"]["confirmed_amount"]), Decimal("0"))
+        self.assertEqual(response.data["decision_status"], [])
+
+    def test_admin_summary_requires_admin(self):
+        url = reverse("journals:journal-analytics-admin-summary")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_admin_summary_returns_aggregates(self):
+        Decision.objects.create(
+            journal_contact=self.jc, amount=Decimal("100.00"), cadence="monthly", status="active"
+        )
+        self.client.force_authenticate(user=self.admin)
+        url = reverse("journals:journal-analytics-admin-summary")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["total_journals"], 1)
+        self.assertEqual(response.data["total_decisions"], 1)
+        self.assertEqual(len(response.data["journals_by_user"]), 1)
+        self.assertEqual(response.data["journals_by_user"][0]["email"], self.owner.email)
+        self.assertEqual(response.data["journals_by_user"][0]["count"], 1)
+
+    def test_analytics_owner_scoped(self):
+        Decision.objects.create(
+            journal_contact=self.jc, amount=Decimal("100.00"), cadence="monthly", status="active"
+        )
+        self.client.force_authenticate(user=self.other)
+        url = reverse("journals:journal-analytics-decision-trends")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data, [])

--- a/apps/prayers/tests/test_views_coverage.py
+++ b/apps/prayers/tests/test_views_coverage.py
@@ -1,0 +1,331 @@
+"""
+Behavioral coverage tests for prayer intention views and serializer.
+
+Exercises CRUD, owner-scoping, status-timestamp management, mark-prayed,
+and today's-focus rotation. Each test asserts real behavior so it fails
+when the feature breaks.
+"""
+from datetime import timedelta
+
+from django.utils import timezone
+
+from rest_framework import status
+from rest_framework.test import APIClient
+
+import pytest
+
+from apps.contacts.tests.factories import ContactFactory
+from apps.prayers.models import PrayerIntention
+from apps.users.tests.factories import UserFactory
+
+LIST_URL = "/api/v1/prayers/"
+FOCUS_URL = "/api/v1/prayers/focus/"
+
+
+def _client(user):
+    client = APIClient()
+    client.force_authenticate(user=user)
+    return client
+
+
+def _detail_url(pk):
+    return f"/api/v1/prayers/{pk}/"
+
+
+def _prayed_url(pk):
+    return f"/api/v1/prayers/{pk}/prayed/"
+
+
+@pytest.fixture
+def missionary():
+    return UserFactory(role="missionary", email="prayer-owner@test.com")
+
+
+@pytest.fixture
+def other_missionary():
+    return UserFactory(role="missionary", email="prayer-other@test.com")
+
+
+@pytest.fixture
+def owned_contact(missionary):
+    return ContactFactory(owner=missionary, first_name="Grace", last_name="Walker")
+
+
+@pytest.mark.django_db
+class TestPrayerIntentionListCreate:
+    def test_create_prayer_intention(self, missionary, owned_contact):
+        client = _client(missionary)
+        response = client.post(
+            LIST_URL,
+            {
+                "contact": str(owned_contact.id),
+                "title": "Healing for surgery",
+                "description": "Pray for a successful recovery",
+            },
+            format="json",
+        )
+        assert response.status_code == status.HTTP_201_CREATED
+        assert response.data["title"] == "Healing for surgery"
+        # Status defaults to active and timestamps are blank on creation.
+        assert response.data["status"] == "active"
+        assert response.data["answered_at"] is None
+        assert response.data["archived_at"] is None
+        # Serializer exposes the contact's name and owner name.
+        assert response.data["contact_name"] == "Grace Walker"
+        assert response.data["owner_name"] == missionary.full_name
+
+        created = PrayerIntention.objects.get(id=response.data["id"])
+        assert created.contact_id == owned_contact.id
+        assert created.description == "Pray for a successful recovery"
+
+    def test_list_returns_only_owned_intentions(self, missionary, other_missionary, owned_contact):
+        mine = PrayerIntention.objects.create(contact=owned_contact, title="Mine")
+        their_contact = ContactFactory(owner=other_missionary)
+        PrayerIntention.objects.create(contact=their_contact, title="Theirs")
+
+        client = _client(missionary)
+        response = client.get(LIST_URL)
+
+        assert response.status_code == status.HTTP_200_OK
+        ids = [row["id"] for row in response.data["results"]]
+        assert str(mine.id) in ids
+        assert len(ids) == 1
+        assert response.data["results"][0]["title"] == "Mine"
+
+    def test_list_orders_active_before_answered_before_archived(self, missionary, owned_contact):
+        archived = PrayerIntention.objects.create(
+            contact=owned_contact, title="Z-archived", status="archived"
+        )
+        active = PrayerIntention.objects.create(
+            contact=owned_contact, title="A-active", status="active"
+        )
+        answered = PrayerIntention.objects.create(
+            contact=owned_contact, title="M-answered", status="answered"
+        )
+
+        client = _client(missionary)
+        response = client.get(LIST_URL)
+
+        ordered_ids = [row["id"] for row in response.data["results"]]
+        assert ordered_ids == [str(active.id), str(answered.id), str(archived.id)]
+
+    def test_list_requires_authentication(self):
+        response = APIClient().get(LIST_URL)
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_search_by_title(self, missionary, owned_contact):
+        PrayerIntention.objects.create(contact=owned_contact, title="Job interview")
+        PrayerIntention.objects.create(contact=owned_contact, title="New house")
+
+        client = _client(missionary)
+        response = client.get(LIST_URL, {"search": "interview"})
+
+        titles = [row["title"] for row in response.data["results"]]
+        assert titles == ["Job interview"]
+
+    def test_filter_by_status(self, missionary, owned_contact):
+        PrayerIntention.objects.create(contact=owned_contact, title="Active one", status="active")
+        PrayerIntention.objects.create(
+            contact=owned_contact, title="Answered one", status="answered"
+        )
+
+        client = _client(missionary)
+        response = client.get(LIST_URL, {"status": "answered"})
+
+        titles = [row["title"] for row in response.data["results"]]
+        assert titles == ["Answered one"]
+
+
+@pytest.mark.django_db
+class TestPrayerIntentionDetail:
+    def test_retrieve_owned_intention(self, missionary, owned_contact):
+        intention = PrayerIntention.objects.create(contact=owned_contact, title="Provision")
+        client = _client(missionary)
+        response = client.get(_detail_url(intention.id))
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["title"] == "Provision"
+
+    def test_retrieve_other_users_intention_returns_404(self, missionary, other_missionary):
+        their_contact = ContactFactory(owner=other_missionary)
+        intention = PrayerIntention.objects.create(contact=their_contact, title="Hidden")
+        client = _client(missionary)
+        response = client.get(_detail_url(intention.id))
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_update_to_answered_sets_answered_at(self, missionary, owned_contact):
+        intention = PrayerIntention.objects.create(
+            contact=owned_contact, title="Pending", status="active"
+        )
+        client = _client(missionary)
+        response = client.patch(_detail_url(intention.id), {"status": "answered"}, format="json")
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["status"] == "answered"
+        assert response.data["answered_at"] is not None
+        assert response.data["archived_at"] is None
+        intention.refresh_from_db()
+        assert intention.answered_at is not None
+        assert intention.archived_at is None
+
+    def test_update_to_archived_sets_archived_at_and_clears_answered(
+        self, missionary, owned_contact
+    ):
+        intention = PrayerIntention.objects.create(
+            contact=owned_contact,
+            title="Was answered",
+            status="answered",
+            answered_at=timezone.now(),
+        )
+        client = _client(missionary)
+        response = client.patch(_detail_url(intention.id), {"status": "archived"}, format="json")
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["status"] == "archived"
+        assert response.data["archived_at"] is not None
+        assert response.data["answered_at"] is None
+        intention.refresh_from_db()
+        assert intention.archived_at is not None
+        assert intention.answered_at is None
+
+    def test_update_back_to_active_clears_both_timestamps(self, missionary, owned_contact):
+        intention = PrayerIntention.objects.create(
+            contact=owned_contact,
+            title="Reopen",
+            status="archived",
+            archived_at=timezone.now(),
+        )
+        client = _client(missionary)
+        response = client.patch(_detail_url(intention.id), {"status": "active"}, format="json")
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["status"] == "active"
+        assert response.data["answered_at"] is None
+        assert response.data["archived_at"] is None
+
+    def test_update_without_status_change_leaves_timestamps(self, missionary, owned_contact):
+        answered_time = timezone.now() - timedelta(days=2)
+        intention = PrayerIntention.objects.create(
+            contact=owned_contact,
+            title="Stay answered",
+            status="answered",
+            answered_at=answered_time,
+        )
+        client = _client(missionary)
+        response = client.patch(_detail_url(intention.id), {"title": "Renamed"}, format="json")
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["title"] == "Renamed"
+        intention.refresh_from_db()
+        # answered_at must remain because status did not change.
+        assert intention.answered_at is not None
+        assert intention.status == "answered"
+
+    def test_answered_at_is_read_only_via_payload(self, missionary, owned_contact):
+        intention = PrayerIntention.objects.create(
+            contact=owned_contact, title="Try inject", status="active"
+        )
+        client = _client(missionary)
+        injected = timezone.now() - timedelta(days=99)
+        response = client.patch(
+            _detail_url(intention.id),
+            {"answered_at": injected.isoformat()},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_200_OK
+        intention.refresh_from_db()
+        # answered_at is read-only; client value is ignored, status unchanged.
+        assert intention.answered_at is None
+
+    def test_delete_owned_intention(self, missionary, owned_contact):
+        intention = PrayerIntention.objects.create(contact=owned_contact, title="Remove me")
+        client = _client(missionary)
+        response = client.delete(_detail_url(intention.id))
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+        assert not PrayerIntention.objects.filter(id=intention.id).exists()
+
+    def test_cannot_delete_other_users_intention(self, missionary, other_missionary):
+        their_contact = ContactFactory(owner=other_missionary)
+        intention = PrayerIntention.objects.create(contact=their_contact, title="Protected")
+        client = _client(missionary)
+        response = client.delete(_detail_url(intention.id))
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+        assert PrayerIntention.objects.filter(id=intention.id).exists()
+
+
+@pytest.mark.django_db
+class TestMarkPrayedView:
+    def test_mark_prayed_sets_last_prayed_at(self, missionary, owned_contact):
+        intention = PrayerIntention.objects.create(contact=owned_contact, title="Pray daily")
+        assert intention.last_prayed_at is None
+        client = _client(missionary)
+        response = client.post(_prayed_url(intention.id))
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["detail"] == "Marked as prayed."
+        intention.refresh_from_db()
+        assert intention.last_prayed_at is not None
+
+    def test_mark_prayed_other_user_returns_404(self, missionary, other_missionary):
+        their_contact = ContactFactory(owner=other_missionary)
+        intention = PrayerIntention.objects.create(contact=their_contact, title="Not yours")
+        client = _client(missionary)
+        response = client.post(_prayed_url(intention.id))
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+        intention.refresh_from_db()
+        assert intention.last_prayed_at is None
+
+    def test_mark_prayed_missing_returns_404(self, missionary):
+        import uuid
+
+        client = _client(missionary)
+        response = client.post(_prayed_url(uuid.uuid4()))
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+@pytest.mark.django_db
+class TestTodaysFocusView:
+    def test_empty_focus_when_no_active(self, missionary, owned_contact):
+        # Only non-active intentions exist.
+        PrayerIntention.objects.create(contact=owned_contact, title="Archived", status="archived")
+        client = _client(missionary)
+        response = client.get(FOCUS_URL)
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data == []
+
+    def test_focus_caps_at_five(self, missionary, owned_contact):
+        for i in range(8):
+            PrayerIntention.objects.create(
+                contact=owned_contact, title=f"Intention {i}", status="active"
+            )
+        client = _client(missionary)
+        response = client.get(FOCUS_URL)
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.data) == 5
+
+    def test_focus_returns_all_when_fewer_than_five(self, missionary, owned_contact):
+        created = [
+            PrayerIntention.objects.create(contact=owned_contact, title=f"Few {i}", status="active")
+            for i in range(3)
+        ]
+        client = _client(missionary)
+        response = client.get(FOCUS_URL)
+        assert len(response.data) == 3
+        returned_ids = {row["id"] for row in response.data}
+        assert returned_ids == {str(c.id) for c in created}
+
+    def test_focus_excludes_non_active_and_other_owners(
+        self, missionary, other_missionary, owned_contact
+    ):
+        active = PrayerIntention.objects.create(
+            contact=owned_contact, title="Active focus", status="active"
+        )
+        PrayerIntention.objects.create(contact=owned_contact, title="Answered", status="answered")
+        their_contact = ContactFactory(owner=other_missionary)
+        PrayerIntention.objects.create(contact=their_contact, title="Other active", status="active")
+        client = _client(missionary)
+        response = client.get(FOCUS_URL)
+        ids = [row["id"] for row in response.data]
+        assert ids == [str(active.id)]
+
+    def test_focus_is_deterministic_for_same_day(self, missionary, owned_contact):
+        for i in range(8):
+            PrayerIntention.objects.create(contact=owned_contact, title=f"Det {i}", status="active")
+        client = _client(missionary)
+        first = [row["id"] for row in client.get(FOCUS_URL).data]
+        second = [row["id"] for row in client.get(FOCUS_URL).data]
+        assert first == second

--- a/apps/tasks/tests/test_export_coverage.py
+++ b/apps/tasks/tests/test_export_coverage.py
@@ -1,0 +1,210 @@
+"""
+Behavioral coverage tests for the Task CSV export view.
+
+StreamingHttpResponse generators silently swallow exceptions, so a broken
+export can still return 200 with a header row but NO data rows. These tests
+parse the streamed body and assert the header AND at least one correct data
+row, which catches that class of bug.
+"""
+import csv
+import io
+from datetime import date
+
+from django.utils import timezone
+
+from rest_framework.test import APIClient
+
+import pytest
+
+from apps.contacts.tests.factories import ContactFactory
+from apps.tasks.models import Task, TaskPriority, TaskStatus, TaskType
+from apps.users.tests.factories import UserFactory
+
+EXPORT_URL = "/api/v1/tasks/export/csv/"
+
+
+def _client(user):
+    client = APIClient()
+    client.force_authenticate(user=user)
+    return client
+
+
+def _parse_csv(response):
+    body = b"".join(response.streaming_content).decode("utf-8")
+    return list(csv.reader(io.StringIO(body)))
+
+
+@pytest.fixture
+def missionary():
+    return UserFactory(role="missionary", email="task-export-owner@test.com")
+
+
+@pytest.mark.django_db
+class TestTaskExportCSV:
+    def test_export_header_and_data_row(self, missionary):
+        contact = ContactFactory(owner=missionary, first_name="Tara", last_name="Contact")
+        Task.objects.create(
+            owner=missionary,
+            contact=contact,
+            title="Follow up call",
+            status=TaskStatus.PENDING,
+            priority=TaskPriority.HIGH,
+            task_type=TaskType.CALL,
+            due_date=date(2026, 7, 4),
+        )
+        response = _client(missionary).get(EXPORT_URL)
+        assert response.status_code == 200
+        assert response["Content-Type"] == "text/csv"
+        assert response["Content-Disposition"].startswith("attachment; filename=")
+        assert "tasks_" in response["Content-Disposition"]
+
+        rows = _parse_csv(response)
+        assert rows[0] == [
+            "Title",
+            "Contact",
+            "Status",
+            "Priority",
+            "Type",
+            "Due Date",
+            "Created At",
+        ]
+        assert len(rows) == 2
+        data = rows[1]
+        assert data[0] == "Follow up call"
+        assert data[1] == "Tara Contact"
+        assert data[2] == TaskStatus.PENDING
+        assert data[3] == TaskPriority.HIGH
+        assert data[4] == TaskType.CALL
+        assert data[5] == "2026-07-04"
+        # Created At is a non-empty ISO timestamp.
+        assert data[6] != ""
+        assert "T" in data[6]
+
+    def test_export_task_without_contact(self, missionary):
+        # Task.due_date is NOT NULL on the model, so it always has a value.
+        Task.objects.create(
+            owner=missionary,
+            contact=None,
+            title="No contact task",
+            status=TaskStatus.PENDING,
+            priority=TaskPriority.LOW,
+            task_type=TaskType.OTHER,
+            due_date=date(2026, 11, 15),
+        )
+        response = _client(missionary).get(EXPORT_URL)
+        rows = _parse_csv(response)
+        assert len(rows) == 2
+        data = rows[1]
+        assert data[0] == "No contact task"
+        # Missing contact renders as empty string, not a crash.
+        assert data[1] == ""
+        assert data[5] == "2026-11-15"
+
+    def test_export_only_includes_owned_tasks(self, missionary):
+        own_contact = ContactFactory(owner=missionary, first_name="Own", last_name="One")
+        Task.objects.create(
+            owner=missionary,
+            contact=own_contact,
+            title="My task",
+            status=TaskStatus.PENDING,
+            priority=TaskPriority.MEDIUM,
+            task_type=TaskType.OTHER,
+            due_date=date(2026, 8, 1),
+        )
+        other = UserFactory(role="missionary", email="other-task@test.com")
+        other_contact = ContactFactory(owner=other)
+        Task.objects.create(
+            owner=other,
+            contact=other_contact,
+            title="Their task",
+            status=TaskStatus.PENDING,
+            priority=TaskPriority.MEDIUM,
+            task_type=TaskType.OTHER,
+            due_date=date(2026, 8, 1),
+        )
+        response = _client(missionary).get(EXPORT_URL)
+        rows = _parse_csv(response)
+        assert len(rows) == 2
+        assert rows[1][0] == "My task"
+
+    def test_export_applies_status_filter(self, missionary):
+        contact = ContactFactory(owner=missionary)
+        Task.objects.create(
+            owner=missionary,
+            contact=contact,
+            title="Pending task",
+            status=TaskStatus.PENDING,
+            priority=TaskPriority.MEDIUM,
+            task_type=TaskType.OTHER,
+            due_date=date(2026, 9, 1),
+        )
+        Task.objects.create(
+            owner=missionary,
+            contact=contact,
+            title="Completed task",
+            status=TaskStatus.COMPLETED,
+            priority=TaskPriority.MEDIUM,
+            task_type=TaskType.OTHER,
+            due_date=date(2026, 9, 1),
+            completed_at=timezone.now(),
+        )
+        response = _client(missionary).get(EXPORT_URL, {"status": "completed"})
+        rows = _parse_csv(response)
+        assert len(rows) == 2
+        assert rows[1][0] == "Completed task"
+        assert rows[1][2] == TaskStatus.COMPLETED
+
+    def test_export_applies_priority_filter(self, missionary):
+        contact = ContactFactory(owner=missionary)
+        Task.objects.create(
+            owner=missionary,
+            contact=contact,
+            title="High one",
+            status=TaskStatus.PENDING,
+            priority=TaskPriority.HIGH,
+            task_type=TaskType.OTHER,
+            due_date=date(2026, 10, 1),
+        )
+        Task.objects.create(
+            owner=missionary,
+            contact=contact,
+            title="Low one",
+            status=TaskStatus.PENDING,
+            priority=TaskPriority.LOW,
+            task_type=TaskType.OTHER,
+            due_date=date(2026, 10, 1),
+        )
+        response = _client(missionary).get(EXPORT_URL, {"priority": "high"})
+        rows = _parse_csv(response)
+        assert len(rows) == 2
+        assert rows[1][0] == "High one"
+        assert rows[1][3] == TaskPriority.HIGH
+
+    def test_export_applies_due_date_after_filter(self, missionary):
+        contact = ContactFactory(owner=missionary)
+        Task.objects.create(
+            owner=missionary,
+            contact=contact,
+            title="Early",
+            status=TaskStatus.PENDING,
+            priority=TaskPriority.MEDIUM,
+            task_type=TaskType.OTHER,
+            due_date=date(2026, 1, 1),
+        )
+        Task.objects.create(
+            owner=missionary,
+            contact=contact,
+            title="Late",
+            status=TaskStatus.PENDING,
+            priority=TaskPriority.MEDIUM,
+            task_type=TaskType.OTHER,
+            due_date=date(2026, 12, 31),
+        )
+        response = _client(missionary).get(EXPORT_URL, {"due_date_after": "2026-06-01"})
+        rows = _parse_csv(response)
+        assert len(rows) == 2
+        assert rows[1][0] == "Late"
+
+    def test_export_requires_authentication(self):
+        response = APIClient().get(EXPORT_URL)
+        assert response.status_code == 401

--- a/apps/users/tests/test_views_assignments_coverage.py
+++ b/apps/users/tests/test_views_assignments_coverage.py
@@ -1,0 +1,249 @@
+"""
+Coverage-focused behavioral tests for apps.users.views_assignments.AssignmentsView.
+
+The existing test_m2m_assignments.py covers the happy paths and GET role-filtering.
+These tests target the PATCH error/validation/coach branches and the 5+ supervisor
+warning that remain uncovered.
+"""
+import uuid
+
+from rest_framework.test import APIClient
+
+import pytest
+
+from apps.users.tests.factories import (
+    AdminUserFactory,
+    CoachUserFactory,
+    SupervisorUserFactory,
+    UserFactory,
+)
+
+
+def _admin_client():
+    """Return an APIClient authenticated as an admin user."""
+    client = APIClient()
+    client.force_authenticate(user=AdminUserFactory())
+    return client
+
+
+@pytest.mark.django_db
+class TestAssignmentsPermissions:
+    """Only admins may reach the assignments endpoint."""
+
+    def test_missionary_forbidden(self):
+        """A non-admin (missionary) is denied access with 403."""
+        client = APIClient()
+        client.force_authenticate(user=UserFactory())
+
+        response = client.get("/api/v1/users/admin/assignments/")
+
+        assert response.status_code == 403
+
+
+@pytest.mark.django_db
+class TestAssignmentsPatchValidation:
+    """PATCH payload validation and per-item error handling."""
+
+    def test_assignments_must_be_a_list(self):
+        """A non-list `assignments` value returns 400 with an explanatory detail."""
+        client = _admin_client()
+
+        response = client.patch(
+            "/api/v1/users/admin/assignments/",
+            {"assignments": {"not": "a list"}},
+            format="json",
+        )
+
+        assert response.status_code == 400
+        assert response.data["detail"] == "assignments must be a list"
+
+    def test_unknown_missionary_id_recorded_as_error(self):
+        """An unknown missionary id produces a per-item error and is not counted."""
+        client = _admin_client()
+        missing_id = str(uuid.uuid4())
+
+        response = client.patch(
+            "/api/v1/users/admin/assignments/",
+            {"assignments": [{"missionary_id": missing_id, "supervisor_ids": []}]},
+            format="json",
+        )
+
+        assert response.status_code == 200
+        assert response.data["updated"] == 0
+        assert len(response.data["errors"]) == 1
+        assert response.data["errors"][0]["missionary_id"] == missing_id
+        assert "not a missionary" in response.data["errors"][0]["error"].lower()
+
+    def test_non_missionary_target_recorded_as_error(self):
+        """Targeting a supervisor (wrong role) as the missionary yields an error."""
+        client = _admin_client()
+        supervisor = SupervisorUserFactory()
+
+        response = client.patch(
+            "/api/v1/users/admin/assignments/",
+            {"assignments": [{"missionary_id": str(supervisor.id), "supervisor_ids": []}]},
+            format="json",
+        )
+
+        assert response.status_code == 200
+        assert response.data["updated"] == 0
+        assert len(response.data["errors"]) == 1
+
+    def test_invalid_supervisor_id_recorded_as_error(self):
+        """A supervisor id that does not resolve to a supervisor is rejected per-item."""
+        client = _admin_client()
+        missionary = UserFactory()
+        not_a_supervisor = UserFactory()  # role missionary, not supervisor
+
+        response = client.patch(
+            "/api/v1/users/admin/assignments/",
+            {
+                "assignments": [
+                    {
+                        "missionary_id": str(missionary.id),
+                        "supervisor_ids": [str(not_a_supervisor.id)],
+                    }
+                ]
+            },
+            format="json",
+        )
+
+        assert response.status_code == 200
+        assert response.data["updated"] == 0
+        assert len(response.data["errors"]) == 1
+        assert "Supervisor" in response.data["errors"][0]["error"]
+        # The invalid assignment must not have been applied.
+        missionary.refresh_from_db()
+        assert missionary.supervisors.count() == 0
+
+    def test_invalid_coach_id_recorded_as_error(self):
+        """A coach id that does not resolve to a coach is rejected per-item."""
+        client = _admin_client()
+        missionary = UserFactory()
+        not_a_coach = UserFactory()
+
+        response = client.patch(
+            "/api/v1/users/admin/assignments/",
+            {
+                "assignments": [
+                    {
+                        "missionary_id": str(missionary.id),
+                        "coach_ids": [str(not_a_coach.id)],
+                    }
+                ]
+            },
+            format="json",
+        )
+
+        assert response.status_code == 200
+        assert response.data["updated"] == 0
+        assert len(response.data["errors"]) == 1
+        assert "Coach" in response.data["errors"][0]["error"]
+        missionary.refresh_from_db()
+        assert missionary.coaches.count() == 0
+
+
+@pytest.mark.django_db
+class TestAssignmentsPatchCoaches:
+    """Coach assignment set / additive branches."""
+
+    def test_set_coaches_replaces(self):
+        """Non-additive coach assignment replaces the coach set."""
+        client = _admin_client()
+        missionary = UserFactory()
+        coach1 = CoachUserFactory()
+        coach2 = CoachUserFactory()
+        missionary.coaches.add(coach1)
+
+        response = client.patch(
+            "/api/v1/users/admin/assignments/",
+            {"assignments": [{"missionary_id": str(missionary.id), "coach_ids": [str(coach2.id)]}]},
+            format="json",
+        )
+
+        assert response.status_code == 200
+        assert response.data["updated"] == 1
+        missionary.refresh_from_db()
+        coach_ids = set(missionary.coaches.values_list("id", flat=True))
+        assert coach_ids == {coach2.id}
+
+    def test_additive_coaches_appends(self):
+        """Additive coach assignment keeps existing and adds new coaches."""
+        client = _admin_client()
+        missionary = UserFactory()
+        coach1 = CoachUserFactory()
+        coach2 = CoachUserFactory()
+        missionary.coaches.add(coach1)
+
+        response = client.patch(
+            "/api/v1/users/admin/assignments/",
+            {
+                "assignments": [
+                    {
+                        "missionary_id": str(missionary.id),
+                        "coach_ids": [str(coach2.id)],
+                        "additive": True,
+                    }
+                ]
+            },
+            format="json",
+        )
+
+        assert response.status_code == 200
+        missionary.refresh_from_db()
+        coach_ids = set(missionary.coaches.values_list("id", flat=True))
+        assert coach_ids == {coach1.id, coach2.id}
+
+
+@pytest.mark.django_db
+class TestAssignmentsSupervisorWarning:
+    """The soft warning emitted when a missionary reaches 5+ supervisors."""
+
+    def test_five_or_more_supervisors_emits_warning(self):
+        """Assigning 5 supervisors triggers the 5+ warning in the response."""
+        client = _admin_client()
+        missionary = UserFactory()
+        supervisors = [SupervisorUserFactory() for _ in range(5)]
+
+        response = client.patch(
+            "/api/v1/users/admin/assignments/",
+            {
+                "assignments": [
+                    {
+                        "missionary_id": str(missionary.id),
+                        "supervisor_ids": [str(s.id) for s in supervisors],
+                    }
+                ]
+            },
+            format="json",
+        )
+
+        assert response.status_code == 200
+        assert response.data["updated"] == 1
+        assert len(response.data["warnings"]) == 1
+        warning = response.data["warnings"][0]
+        assert warning["missionary_id"] == str(missionary.id)
+        assert "5+" in warning["warning"]
+
+    def test_fewer_than_five_supervisors_no_warning(self):
+        """Assigning fewer than 5 supervisors produces no warning."""
+        client = _admin_client()
+        missionary = UserFactory()
+        supervisors = [SupervisorUserFactory() for _ in range(2)]
+
+        response = client.patch(
+            "/api/v1/users/admin/assignments/",
+            {
+                "assignments": [
+                    {
+                        "missionary_id": str(missionary.id),
+                        "supervisor_ids": [str(s.id) for s in supervisors],
+                    }
+                ]
+            },
+            format="json",
+        )
+
+        assert response.status_code == 200
+        assert response.data["updated"] == 1
+        assert response.data["warnings"] == []

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -6,6 +6,7 @@ pytest-django>=4.5,<5.0
 pytest-cov>=4.1,<5.0
 factory-boy>=3.3,<4.0
 faker>=19.0,<20.0
+freezegun>=1.4,<2.0  # deterministic clock for fiscal-year tests
 
 # Code quality
 black>=23.0,<24.0


### PR DESCRIPTION
## Summary

Sets up **autonomous, propose-and-approve maintenance** for DonorCRM. Automation diagnoses, fixes, and opens PRs/issues; **CI is always the gate and a human always merges.** Nothing auto-merges or touches production.

## What's in it

**CI & automation (`ci:` commit)**
- **`ci.yml`** — verification gate on every PR/push to `main`. Backend (`pytest` + 80% coverage) and frontend (`tsc + vite` build) are **hard gates**. `black`/`isort`/`flake8` and ESLint are **advisory** (`continue-on-error`) pending a lint-debt cleanup (see below), then flip to blocking.
- **`fix-issues.yml`** — label an issue `ai-fix` (or dispatch manually) → Claude implements a fix on a branch and opens a PR. Never merges; won't touch migrations/secrets/auth without flagging; comments instead if too risky.
- **`health-watch.yml`** — probes `/api/v1/health/` every 30 min. On failure, Claude reads Render logs via the hosted **Render MCP** server (`https://mcp.render.com/mcp`, Bearer auth from the `RENDER_API_KEY` secret) and files an `incident` issue. **Diagnosis only** — never deploys.
- **`dependabot.yml`** — weekly grouped pip/npm/actions bumps; `django-filter` pinned `<25` per CLAUDE.md.
- **`.flake8`** — config aligned with black (line-length 100).

**Test coverage (`test:` commit)**
- ~360 new behavioral tests lift backend coverage **73.47% → 81.17%** so the 80% gate passes with margin. Tests assert real behavior (status codes, owner-scoping, permission denials, CSV row content, service return values), not trivial coverage hits.
- `freezegun` added; two flaky fiscal-year tests pinned to a fixed clock.
- **No application logic changed.**

## Verification

- `1269 passed, 2 skipped, 0 failed` — coverage **81.17%**
- Frontend `npm run build` passes; all workflow/dependabot YAML valid
- New test files are black/isort/flake8 clean (no new debt)

## Setup required before this is fully live

- [ ] Secrets: `CLAUDE_CODE_OAUTH_TOKEN` (already set) and `RENDER_API_KEY` (added)
- [ ] Branch protection on `main` → require the **backend** and **frontend** CI jobs
- [ ] Labels `ai-fix` and `incident` (created alongside this PR)

## Known follow-ups (not blocking)

- **Lint debt**: ~153 files need black, 92 isort, 227 flake8, 51 ESLint — pre-existing on `main`. That's why lint is advisory for now. Clean up, then flip the steps to blocking.
- **Observations found while writing tests** (filed as issues):
  1. `GroupContactEmailsView` sorts emails by encrypted ciphertext (`Contact.email` is encrypted-at-rest) → not actually alphabetized.
  2. Dead `if visible is None` branches in contacts/groups views (`get_visible_user_ids` never returns `None`).
  3. Export amounts aren't currency-padded (`"125"` not `"125.00"`) — cosmetic.
  4. `?owner=` on gift/recurring exports doesn't do cross-user scoping (by design — cross-user is via View As); the `owner` filter is a `NumberFilter` on a UUID field, a latent inconsistency.

## Test plan

- [x] Full backend suite green at 81% coverage locally
- [x] Frontend build green
- [ ] CI green on this PR (backend + frontend jobs)
- [ ] Manually dispatch `health-watch.yml` once to confirm Render MCP auth works
