### PR TITLE
ci: auto-merge Dependabot patch/minor PRs through the gate

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,38 @@
+name: Dependabot auto-merge
+
+# Auto-merges Dependabot PATCH and MINOR bumps once the required CI checks pass.
+# MAJOR bumps are intentionally left for human review — a green build can't rule
+# out breaking runtime changes. This replaces the unreliable `@dependabot merge`
+# comment command and respects branch protection: GitHub auto-merge only
+# completes when the required `backend`/`frontend` checks are green AND the
+# branch is up to date (Dependabot rebases as the base moves), so no admin
+# bypass is needed. Requires "Allow auto-merge" enabled on the repo.
+
+on: pull_request
+
+# The default workflow token is read-only; grant just what auto-merge needs.
+permissions:
+  contents: write # complete the merge
+  pull-requests: write # set the auto-merge state on the PR
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    # Only Dependabot PRs on this repo (the repo guard prevents forks from running it).
+    if: >
+      github.event.pull_request.user.login == 'dependabot[bot]' &&
+      github.repository == 'matkukla/DonorCRM'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+
+      - name: Enable auto-merge for patch & minor updates
+        # Majors are excluded on purpose — they wait for a human reviewer.
+        if: >
+          steps.meta.outputs.update-type == 'version-update:semver-patch' ||
+          steps.meta.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What

Adds a **Dependabot auto-merge** workflow + enables "Allow auto-merge" on the repo.

When Dependabot opens a **patch** or **minor** bump, GitHub auto-merge is enabled and the PR merges automatically **once the required `backend`/`frontend` checks pass and the branch is up to date** (Dependabot rebases as the base moves). **Major** bumps are intentionally excluded — they wait for a human, since a green build can't rule out breaking runtime changes.

## Why

The manual `@dependabot merge` command was unresponsive (no reaction), and the repo had `allow_auto_merge: false`, so the recent safe batch had to be merged with `--admin` (bypassing the up-to-date freshness rule). This makes safe bumps flow through the gate automatically — no bypass, no manual commands.

## How it respects the gate

- Uses GitHub auto-merge, which **only completes when required checks are green + branch up to date** — strict branch protection stays intact.
- Least-privilege: default workflow token stays read-only; this workflow grants `contents`/`pull-requests: write` only to itself.
- Repo-guarded `if` (`github.repository == 'matkukla/DonorCRM'`) so forks can't run it.

## Test plan

- [x] YAML valid; `backend`/`frontend` CI green on this PR
- [ ] After merge: next Dependabot patch/minor PR auto-merges once CI passes
- [ ] Next Dependabot **major** PR is NOT auto-merged (stays open for review)
