### PR TITLE
ci: fix claude-review on bot PRs (skip Dependabot, allow ai-fix)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,11 +12,11 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    # Skip Dependabot PRs: their pull_request runs can't access secrets (so the
+    # review can't authenticate) and reviewing a version bump adds little. The
+    # dependabot-auto-merge workflow + CI gate already cover those; a human can
+    # still @claude on a major bump for an on-demand review.
+    if: github.event.pull_request.user.login != 'dependabot[bot]'
 
     runs-on: ubuntu-latest
     permissions:
@@ -39,7 +39,10 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
-          allowed_bots: 'dependabot'
+          # Allow the ai-fix pipeline's PRs (authored by the Claude GitHub App,
+          # claude[bot]) to be reviewed — the review half of propose-and-approve.
+          # Human PRs are always reviewed; Dependabot is skipped via the job `if`.
+          allowed_bots: 'claude[bot]'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 


### PR DESCRIPTION
## What

Fixes `claude-review` failing on **every bot-authored PR**.

## Root cause (two distinct bugs)

1. **Dependabot PRs** — `pull_request` runs triggered by Dependabot get a read-only token with **no access to secrets**, so `CLAUDE_CODE_OAUTH_TOKEN` is empty and the action can't authenticate. (Reviewing a version-bump diff is also low value.)
2. **ai-fix PRs** — authored by the Claude GitHub App (`claude[bot]`). The action's bot guard rejected them because `allowed_bots` was empty (then `'dependabot'`), which doesn't include `claude[bot]`.

## Fix

- **Skip Dependabot** via a job-level `if` → the check no longer runs (and no longer fails) on those PRs. The `dependabot-auto-merge` workflow + CI gate already cover them; a human can `@claude` on a major bump for an on-demand review.
- **`allowed_bots: 'claude[bot]'`** → the review now runs on ai-fix PRs, restoring the **review half** of the propose-and-approve loop where it matters most.
- Human PRs were and remain reviewed.

## Test plan

- [x] YAML valid; `backend`/`frontend` CI green
- [ ] **`claude-review` passes on this (human) PR** — confirms the workflow still works
- [ ] After merge: trigger an ai-fix PR and confirm `claude-review` runs + passes on it (the real fix)
- [ ] A Dependabot PR shows `claude-review` as skipped, not failed
