### PR TITLE
style: clear backend lint debt + make black/isort/flake8 blocking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,21 +31,15 @@ jobs:
         # not required; dev.txt pulls in base.txt + pytest/black/isort/flake8.
         run: pip install -r requirements/dev.txt
 
-      # Lint is ADVISORY until the pre-existing formatting/lint debt is cleaned
-      # up (black would reformat ~153 files, plus isort/flake8 backlog). These
-      # steps surface violations without failing the build so the gate can land
-      # now. Cleanup tracked separately; flip continue-on-error off once green.
+      # HARD gates: the backend lint debt was cleaned up, so these now block.
       - name: black
         run: black --check apps/ config/
-        continue-on-error: true
 
       - name: isort
         run: isort --check-only apps/ config/
-        continue-on-error: true
 
       - name: flake8
         run: flake8 apps/ config/
-        continue-on-error: true
 
       # HARD gate: tests + 80% coverage must pass.
       - name: pytest (80% coverage gate)
@@ -72,8 +66,11 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      # Advisory, same as the backend linters: ESLint has a pre-existing
-      # backlog (~51 errors). Surfaces issues without failing the build.
+      # Still ADVISORY: ESLint has ~51 pre-existing errors, many from strict
+      # react-hooks rules (conditional hook calls, set-state-in-effect) that
+      # need careful per-component refactoring. The frontend has no unit-test
+      # net, so forcing these blind risks regressions — tracked as a separate,
+      # app-verified effort before this becomes a hard gate.
       - name: ESLint
         run: npm run lint
         continue-on-error: true

--- a/apps/contacts/admin.py
+++ b/apps/contacts/admin.py
@@ -9,45 +9,56 @@ from apps.contacts.models import Contact
 @admin.register(Contact)
 class ContactAdmin(admin.ModelAdmin):
     list_display = (
-        'full_name', 'email', 'owner', 'status',
-        'total_given', 'gift_count', 'last_gift_date', 'needs_thank_you'
+        "full_name",
+        "email",
+        "owner",
+        "status",
+        "total_given",
+        "gift_count",
+        "last_gift_date",
+        "needs_thank_you",
     )
-    list_filter = ('status', 'owner', 'needs_thank_you', 'created_at')
-    search_fields = ('first_name', 'last_name', 'email', 'phone')
-    ordering = ('last_name', 'first_name')
+    list_filter = ("status", "owner", "needs_thank_you", "created_at")
+    search_fields = ("first_name", "last_name", "email", "phone")
+    ordering = ("last_name", "first_name")
     readonly_fields = (
-        'total_given', 'gift_count', 'first_gift_date',
-        'last_gift_date', 'last_gift_amount', 'created_at', 'updated_at'
+        "total_given",
+        "gift_count",
+        "first_gift_date",
+        "last_gift_date",
+        "last_gift_amount",
+        "created_at",
+        "updated_at",
     )
 
     fieldsets = (
-        (None, {
-            'fields': ('owner', 'first_name', 'last_name', 'status')
-        }),
-        ('Contact Info', {
-            'fields': ('email', 'phone', 'phone_secondary')
-        }),
-        ('Address', {
-            'fields': ('street_address', 'city', 'state', 'postal_code', 'country')
-        }),
-        ('Giving Statistics', {
-            'fields': (
-                'total_given', 'gift_count', 'first_gift_date',
-                'last_gift_date', 'last_gift_amount'
-            )
-        }),
-        ('Thank You', {
-            'fields': ('needs_thank_you', 'last_thanked_at')
-        }),
-        ('Organization', {
-            'fields': ('organization_name', 'external_constituent_id'),
-            'classes': ('collapse',),
-        }),
-        ('Notes', {
-            'fields': ('notes',)
-        }),
+        (None, {"fields": ("owner", "first_name", "last_name", "status")}),
+        ("Contact Info", {"fields": ("email", "phone", "phone_secondary")}),
+        ("Address", {"fields": ("street_address", "city", "state", "postal_code", "country")}),
+        (
+            "Giving Statistics",
+            {
+                "fields": (
+                    "total_given",
+                    "gift_count",
+                    "first_gift_date",
+                    "last_gift_date",
+                    "last_gift_amount",
+                )
+            },
+        ),
+        ("Thank You", {"fields": ("needs_thank_you", "last_thanked_at")}),
+        (
+            "Organization",
+            {
+                "fields": ("organization_name", "external_constituent_id"),
+                "classes": ("collapse",),
+            },
+        ),
+        ("Notes", {"fields": ("notes",)}),
     )
 
     def full_name(self, obj):
         return obj.full_name
-    full_name.short_description = 'Name'
+
+    full_name.short_description = "Name"

--- a/apps/contacts/apps.py
+++ b/apps/contacts/apps.py
@@ -2,6 +2,6 @@ from django.apps import AppConfig
 
 
 class ContactsConfig(AppConfig):
-    default_auto_field = 'django.db.models.BigAutoField'
-    name = 'apps.contacts'
-    verbose_name = 'Contacts'
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "apps.contacts"
+    verbose_name = "Contacts"

--- a/apps/contacts/export_views.py
+++ b/apps/contacts/export_views.py
@@ -4,9 +4,10 @@ CSV export view for contacts with FilterSet-based filtering.
 import csv
 from datetime import datetime
 
+from django.http import StreamingHttpResponse
+
 from rest_framework import permissions
 from rest_framework.views import APIView
-from django.http import StreamingHttpResponse
 
 from apps.contacts.filters import ContactFilterSet
 from apps.contacts.models import Contact
@@ -16,6 +17,7 @@ from apps.imports.services import sanitize_csv_value
 
 class Echo:
     """Pseudo-buffer for csv.writer to write to StreamingHttpResponse."""
+
     def write(self, value):
         return value
 
@@ -25,6 +27,7 @@ class ContactExportCSVView(APIView):
     GET: Export contacts as filtered CSV file.
     Applies the same ContactFilterSet as the list endpoint.
     """
+
     permission_classes = [permissions.IsAuthenticated]
 
     def get(self, request):
@@ -35,43 +38,47 @@ class ContactExportCSVView(APIView):
         queryset = Contact.objects.filter(owner_id__in=visible, is_merged=False)
 
         # Admin/supervisor/coach owner filter (intentionally NOT in FilterSet - security)
-        owner_id = request.query_params.get('owner')
-        if owner_id and user.role in ['admin', 'supervisor', 'coach']:
+        owner_id = request.query_params.get("owner")
+        if owner_id and user.role in ["admin", "supervisor", "coach"]:
             queryset = queryset.filter(owner_id=owner_id)
 
         # Apply FilterSet (same as list endpoint)
         filterset = ContactFilterSet(request.query_params, queryset=queryset)
-        filtered_qs = filterset.qs.select_related('owner')[:10000]
+        filtered_qs = filterset.qs.select_related("owner")[:10000]
 
-        filename = f'contacts_{datetime.now().date().isoformat()}.csv'
+        filename = f"contacts_{datetime.now().date().isoformat()}.csv"
 
         def generate_csv():
             pseudo_buffer = Echo()
             writer = csv.writer(pseudo_buffer)
 
             # Header
-            yield writer.writerow([
-                'Name',
-                'Email',
-                'Phone',
-                'Status',
-                'Owner',
-                'Last Gift Date',
-                'Total Given',
-            ])
+            yield writer.writerow(
+                [
+                    "Name",
+                    "Email",
+                    "Phone",
+                    "Status",
+                    "Owner",
+                    "Last Gift Date",
+                    "Total Given",
+                ]
+            )
 
             # Data rows
             for contact in filtered_qs:
-                yield writer.writerow([
-                    sanitize_csv_value(contact.full_name),
-                    sanitize_csv_value(contact.email or ''),
-                    sanitize_csv_value(contact.phone or ''),
-                    sanitize_csv_value(contact.status or ''),
-                    sanitize_csv_value(contact.owner.full_name if contact.owner else ''),
-                    contact.last_gift_date or '',
-                    str(contact.total_given or 0),
-                ])
+                yield writer.writerow(
+                    [
+                        sanitize_csv_value(contact.full_name),
+                        sanitize_csv_value(contact.email or ""),
+                        sanitize_csv_value(contact.phone or ""),
+                        sanitize_csv_value(contact.status or ""),
+                        sanitize_csv_value(contact.owner.full_name if contact.owner else ""),
+                        contact.last_gift_date or "",
+                        str(contact.total_given or 0),
+                    ]
+                )
 
-        response = StreamingHttpResponse(generate_csv(), content_type='text/csv')
-        response['Content-Disposition'] = f'attachment; filename="{filename}"'
+        response = StreamingHttpResponse(generate_csv(), content_type="text/csv")
+        response["Content-Disposition"] = f'attachment; filename="{filename}"'
         return response

--- a/apps/contacts/filters.py
+++ b/apps/contacts/filters.py
@@ -7,12 +7,12 @@ from apps.contacts.models import Contact
 
 
 class ContactFilterSet(django_filters.FilterSet):
-    status = django_filters.CharFilter(field_name='status')
-    needs_thank_you = django_filters.BooleanFilter(field_name='needs_thank_you')
-    last_gift_after = django_filters.DateFilter(field_name='last_gift_date', lookup_expr='gte')
-    last_gift_before = django_filters.DateFilter(field_name='last_gift_date', lookup_expr='lte')
-    group = django_filters.UUIDFilter(field_name='groups__id')
+    status = django_filters.CharFilter(field_name="status")
+    needs_thank_you = django_filters.BooleanFilter(field_name="needs_thank_you")
+    last_gift_after = django_filters.DateFilter(field_name="last_gift_date", lookup_expr="gte")
+    last_gift_before = django_filters.DateFilter(field_name="last_gift_date", lookup_expr="lte")
+    group = django_filters.UUIDFilter(field_name="groups__id")
 
     class Meta:
         model = Contact
-        fields = ['status', 'needs_thank_you', 'last_gift_after', 'last_gift_before', 'group']
+        fields = ["status", "needs_thank_you", "last_gift_after", "last_gift_before", "group"]

--- a/apps/contacts/serializers.py
+++ b/apps/contacts/serializers.py
@@ -12,16 +12,27 @@ class ContactListSerializer(serializers.ModelSerializer):
     """
     Serializer for contact list view (minimal fields).
     """
+
     full_name = serializers.CharField(read_only=True)
-    owner_name = serializers.CharField(source='owner.full_name', read_only=True)
+    owner_name = serializers.CharField(source="owner.full_name", read_only=True)
 
     class Meta:
         model = Contact
         fields = [
-            'id', 'first_name', 'last_name', 'full_name', 'organization_name',
-            'email', 'phone', 'status',
-            'total_given', 'gift_count', 'last_gift_date',
-            'needs_thank_you', 'owner', 'owner_name'
+            "id",
+            "first_name",
+            "last_name",
+            "full_name",
+            "organization_name",
+            "email",
+            "phone",
+            "status",
+            "total_given",
+            "gift_count",
+            "last_gift_date",
+            "needs_thank_you",
+            "owner",
+            "owner_name",
         ]
 
 
@@ -29,43 +40,70 @@ class ContactDetailSerializer(serializers.ModelSerializer):
     """
     Serializer for contact detail view (all fields).
     """
+
     full_name = serializers.CharField(read_only=True)
     first_name = serializers.CharField(max_length=150, required=False, allow_blank=True)
     last_name = serializers.CharField(max_length=150, required=False, allow_blank=True)
     full_address = serializers.CharField(read_only=True)
-    owner_name = serializers.CharField(source='owner.full_name', read_only=True)
+    owner_name = serializers.CharField(source="owner.full_name", read_only=True)
     has_active_pledge = serializers.BooleanField(read_only=True)
     monthly_pledge_amount = serializers.DecimalField(
         max_digits=10, decimal_places=2, read_only=True
     )
     groups = GroupSerializer(many=True, read_only=True)
     group_ids = serializers.ListField(
-        child=serializers.UUIDField(),
-        write_only=True,
-        required=False
+        child=serializers.UUIDField(), write_only=True, required=False
     )
 
     class Meta:
         model = Contact
         fields = [
-            'id', 'owner', 'owner_name',
-            'first_name', 'last_name', 'full_name', 'organization_name',
-            'email', 'phone', 'phone_secondary',
-            'street_address', 'city', 'state', 'postal_code', 'country',
-            'full_address', 'status',
-            'first_gift_date', 'last_gift_date', 'last_gift_amount',
-            'total_given', 'gift_count',
-            'has_active_pledge', 'monthly_pledge_amount',
-            'last_thanked_at', 'needs_thank_you',
-            'notes', 'external_id', 'external_constituent_id',
-            'groups', 'group_ids',
-            'created_at', 'updated_at'
+            "id",
+            "owner",
+            "owner_name",
+            "first_name",
+            "last_name",
+            "full_name",
+            "organization_name",
+            "email",
+            "phone",
+            "phone_secondary",
+            "street_address",
+            "city",
+            "state",
+            "postal_code",
+            "country",
+            "full_address",
+            "status",
+            "first_gift_date",
+            "last_gift_date",
+            "last_gift_amount",
+            "total_given",
+            "gift_count",
+            "has_active_pledge",
+            "monthly_pledge_amount",
+            "last_thanked_at",
+            "needs_thank_you",
+            "notes",
+            "external_id",
+            "external_constituent_id",
+            "groups",
+            "group_ids",
+            "created_at",
+            "updated_at",
         ]
         read_only_fields = [
-            'id', 'owner', 'first_gift_date', 'last_gift_date',
-            'last_gift_amount', 'total_given', 'gift_count',
-            'external_id', 'external_constituent_id',
-            'created_at', 'updated_at'
+            "id",
+            "owner",
+            "first_gift_date",
+            "last_gift_date",
+            "last_gift_amount",
+            "total_given",
+            "gift_count",
+            "external_id",
+            "external_constituent_id",
+            "created_at",
+            "updated_at",
         ]
 
     def _visible_groups(self, group_ids):
@@ -74,11 +112,12 @@ class ContactDetailSerializer(serializers.ModelSerializer):
         Scope to owned groups plus shared (owner=None) groups. Respects
         View As by threading the request through get_visible_user_ids().
         """
-        from apps.core.permissions import get_visible_user_ids
-        from apps.groups.models import Group
         from django.db.models import Q
 
-        request = self.context.get('request')
+        from apps.core.permissions import get_visible_user_ids
+        from apps.groups.models import Group
+
+        request = self.context.get("request")
         if not request or not request.user.is_authenticated:
             return Group.objects.none()
 
@@ -88,14 +127,14 @@ class ContactDetailSerializer(serializers.ModelSerializer):
         )
 
     def create(self, validated_data):
-        group_ids = validated_data.pop('group_ids', [])
+        group_ids = validated_data.pop("group_ids", [])
         contact = super().create(validated_data)
         if group_ids:
             contact.groups.set(self._visible_groups(group_ids))
         return contact
 
     def update(self, instance, validated_data):
-        group_ids = validated_data.pop('group_ids', None)
+        group_ids = validated_data.pop("group_ids", None)
         contact = super().update(instance, validated_data)
         if group_ids is not None:
             contact.groups.set(self._visible_groups(group_ids))
@@ -106,38 +145,52 @@ class ContactCreateSerializer(serializers.ModelSerializer):
     """
     Serializer for creating contacts.
     """
+
     first_name = serializers.CharField(max_length=150, required=False, allow_blank=True)
     last_name = serializers.CharField(max_length=150, required=False, allow_blank=True)
     group_ids = serializers.ListField(
-        child=serializers.UUIDField(),
-        write_only=True,
-        required=False
+        child=serializers.UUIDField(), write_only=True, required=False
     )
 
     class Meta:
         model = Contact
         fields = [
-            'id', 'first_name', 'last_name', 'organization_name', 'email', 'phone', 'phone_secondary',
-            'street_address', 'city', 'state', 'postal_code', 'country',
-            'status', 'notes', 'group_ids',
-            'total_given', 'gift_count', 'needs_thank_you'
+            "id",
+            "first_name",
+            "last_name",
+            "organization_name",
+            "email",
+            "phone",
+            "phone_secondary",
+            "street_address",
+            "city",
+            "state",
+            "postal_code",
+            "country",
+            "status",
+            "notes",
+            "group_ids",
+            "total_given",
+            "gift_count",
+            "needs_thank_you",
         ]
-        read_only_fields = ['id', 'total_given', 'gift_count', 'needs_thank_you']
+        read_only_fields = ["id", "total_given", "gift_count", "needs_thank_you"]
 
     def create(self, validated_data):
-        group_ids = validated_data.pop('group_ids', [])
+        group_ids = validated_data.pop("group_ids", [])
 
         # Set owner to current user
-        request = self.context.get('request')
+        request = self.context.get("request")
         if request and request.user.is_authenticated:
-            validated_data['owner'] = request.user
+            validated_data["owner"] = request.user
 
         contact = Contact.objects.create(**validated_data)
 
         if group_ids:
+            from django.db.models import Q
+
             from apps.core.permissions import get_visible_user_ids
             from apps.groups.models import Group
-            from django.db.models import Q
 
             if request and request.user.is_authenticated:
                 visible = get_visible_user_ids(request.user, request=request)
@@ -151,22 +204,24 @@ class ContactCreateSerializer(serializers.ModelSerializer):
 
 class DuplicateCheckSerializer(serializers.Serializer):
     """Input for pre-creation duplicate check."""
-    first_name = serializers.CharField(max_length=150, required=False, allow_blank=True, default='')
-    last_name = serializers.CharField(max_length=150, required=False, allow_blank=True, default='')
-    email = serializers.EmailField(required=False, allow_blank=True, default='')
-    phone = serializers.CharField(max_length=20, required=False, allow_blank=True, default='')
+
+    first_name = serializers.CharField(max_length=150, required=False, allow_blank=True, default="")
+    last_name = serializers.CharField(max_length=150, required=False, allow_blank=True, default="")
+    email = serializers.EmailField(required=False, allow_blank=True, default="")
+    phone = serializers.CharField(max_length=20, required=False, allow_blank=True, default="")
 
 
 class DuplicateMatchSerializer(serializers.Serializer):
     """Single duplicate match result."""
-    id = serializers.UUIDField(source='contact.id')
-    first_name = serializers.CharField(source='contact.first_name')
-    last_name = serializers.CharField(source='contact.last_name')
-    full_name = serializers.CharField(source='contact.full_name')
-    email = serializers.EmailField(source='contact.email', allow_blank=True)
-    phone = serializers.CharField(source='contact.phone', allow_blank=True)
-    organization_name = serializers.CharField(source='contact.organization_name', allow_blank=True)
-    status = serializers.CharField(source='contact.status')
+
+    id = serializers.UUIDField(source="contact.id")
+    first_name = serializers.CharField(source="contact.first_name")
+    last_name = serializers.CharField(source="contact.last_name")
+    full_name = serializers.CharField(source="contact.full_name")
+    email = serializers.EmailField(source="contact.email", allow_blank=True)
+    phone = serializers.CharField(source="contact.phone", allow_blank=True)
+    organization_name = serializers.CharField(source="contact.organization_name", allow_blank=True)
+    status = serializers.CharField(source="contact.status")
     confidence = serializers.CharField()
     reasons = serializers.ListField(child=serializers.CharField())
     similarity = serializers.FloatField()
@@ -174,12 +229,14 @@ class DuplicateMatchSerializer(serializers.Serializer):
 
 class MergeRequestSerializer(serializers.Serializer):
     """Input for merge operation."""
+
     survivor_id = serializers.UUIDField()
     loser_id = serializers.UUIDField()
 
 
 class DismissRequestSerializer(serializers.Serializer):
     """Input for dismissing a duplicate pair."""
+
     contact_a_id = serializers.UUIDField()
     contact_b_id = serializers.UUIDField()
 
@@ -187,15 +244,12 @@ class DismissRequestSerializer(serializers.Serializer):
 class ContactJournalMembershipSerializer(serializers.ModelSerializer):
     """Serializer for contact's journal memberships (for Journals tab)."""
 
-    journal_id = serializers.UUIDField(source='journal.id', read_only=True)
-    journal_name = serializers.CharField(source='journal.name', read_only=True)
+    journal_id = serializers.UUIDField(source="journal.id", read_only=True)
+    journal_name = serializers.CharField(source="journal.name", read_only=True)
     goal_amount = serializers.DecimalField(
-        source='journal.goal_amount',
-        max_digits=10,
-        decimal_places=2,
-        read_only=True
+        source="journal.goal_amount", max_digits=10, decimal_places=2, read_only=True
     )
-    deadline = serializers.DateField(source='journal.deadline', read_only=True)
+    deadline = serializers.DateField(source="journal.deadline", read_only=True)
 
     # Current stage - computed from most recent event
     current_stage = serializers.SerializerMethodField()
@@ -206,30 +260,30 @@ class ContactJournalMembershipSerializer(serializers.ModelSerializer):
     class Meta:
         model = JournalContact
         fields = [
-            'id',
-            'journal_id',
-            'journal_name',
-            'goal_amount',
-            'deadline',
-            'current_stage',
-            'decision',
-            'created_at',
+            "id",
+            "journal_id",
+            "journal_name",
+            "goal_amount",
+            "deadline",
+            "current_stage",
+            "decision",
+            "created_at",
         ]
         read_only_fields = fields
 
     def get_current_stage(self, obj):
         """Get most recent stage from prefetched events."""
         # Events are prefetched and ordered by -created_at
-        events = getattr(obj, 'prefetched_events', None)
+        events = getattr(obj, "prefetched_events", None)
         if events:
             return events[0].stage if events else PipelineStage.CONTACT
         # Fallback if not prefetched
-        latest = obj.stage_events.order_by('-created_at').first()
+        latest = obj.stage_events.order_by("-created_at").first()
         return latest.stage if latest else PipelineStage.CONTACT
 
     def get_decision(self, obj):
         """Get decision summary from prefetched decision."""
-        decisions = getattr(obj, 'prefetched_decisions', None)
+        decisions = getattr(obj, "prefetched_decisions", None)
         if decisions:
             decision = decisions[0] if decisions else None
         else:
@@ -239,8 +293,8 @@ class ContactJournalMembershipSerializer(serializers.ModelSerializer):
             return None
 
         return {
-            'id': str(decision.id),
-            'amount': str(decision.amount),
-            'cadence': decision.cadence,
-            'status': decision.status,
+            "id": str(decision.id),
+            "amount": str(decision.amount),
+            "cadence": decision.cadence,
+            "status": decision.status,
         }

--- a/apps/contacts/services.py
+++ b/apps/contacts/services.py
@@ -47,7 +47,8 @@ def find_duplicates_for_contact(contact_data, owner_id, exclude_id=None):
         exclude_id: optional UUID to exclude (e.g., the contact being edited)
 
     Returns:
-        List of dicts: [{'contact': Contact, 'confidence': str, 'reasons': list, 'similarity': float}]
+        List of dicts:
+        [{'contact': Contact, 'confidence': str, 'reasons': list, 'similarity': float}]
         Sorted by confidence (high > medium > low), then similarity descending.
         Limited to 10 results.
     """

--- a/apps/contacts/tasks.py
+++ b/apps/contacts/tasks.py
@@ -24,17 +24,17 @@ def detect_at_risk_donors():
 
     cutoff_date = timezone.now().date() - timedelta(days=60)
 
-    logger.info('Starting at-risk donor detection')
+    logger.info("Starting at-risk donor detection")
 
     # Find at-risk donors who haven't already been flagged recently
     at_risk_contacts = Contact.active.filter(
         status=ContactStatus.DONOR,
         last_gift_date__lt=cutoff_date,
-        gift_count__gte=2  # Has given at least twice
+        gift_count__gte=2,  # Has given at least twice
     ).exclude(
         # Exclude those we already notified in the last 30 days
         events__event_type=EventType.AT_RISK,
-        events__created_at__gte=timezone.now() - timedelta(days=30)
+        events__created_at__gte=timezone.now() - timedelta(days=30),
     )
 
     at_risk_count = 0
@@ -43,18 +43,18 @@ def detect_at_risk_donors():
         Event.objects.create(
             user=contact.owner,
             event_type=EventType.AT_RISK,
-            title=f'{contact.full_name} is at risk of lapsing',
-            message=f'Last gift was on {contact.last_gift_date}. Consider reaching out.',
+            title=f"{contact.full_name} is at risk of lapsing",
+            message=f"Last gift was on {contact.last_gift_date}. Consider reaching out.",
             severity=EventSeverity.WARNING,
             contact=contact,
             metadata={
-                'last_gift_date': str(contact.last_gift_date),
-                'days_since_last_gift': (timezone.now().date() - contact.last_gift_date).days,
-                'total_given': str(contact.total_given),
-            }
+                "last_gift_date": str(contact.last_gift_date),
+                "days_since_last_gift": (timezone.now().date() - contact.last_gift_date).days,
+                "total_given": str(contact.total_given),
+            },
         )
         at_risk_count += 1
 
-    logger.info(f'At-risk detection completed: {at_risk_count} donors identified')
+    logger.info(f"At-risk detection completed: {at_risk_count} donors identified")
 
-    return f'Identified {at_risk_count} at-risk donors'
+    return f"Identified {at_risk_count} at-risk donors"

--- a/apps/contacts/tests/factories.py
+++ b/apps/contacts/tests/factories.py
@@ -20,28 +20,31 @@ class ContactFactory(factory.django.DjangoModelFactory):
     first_name = factory.LazyFunction(fake.first_name)
     last_name = factory.LazyFunction(fake.last_name)
     email = factory.LazyFunction(fake.email)
-    phone = factory.LazyFunction(lambda: fake.numerify('###-###-####'))
+    phone = factory.LazyFunction(lambda: fake.numerify("###-###-####"))
     street_address = factory.LazyFunction(fake.street_address)
     city = factory.LazyFunction(fake.city)
     state = factory.LazyFunction(fake.state_abbr)
     postal_code = factory.LazyFunction(fake.zipcode)
-    country = 'USA'
+    country = "USA"
     status = ContactStatus.PROSPECT
-    notes = ''
+    notes = ""
 
 
 class DonorContactFactory(ContactFactory):
     """Factory for creating donor contacts with giving history."""
+
     status = ContactStatus.DONOR
 
 
 class LapsedContactFactory(ContactFactory):
     """Factory for creating lapsed donor contacts."""
+
     status = ContactStatus.LAPSED
 
 
 class OrgContactFactory(ContactFactory):
     """Factory for creating organization-type contacts with blank first/last names."""
-    first_name = ''
-    last_name = ''
+
+    first_name = ""
+    last_name = ""
     organization_name = factory.LazyFunction(lambda: fake.company())

--- a/apps/contacts/tests/test_contact_journals.py
+++ b/apps/contacts/tests/test_contact_journals.py
@@ -7,15 +7,24 @@ Tests verify:
 - Query optimization prevents N+1 queries
 - Ownership validation
 """
+import datetime
+from decimal import Decimal
+
 from django.contrib.auth import get_user_model
 from django.urls import reverse
+
 from rest_framework import status
 from rest_framework.test import APITestCase
-from decimal import Decimal
-import datetime
 
 from apps.contacts.models import Contact
-from apps.journals.models import Journal, JournalContact, JournalStageEvent, Decision, PipelineStage, StageEventType
+from apps.journals.models import (
+    Decision,
+    Journal,
+    JournalContact,
+    JournalStageEvent,
+    PipelineStage,
+    StageEventType,
+)
 
 User = get_user_model()
 
@@ -27,56 +36,53 @@ class ContactJournalsAPITests(APITestCase):
         """Set up test data: user, contact, journal with membership."""
         # Create user
         self.user = User.objects.create_user(
-            email='owner@example.com',
-            password='password123',
-            first_name='Owner',
-            last_name='User',
-            role='missionary'
+            email="owner@example.com",
+            password="password123",
+            first_name="Owner",
+            last_name="User",
+            role="missionary",
         )
 
         # Create contact
         self.contact = Contact.objects.create(
             owner=self.user,
-            first_name='John',
-            last_name='Doe',
-            email='john@example.com',
-            status='partner'
+            first_name="John",
+            last_name="Doe",
+            email="john@example.com",
+            status="partner",
         )
 
         # Create journal
         self.journal = Journal.objects.create(
             owner=self.user,
-            name='Q1 2025 Campaign',
-            goal_amount=Decimal('5000.00'),
-            deadline=datetime.date(2025, 3, 31)
+            name="Q1 2025 Campaign",
+            goal_amount=Decimal("5000.00"),
+            deadline=datetime.date(2025, 3, 31),
         )
 
         # Create membership
-        self.membership = JournalContact.objects.create(
-            journal=self.journal,
-            contact=self.contact
-        )
+        self.membership = JournalContact.objects.create(journal=self.journal, contact=self.contact)
 
         # Create stage event
         self.event = JournalStageEvent.objects.create(
             journal_contact=self.membership,
             stage=PipelineStage.MEET,
             event_type=StageEventType.MEETING_COMPLETED,
-            triggered_by=self.user
+            triggered_by=self.user,
         )
 
         # Create decision
         self.decision = Decision.objects.create(
             journal_contact=self.membership,
-            amount=Decimal('100.00'),
-            cadence='monthly',
-            status='active'
+            amount=Decimal("100.00"),
+            cadence="monthly",
+            status="active",
         )
 
     def test_get_contact_journals(self):
         """GET /api/v1/contacts/{id}/journals/ returns list of memberships."""
         self.client.force_authenticate(user=self.user)
-        url = reverse('contacts:contact-journals', args=[self.contact.id])
+        url = reverse("contacts:contact-journals", args=[self.contact.id])
 
         response = self.client.get(url)
 
@@ -84,8 +90,8 @@ class ContactJournalsAPITests(APITestCase):
 
         # Should return list with one membership
         data = response.data
-        if 'results' in data:  # Paginated response
-            results = data['results']
+        if "results" in data:  # Paginated response
+            results = data["results"]
         else:
             results = data
 
@@ -93,52 +99,49 @@ class ContactJournalsAPITests(APITestCase):
 
         # Verify structure
         membership_data = results[0]
-        self.assertEqual(str(membership_data['id']), str(self.membership.id))
-        self.assertEqual(str(membership_data['journal_id']), str(self.journal.id))
-        self.assertEqual(membership_data['journal_name'], 'Q1 2025 Campaign')
-        self.assertEqual(membership_data['goal_amount'], '5000.00')
-        self.assertEqual(membership_data['deadline'], '2025-03-31')
-        self.assertEqual(membership_data['current_stage'], PipelineStage.MEET)
+        self.assertEqual(str(membership_data["id"]), str(self.membership.id))
+        self.assertEqual(str(membership_data["journal_id"]), str(self.journal.id))
+        self.assertEqual(membership_data["journal_name"], "Q1 2025 Campaign")
+        self.assertEqual(membership_data["goal_amount"], "5000.00")
+        self.assertEqual(membership_data["deadline"], "2025-03-31")
+        self.assertEqual(membership_data["current_stage"], PipelineStage.MEET)
 
         # Verify decision structure
-        decision_data = membership_data['decision']
+        decision_data = membership_data["decision"]
         self.assertIsNotNone(decision_data)
-        self.assertEqual(str(decision_data['id']), str(self.decision.id))
-        self.assertEqual(decision_data['amount'], '100.00')
-        self.assertEqual(decision_data['cadence'], 'monthly')
-        self.assertEqual(decision_data['status'], 'active')
+        self.assertEqual(str(decision_data["id"]), str(self.decision.id))
+        self.assertEqual(decision_data["amount"], "100.00")
+        self.assertEqual(decision_data["cadence"], "monthly")
+        self.assertEqual(decision_data["status"], "active")
 
     def test_no_n_plus_one_queries(self):
         """Query count should not increase with number of memberships."""
         # Create second journal and membership
         journal2 = Journal.objects.create(
             owner=self.user,
-            name='Q2 2025 Campaign',
-            goal_amount=Decimal('3000.00'),
-            deadline=datetime.date(2025, 6, 30)
+            name="Q2 2025 Campaign",
+            goal_amount=Decimal("3000.00"),
+            deadline=datetime.date(2025, 6, 30),
         )
 
-        membership2 = JournalContact.objects.create(
-            journal=journal2,
-            contact=self.contact
-        )
+        membership2 = JournalContact.objects.create(journal=journal2, contact=self.contact)
 
         JournalStageEvent.objects.create(
             journal_contact=membership2,
             stage=PipelineStage.DECISION,
             event_type=StageEventType.ASK_MADE,
-            triggered_by=self.user
+            triggered_by=self.user,
         )
 
         Decision.objects.create(
             journal_contact=membership2,
-            amount=Decimal('50.00'),
-            cadence='quarterly',
-            status='pending'
+            amount=Decimal("50.00"),
+            cadence="quarterly",
+            status="pending",
         )
 
         self.client.force_authenticate(user=self.user)
-        url = reverse('contacts:contact-journals', args=[self.contact.id])
+        url = reverse("contacts:contact-journals", args=[self.contact.id])
 
         # Make request - check result has both memberships
         response = self.client.get(url)
@@ -146,8 +149,8 @@ class ContactJournalsAPITests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         data = response.data
-        if 'results' in data:
-            results = data['results']
+        if "results" in data:
+            results = data["results"]
         else:
             results = data
 
@@ -155,30 +158,30 @@ class ContactJournalsAPITests(APITestCase):
         self.assertEqual(len(results), 2)
 
         # Verify both journals present
-        journal_names = {r['journal_name'] for r in results}
-        self.assertEqual(journal_names, {'Q1 2025 Campaign', 'Q2 2025 Campaign'})
+        journal_names = {r["journal_name"] for r in results}
+        self.assertEqual(journal_names, {"Q1 2025 Campaign", "Q2 2025 Campaign"})
 
     def test_contact_with_no_journals(self):
         """Contact with no journal memberships returns empty list."""
         # Create contact without memberships
         contact2 = Contact.objects.create(
             owner=self.user,
-            first_name='Jane',
-            last_name='Smith',
-            email='jane@example.com',
-            status='prospect'
+            first_name="Jane",
+            last_name="Smith",
+            email="jane@example.com",
+            status="prospect",
         )
 
         self.client.force_authenticate(user=self.user)
-        url = reverse('contacts:contact-journals', args=[contact2.id])
+        url = reverse("contacts:contact-journals", args=[contact2.id])
 
         response = self.client.get(url)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         data = response.data
-        if 'results' in data:  # Paginated
-            results = data['results']
+        if "results" in data:  # Paginated
+            results = data["results"]
         else:
             results = data
 
@@ -188,40 +191,39 @@ class ContactJournalsAPITests(APITestCase):
         """Users only see memberships for journals they own."""
         # Create second user with different journal
         other_user = User.objects.create_user(
-            email='other@example.com',
-            password='password123',
-            first_name='Other',
-            last_name='User',
-            role='missionary'
+            email="other@example.com",
+            password="password123",
+            first_name="Other",
+            last_name="User",
+            role="missionary",
         )
 
         other_journal = Journal.objects.create(
             owner=other_user,
-            name='Other Journal',
-            goal_amount=Decimal('1000.00'),
-            deadline=datetime.date(2025, 12, 31)
+            name="Other Journal",
+            goal_amount=Decimal("1000.00"),
+            deadline=datetime.date(2025, 12, 31),
         )
 
         # Add contact to other user's journal
         other_membership = JournalContact.objects.create(
-            journal=other_journal,
-            contact=self.contact
+            journal=other_journal, contact=self.contact
         )
 
         # Original user should only see their own journal
         self.client.force_authenticate(user=self.user)
-        url = reverse('contacts:contact-journals', args=[self.contact.id])
+        url = reverse("contacts:contact-journals", args=[self.contact.id])
 
         response = self.client.get(url)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         data = response.data
-        if 'results' in data:
-            results = data['results']
+        if "results" in data:
+            results = data["results"]
         else:
             results = data
 
         # Should only see the one journal owned by self.user
         self.assertEqual(len(results), 1)
-        self.assertEqual(results[0]['journal_name'], 'Q1 2025 Campaign')
+        self.assertEqual(results[0]["journal_name"], "Q1 2025 Campaign")

--- a/apps/contacts/tests/test_contact_journals.py
+++ b/apps/contacts/tests/test_contact_journals.py
@@ -206,9 +206,7 @@ class ContactJournalsAPITests(APITestCase):
         )
 
         # Add contact to other user's journal
-        other_membership = JournalContact.objects.create(
-            journal=other_journal, contact=self.contact
-        )
+        JournalContact.objects.create(journal=other_journal, contact=self.contact)
 
         # Original user should only see their own journal
         self.client.force_authenticate(user=self.user)

--- a/apps/contacts/tests/test_duplicate_api.py
+++ b/apps/contacts/tests/test_duplicate_api.py
@@ -11,7 +11,7 @@ from rest_framework.test import APIClient
 
 import pytest
 
-from apps.contacts.models import Contact, DismissedDuplicate
+from apps.contacts.models import DismissedDuplicate
 from apps.contacts.tests.factories import ContactFactory
 from apps.users.tests.factories import UserFactory
 

--- a/apps/contacts/tests/test_duplicate_api.py
+++ b/apps/contacts/tests/test_duplicate_api.py
@@ -7,8 +7,9 @@ while still testing the full HTTP request/response cycle.
 import uuid
 from unittest.mock import patch
 
-import pytest
 from rest_framework.test import APIClient
+
+import pytest
 
 from apps.contacts.models import Contact, DismissedDuplicate
 from apps.contacts.tests.factories import ContactFactory
@@ -37,33 +38,35 @@ class TestDuplicateCheck:
 
     def test_duplicate_check_returns_matches(self, auth_client, user):
         """POST with matching email returns match with confidence='high'."""
-        contact = ContactFactory(owner=user, email='existing@example.com')
-        mock_result = [{
-            'contact': contact,
-            'confidence': 'high',
-            'reasons': ['Exact email match'],
-            'similarity': 1.0,
-        }]
-        with patch('apps.contacts.views.find_duplicates_for_contact', return_value=mock_result):
+        contact = ContactFactory(owner=user, email="existing@example.com")
+        mock_result = [
+            {
+                "contact": contact,
+                "confidence": "high",
+                "reasons": ["Exact email match"],
+                "similarity": 1.0,
+            }
+        ]
+        with patch("apps.contacts.views.find_duplicates_for_contact", return_value=mock_result):
             resp = auth_client.post(
-                '/api/v1/contacts/duplicates/check/',
-                {'email': 'existing@example.com'},
-                format='json',
+                "/api/v1/contacts/duplicates/check/",
+                {"email": "existing@example.com"},
+                format="json",
             )
         assert resp.status_code == 200
         data = resp.json()
         assert len(data) == 1
-        assert data[0]['confidence'] == 'high'
-        assert data[0]['id'] == str(contact.id)
-        assert data[0]['email'] == 'existing@example.com'
+        assert data[0]["confidence"] == "high"
+        assert data[0]["id"] == str(contact.id)
+        assert data[0]["email"] == "existing@example.com"
 
     def test_duplicate_check_empty_returns_empty(self, auth_client, user):
         """POST with unique data returns empty list."""
-        with patch('apps.contacts.views.find_duplicates_for_contact', return_value=[]):
+        with patch("apps.contacts.views.find_duplicates_for_contact", return_value=[]):
             resp = auth_client.post(
-                '/api/v1/contacts/duplicates/check/',
-                {'first_name': 'UniquelyUniqueName', 'last_name': 'Nobody'},
-                format='json',
+                "/api/v1/contacts/duplicates/check/",
+                {"first_name": "UniquelyUniqueName", "last_name": "Nobody"},
+                format="json",
             )
         assert resp.status_code == 200
         assert resp.json() == []
@@ -71,9 +74,9 @@ class TestDuplicateCheck:
     def test_duplicate_check_unauthenticated_403(self, api_client):
         """Unauthenticated request returns 401."""
         resp = api_client.post(
-            '/api/v1/contacts/duplicates/check/',
-            {'email': 'test@example.com'},
-            format='json',
+            "/api/v1/contacts/duplicates/check/",
+            {"email": "test@example.com"},
+            format="json",
         )
         assert resp.status_code == 401
 
@@ -84,21 +87,21 @@ class TestMergeContacts:
 
     def test_merge_success(self, auth_client, user):
         """POST with valid survivor_id/loser_id returns survivor data."""
-        survivor = ContactFactory(owner=user, first_name='Alice', last_name='Smith')
-        loser = ContactFactory(owner=user, first_name='Alice', last_name='Smithe')
+        survivor = ContactFactory(owner=user, first_name="Alice", last_name="Smith")
+        loser = ContactFactory(owner=user, first_name="Alice", last_name="Smithe")
 
         resp = auth_client.post(
-            '/api/v1/contacts/duplicates/merge/',
+            "/api/v1/contacts/duplicates/merge/",
             {
-                'survivor_id': str(survivor.id),
-                'loser_id': str(loser.id),
+                "survivor_id": str(survivor.id),
+                "loser_id": str(loser.id),
             },
-            format='json',
+            format="json",
         )
         assert resp.status_code == 200
         data = resp.json()
-        assert data['id'] == str(survivor.id)
-        assert data['first_name'] == 'Alice'
+        assert data["id"] == str(survivor.id)
+        assert data["first_name"] == "Alice"
 
         # Verify loser is now soft-deleted
         loser.refresh_from_db()
@@ -108,12 +111,12 @@ class TestMergeContacts:
     def test_merge_invalid_ids_404(self, auth_client, user):
         """POST with nonexistent IDs returns 404."""
         resp = auth_client.post(
-            '/api/v1/contacts/duplicates/merge/',
+            "/api/v1/contacts/duplicates/merge/",
             {
-                'survivor_id': str(uuid.uuid4()),
-                'loser_id': str(uuid.uuid4()),
+                "survivor_id": str(uuid.uuid4()),
+                "loser_id": str(uuid.uuid4()),
             },
-            format='json',
+            format="json",
         )
         assert resp.status_code == 404
 
@@ -127,12 +130,12 @@ class TestDismissDuplicate:
         c1 = ContactFactory(owner=user)
         c2 = ContactFactory(owner=user)
         resp = auth_client.post(
-            '/api/v1/contacts/duplicates/dismiss/',
+            "/api/v1/contacts/duplicates/dismiss/",
             {
-                'contact_a_id': str(c1.id),
-                'contact_b_id': str(c2.id),
+                "contact_a_id": str(c1.id),
+                "contact_b_id": str(c2.id),
             },
-            format='json',
+            format="json",
         )
         assert resp.status_code == 201
         assert DismissedDuplicate.objects.count() == 1
@@ -144,14 +147,14 @@ class TestContactListExcludesMerged:
 
     def test_contact_list_excludes_merged(self, auth_client, user):
         """GET /api/v1/contacts/ does not include is_merged=True contacts."""
-        active = ContactFactory(owner=user, first_name='Active')
-        merged = ContactFactory(owner=user, first_name='Merged', is_merged=True)
+        active = ContactFactory(owner=user, first_name="Active")
+        merged = ContactFactory(owner=user, first_name="Merged", is_merged=True)
 
-        resp = auth_client.get('/api/v1/contacts/')
+        resp = auth_client.get("/api/v1/contacts/")
         assert resp.status_code == 200
         data = resp.json()
         # Response may be paginated
-        results = data.get('results', data)
-        ids = [r['id'] for r in results]
+        results = data.get("results", data)
+        ids = [r["id"] for r in results]
         assert str(active.id) in ids
         assert str(merged.id) not in ids

--- a/apps/contacts/tests/test_duplicate_detection.py
+++ b/apps/contacts/tests/test_duplicate_detection.py
@@ -3,11 +3,9 @@ Tests for duplicate contact detection functionality.
 SQLite-compatible -- TrigramSimilarity is mocked where needed since pg_trgm
 functions do not work on SQLite.
 """
-from unittest.mock import MagicMock, patch
-
 import pytest
 
-from apps.contacts.models import Contact, DismissedDuplicate
+from apps.contacts.models import DismissedDuplicate
 from apps.contacts.tests.factories import ContactFactory
 from apps.users.tests.factories import UserFactory
 

--- a/apps/contacts/tests/test_duplicate_detection.py
+++ b/apps/contacts/tests/test_duplicate_detection.py
@@ -3,8 +3,9 @@ Tests for duplicate contact detection functionality.
 SQLite-compatible -- TrigramSimilarity is mocked where needed since pg_trgm
 functions do not work on SQLite.
 """
+from unittest.mock import MagicMock, patch
+
 import pytest
-from unittest.mock import patch, MagicMock
 
 from apps.contacts.models import Contact, DismissedDuplicate
 from apps.contacts.tests.factories import ContactFactory
@@ -20,36 +21,44 @@ class TestFindDuplicatesForContact:
         from apps.contacts.services import find_duplicates_for_contact
 
         user = UserFactory()
-        existing = ContactFactory(owner=user, email='john@example.com')
+        existing = ContactFactory(owner=user, email="john@example.com")
 
         results = find_duplicates_for_contact(
-            contact_data={'first_name': 'Different', 'last_name': 'Name',
-                          'email': 'john@example.com', 'phone': ''},
-            owner_id=user.id
+            contact_data={
+                "first_name": "Different",
+                "last_name": "Name",
+                "email": "john@example.com",
+                "phone": "",
+            },
+            owner_id=user.id,
         )
 
         assert len(results) >= 1
-        match = next(r for r in results if r['contact'].id == existing.id)
-        assert match['confidence'] == 'high'
-        assert 'email' in ' '.join(match['reasons']).lower()
+        match = next(r for r in results if r["contact"].id == existing.id)
+        assert match["confidence"] == "high"
+        assert "email" in " ".join(match["reasons"]).lower()
 
     def test_find_duplicates_exact_phone_match(self):
         """Exact phone match returns 'high' confidence result."""
         from apps.contacts.services import find_duplicates_for_contact
 
         user = UserFactory()
-        existing = ContactFactory(owner=user, phone='555-123-4567')
+        existing = ContactFactory(owner=user, phone="555-123-4567")
 
         results = find_duplicates_for_contact(
-            contact_data={'first_name': 'Different', 'last_name': 'Name',
-                          'email': '', 'phone': '555-123-4567'},
-            owner_id=user.id
+            contact_data={
+                "first_name": "Different",
+                "last_name": "Name",
+                "email": "",
+                "phone": "555-123-4567",
+            },
+            owner_id=user.id,
         )
 
         assert len(results) >= 1
-        match = next(r for r in results if r['contact'].id == existing.id)
-        assert match['confidence'] == 'high'
-        assert 'phone' in ' '.join(match['reasons']).lower()
+        match = next(r for r in results if r["contact"].id == existing.id)
+        assert match["confidence"] == "high"
+        assert "phone" in " ".join(match["reasons"]).lower()
 
     def test_find_duplicates_owner_scoping(self):
         """Only returns contacts owned by the specified user."""
@@ -58,17 +67,21 @@ class TestFindDuplicatesForContact:
         user_a = UserFactory()
         user_b = UserFactory()
         # Same email but different owners
-        ContactFactory(owner=user_a, email='shared@example.com')
-        ContactFactory(owner=user_b, email='shared@example.com')
+        ContactFactory(owner=user_a, email="shared@example.com")
+        ContactFactory(owner=user_b, email="shared@example.com")
 
         results = find_duplicates_for_contact(
-            contact_data={'first_name': '', 'last_name': '',
-                          'email': 'shared@example.com', 'phone': ''},
-            owner_id=user_a.id
+            contact_data={
+                "first_name": "",
+                "last_name": "",
+                "email": "shared@example.com",
+                "phone": "",
+            },
+            owner_id=user_a.id,
         )
 
         # Only user_a's contact should appear
-        owner_ids = {r['contact'].owner_id for r in results}
+        owner_ids = {r["contact"].owner_id for r in results}
         assert owner_ids == {user_a.id}
 
     def test_find_duplicates_excludes_merged(self):
@@ -76,15 +89,19 @@ class TestFindDuplicatesForContact:
         from apps.contacts.services import find_duplicates_for_contact
 
         user = UserFactory()
-        merged = ContactFactory(owner=user, email='merged@example.com', is_merged=True)
+        merged = ContactFactory(owner=user, email="merged@example.com", is_merged=True)
 
         results = find_duplicates_for_contact(
-            contact_data={'first_name': '', 'last_name': '',
-                          'email': 'merged@example.com', 'phone': ''},
-            owner_id=user.id
+            contact_data={
+                "first_name": "",
+                "last_name": "",
+                "email": "merged@example.com",
+                "phone": "",
+            },
+            owner_id=user.id,
         )
 
-        contact_ids = {r['contact'].id for r in results}
+        contact_ids = {r["contact"].id for r in results}
         assert merged.id not in contact_ids
 
     def test_find_duplicates_excludes_self(self):
@@ -92,16 +109,20 @@ class TestFindDuplicatesForContact:
         from apps.contacts.services import find_duplicates_for_contact
 
         user = UserFactory()
-        contact = ContactFactory(owner=user, email='self@example.com')
+        contact = ContactFactory(owner=user, email="self@example.com")
 
         results = find_duplicates_for_contact(
-            contact_data={'first_name': '', 'last_name': '',
-                          'email': 'self@example.com', 'phone': ''},
+            contact_data={
+                "first_name": "",
+                "last_name": "",
+                "email": "self@example.com",
+                "phone": "",
+            },
             owner_id=user.id,
-            exclude_id=contact.id
+            exclude_id=contact.id,
         )
 
-        contact_ids = {r['contact'].id for r in results}
+        contact_ids = {r["contact"].id for r in results}
         assert contact.id not in contact_ids
 
 

--- a/apps/contacts/tests/test_integration.py
+++ b/apps/contacts/tests/test_integration.py
@@ -3,10 +3,12 @@ Integration tests for the complete donor workflow.
 """
 from decimal import Decimal
 
-import pytest
 from django.utils import timezone
+
 from rest_framework import status
 from rest_framework.test import APIClient
+
+import pytest
 
 from apps.contacts.models import Contact, ContactStatus
 
@@ -28,54 +30,63 @@ class TestDonorWorkflow:
         client, user = authenticated_client
 
         # Step 1: Create a prospect
-        response = client.post('/api/v1/contacts/', {
-            'first_name': 'Jane',
-            'last_name': 'Smith',
-            'email': 'jane.smith@example.com',
-            'phone': '555-1234',
-            'status': ContactStatus.PROSPECT
-        })
+        response = client.post(
+            "/api/v1/contacts/",
+            {
+                "first_name": "Jane",
+                "last_name": "Smith",
+                "email": "jane.smith@example.com",
+                "phone": "555-1234",
+                "status": ContactStatus.PROSPECT,
+            },
+        )
         assert response.status_code == status.HTTP_201_CREATED
-        contact_id = response.data['id']
-        assert response.data['status'] == ContactStatus.PROSPECT
-        assert response.data['total_given'] == '0.00'
-        assert response.data['gift_count'] == 0
+        contact_id = response.data["id"]
+        assert response.data["status"] == ContactStatus.PROSPECT
+        assert response.data["total_given"] == "0.00"
+        assert response.data["gift_count"] == 0
 
         # Step 2: Add first gift via Gift API
-        response = client.post('/api/v1/gifts/', {
-            'donor_contact': contact_id,
-            'amount_cents': 10000,  # $100.00
-            'gift_date': timezone.now().date().isoformat(),
-        })
+        response = client.post(
+            "/api/v1/gifts/",
+            {
+                "donor_contact": contact_id,
+                "amount_cents": 10000,  # $100.00
+                "gift_date": timezone.now().date().isoformat(),
+            },
+        )
         assert response.status_code == status.HTTP_201_CREATED
 
         # Step 3: Verify contact stats updated
-        response = client.get(f'/api/v1/contacts/{contact_id}/')
+        response = client.get(f"/api/v1/contacts/{contact_id}/")
         assert response.status_code == status.HTTP_200_OK
-        assert response.data['status'] == ContactStatus.DONOR
-        assert Decimal(response.data['total_given']) == Decimal('100.00')
-        assert response.data['gift_count'] == 1
-        assert response.data['needs_thank_you'] is True
+        assert response.data["status"] == ContactStatus.DONOR
+        assert Decimal(response.data["total_given"]) == Decimal("100.00")
+        assert response.data["gift_count"] == 1
+        assert response.data["needs_thank_you"] is True
 
         # Step 4: Mark as thanked
-        response = client.post(f'/api/v1/contacts/{contact_id}/thank/')
+        response = client.post(f"/api/v1/contacts/{contact_id}/thank/")
         assert response.status_code == status.HTTP_200_OK
 
-        response = client.get(f'/api/v1/contacts/{contact_id}/')
-        assert response.data['needs_thank_you'] is False
+        response = client.get(f"/api/v1/contacts/{contact_id}/")
+        assert response.data["needs_thank_you"] is False
 
         # Step 5: Add second gift
-        response = client.post('/api/v1/gifts/', {
-            'donor_contact': contact_id,
-            'amount_cents': 5000,  # $50.00
-            'gift_date': timezone.now().date().isoformat(),
-        })
+        response = client.post(
+            "/api/v1/gifts/",
+            {
+                "donor_contact": contact_id,
+                "amount_cents": 5000,  # $50.00
+                "gift_date": timezone.now().date().isoformat(),
+            },
+        )
         assert response.status_code == status.HTTP_201_CREATED
 
         # Verify cumulative stats
-        response = client.get(f'/api/v1/contacts/{contact_id}/')
-        assert Decimal(response.data['total_given']) == Decimal('150.00')
-        assert response.data['gift_count'] == 2
+        response = client.get(f"/api/v1/contacts/{contact_id}/")
+        assert Decimal(response.data["total_given"]) == Decimal("150.00")
+        assert response.data["gift_count"] == 2
 
 
 @pytest.mark.django_db
@@ -94,24 +105,26 @@ class TestRecurringGiftWorkflow:
         client, user = authenticated_client
 
         # Create contact
-        response = client.post('/api/v1/contacts/', {
-            'first_name': 'Bob',
-            'last_name': 'Jones',
-            'email': 'bob@example.com'
-        })
-        contact_id = response.data['id']
+        response = client.post(
+            "/api/v1/contacts/",
+            {"first_name": "Bob", "last_name": "Jones", "email": "bob@example.com"},
+        )
+        contact_id = response.data["id"]
 
         # Create monthly recurring gift for $100 (10000 cents)
-        response = client.post('/api/v1/gifts/recurring/', {
-            'donor_contact': contact_id,
-            'amount_cents': 10000,
-            'frequency': 'monthly',
-            'start_date': timezone.now().date().isoformat(),
-            'status': 'active'
-        })
+        response = client.post(
+            "/api/v1/gifts/recurring/",
+            {
+                "donor_contact": contact_id,
+                "amount_cents": 10000,
+                "frequency": "monthly",
+                "start_date": timezone.now().date().isoformat(),
+                "status": "active",
+            },
+        )
         assert response.status_code == status.HTTP_201_CREATED
-        assert response.data['amount_cents'] == 10000
-        assert response.data['frequency'] == 'monthly'
+        assert response.data["amount_cents"] == 10000
+        assert response.data["frequency"] == "monthly"
 
 
 @pytest.mark.django_db
@@ -127,30 +140,32 @@ class TestDashboardIntegration:
         client, user = authenticated_client
 
         # Create contact and gift
-        contact_response = client.post('/api/v1/contacts/', {
-            'first_name': 'Test',
-            'last_name': 'Dashboard',
-            'email': 'test@dashboard.com'
-        })
-        contact_id = contact_response.data['id']
+        contact_response = client.post(
+            "/api/v1/contacts/",
+            {"first_name": "Test", "last_name": "Dashboard", "email": "test@dashboard.com"},
+        )
+        contact_id = contact_response.data["id"]
 
-        client.post('/api/v1/gifts/', {
-            'donor_contact': contact_id,
-            'amount_cents': 25000,  # $250.00
-            'gift_date': timezone.now().date().isoformat(),
-        })
+        client.post(
+            "/api/v1/gifts/",
+            {
+                "donor_contact": contact_id,
+                "amount_cents": 25000,  # $250.00
+                "gift_date": timezone.now().date().isoformat(),
+            },
+        )
 
         # Get dashboard
-        response = client.get('/api/v1/dashboard/')
+        response = client.get("/api/v1/dashboard/")
         assert response.status_code == status.HTTP_200_OK
 
         # Verify thank-you queue
-        response = client.get('/api/v1/dashboard/thank-you-queue/')
+        response = client.get("/api/v1/dashboard/thank-you-queue/")
         assert response.status_code == status.HTTP_200_OK
         assert len(response.data) >= 1
 
         # Verify recent gifts
-        response = client.get('/api/v1/dashboard/recent-gifts/')
+        response = client.get("/api/v1/dashboard/recent-gifts/")
         assert response.status_code == status.HTTP_200_OK
         assert len(response.data) >= 1
 
@@ -166,25 +181,24 @@ class TestPermissionBoundaries:
         client, user1 = authenticated_client
 
         # User 1 creates a contact
-        response = client.post('/api/v1/contacts/', {
-            'first_name': 'Private',
-            'last_name': 'Contact',
-            'email': 'private@example.com'
-        })
-        contact_id = response.data['id']
+        response = client.post(
+            "/api/v1/contacts/",
+            {"first_name": "Private", "last_name": "Contact", "email": "private@example.com"},
+        )
+        contact_id = response.data["id"]
 
         # Create another user and authenticate as them
-        user2 = user_factory(role='missionary')
+        user2 = user_factory(role="missionary")
         client.force_authenticate(user=user2)
 
         # User 2 tries to access User 1's contact
-        response = client.get(f'/api/v1/contacts/{contact_id}/')
+        response = client.get(f"/api/v1/contacts/{contact_id}/")
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
         # User 2 lists contacts - should not see User 1's contact
-        response = client.get('/api/v1/contacts/')
+        response = client.get("/api/v1/contacts/")
         assert response.status_code == status.HTTP_200_OK
-        contact_ids = [c['id'] for c in response.data['results']]
+        contact_ids = [c["id"] for c in response.data["results"]]
         assert contact_id not in contact_ids
 
     def test_admin_sees_own_contacts_only(self, authenticated_client, admin_client):
@@ -193,56 +207,52 @@ class TestPermissionBoundaries:
         admin_cli, admin = admin_client
 
         # Regular user creates a contact
-        response = client.post('/api/v1/contacts/', {
-            'first_name': 'Other',
-            'last_name': 'UserContact',
-            'email': 'other@example.com'
-        })
-        other_contact_id = response.data['id']
+        response = client.post(
+            "/api/v1/contacts/",
+            {"first_name": "Other", "last_name": "UserContact", "email": "other@example.com"},
+        )
+        other_contact_id = response.data["id"]
 
         # Admin creates their own contact
-        response = admin_cli.post('/api/v1/contacts/', {
-            'first_name': 'Admin',
-            'last_name': 'OwnContact',
-            'email': 'admin-own@example.com'
-        })
-        admin_contact_id = response.data['id']
+        response = admin_cli.post(
+            "/api/v1/contacts/",
+            {"first_name": "Admin", "last_name": "OwnContact", "email": "admin-own@example.com"},
+        )
+        admin_contact_id = response.data["id"]
 
         # Admin cannot see other user's contact
-        response = admin_cli.get(f'/api/v1/contacts/{other_contact_id}/')
+        response = admin_cli.get(f"/api/v1/contacts/{other_contact_id}/")
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
         # Admin can see their own contact
-        response = admin_cli.get(f'/api/v1/contacts/{admin_contact_id}/')
+        response = admin_cli.get(f"/api/v1/contacts/{admin_contact_id}/")
         assert response.status_code == status.HTTP_200_OK
 
         # Admin list only includes their own contacts
-        response = admin_cli.get('/api/v1/contacts/')
+        response = admin_cli.get("/api/v1/contacts/")
         assert response.status_code == status.HTTP_200_OK
-        contact_ids = [c['id'] for c in response.data['results']]
+        contact_ids = [c["id"] for c in response.data["results"]]
         assert admin_contact_id in contact_ids
         assert other_contact_id not in contact_ids
 
     def test_coach_cannot_modify_others_contacts(self, authenticated_client):
         """Test coach users cannot modify contacts they don't own."""
         from apps.users.tests.factories import CoachUserFactory
+
         client, user = authenticated_client
 
         # Create contact as missionary
-        response = client.post('/api/v1/contacts/', {
-            'first_name': 'Someone',
-            'last_name': 'Else',
-            'email': 'someone@example.com'
-        })
-        contact_id = response.data['id']
+        response = client.post(
+            "/api/v1/contacts/",
+            {"first_name": "Someone", "last_name": "Else", "email": "someone@example.com"},
+        )
+        contact_id = response.data["id"]
 
         # Coach cannot update another user's contact
         coach = CoachUserFactory()
         coach_client = APIClient()
         coach_client.force_authenticate(user=coach)
-        response = coach_client.patch(f'/api/v1/contacts/{contact_id}/', {
-            'first_name': 'Updated'
-        })
+        response = coach_client.patch(f"/api/v1/contacts/{contact_id}/", {"first_name": "Updated"})
         assert response.status_code in (status.HTTP_403_FORBIDDEN, status.HTTP_404_NOT_FOUND)
 
 
@@ -257,31 +267,33 @@ class TestEventNotifications:
         client, user = authenticated_client
 
         # Create contact
-        response = client.post('/api/v1/contacts/', {
-            'first_name': 'Event',
-            'last_name': 'Test',
-            'email': 'event@test.com'
-        })
-        contact_id = response.data['id']
+        response = client.post(
+            "/api/v1/contacts/",
+            {"first_name": "Event", "last_name": "Test", "email": "event@test.com"},
+        )
+        contact_id = response.data["id"]
 
         # Check events before gift
-        events_before = client.get('/api/v1/events/').data['count']
+        events_before = client.get("/api/v1/events/").data["count"]
 
         # Add gift
-        client.post('/api/v1/gifts/', {
-            'donor_contact': contact_id,
-            'amount_cents': 7500,  # $75.00
-            'gift_date': timezone.now().date().isoformat(),
-        })
+        client.post(
+            "/api/v1/gifts/",
+            {
+                "donor_contact": contact_id,
+                "amount_cents": 7500,  # $75.00
+                "gift_date": timezone.now().date().isoformat(),
+            },
+        )
 
         # Check events after gift
-        response = client.get('/api/v1/events/')
-        events_after = response.data['count']
+        response = client.get("/api/v1/events/")
+        events_after = response.data["count"]
         assert events_after > events_before
 
         # Find the donation event (uses DONATION_RECEIVED event type for backward compat)
-        events = response.data['results']
-        donation_events = [e for e in events if e['event_type'] == 'donation_received']
+        events = response.data["results"]
+        donation_events = [e for e in events if e["event_type"] == "donation_received"]
         assert len(donation_events) > 0
 
 
@@ -293,22 +305,24 @@ class TestCoachContactAccess:
         """ROLE-03: Coach can GET /api/v1/contacts/ and receive 200."""
         coach_user.coached_users.add(missionary_user)
         api_client.force_authenticate(user=coach_user)
-        response = api_client.get('/api/v1/contacts/')
+        response = api_client.get("/api/v1/contacts/")
         assert response.status_code == 200
 
     def test_coach_cannot_create_contact(self, api_client, coach_user):
         """ROLE-03 write block: Coach POST /api/v1/contacts/ returns 403."""
         api_client.force_authenticate(user=coach_user)
-        response = api_client.post('/api/v1/contacts/', data={
-            'first_name': 'Test', 'last_name': 'Donor'
-        }, format='json')
+        response = api_client.post(
+            "/api/v1/contacts/", data={"first_name": "Test", "last_name": "Donor"}, format="json"
+        )
         assert response.status_code == 403
 
-    def test_coach_contact_list_scoped_to_missionaries(self, api_client, coach_user, missionary_user):
+    def test_coach_contact_list_scoped_to_missionaries(
+        self, api_client, coach_user, missionary_user
+    ):
         """ROLE-05: Coach sees only contacts owned by their coached missionaries."""
         coach_user.coached_users.add(missionary_user)
-        Contact.objects.create(owner=missionary_user, first_name='Visible', last_name='Contact')
+        Contact.objects.create(owner=missionary_user, first_name="Visible", last_name="Contact")
         api_client.force_authenticate(user=coach_user)
-        response = api_client.get('/api/v1/contacts/')
+        response = api_client.get("/api/v1/contacts/")
         assert response.status_code == 200
         # scoped: returns contacts owned by coached missionaries

--- a/apps/contacts/tests/test_merge.py
+++ b/apps/contacts/tests/test_merge.py
@@ -2,13 +2,11 @@
 Tests for contact merge functionality.
 All tests are SQLite-safe (no pg_trgm usage).
 """
-from datetime import date, timedelta
-
-from django.utils import timezone
+from datetime import date
 
 import pytest
 
-from apps.contacts.models import Contact, ContactMergeLog
+from apps.contacts.models import ContactMergeLog
 from apps.contacts.tests.factories import ContactFactory
 from apps.events.tests.factories import EventFactory
 from apps.gifts.tests.factories import GiftFactory, RecurringGiftFactory
@@ -56,7 +54,6 @@ class TestMergeContacts:
     def test_merge_reassigns_tasks(self):
         """After merge, tasks from loser belong to survivor."""
         from apps.contacts.services import merge_contacts
-        from apps.tasks.models import Task
 
         user = UserFactory()
         survivor = ContactFactory(owner=user)
@@ -86,7 +83,6 @@ class TestMergeContacts:
     def test_merge_reassigns_events(self):
         """After merge, events linked to loser contact are reassigned to survivor."""
         from apps.contacts.services import merge_contacts
-        from apps.events.models import Event
 
         user = UserFactory()
         survivor = ContactFactory(owner=user)

--- a/apps/contacts/tests/test_merge.py
+++ b/apps/contacts/tests/test_merge.py
@@ -2,17 +2,19 @@
 Tests for contact merge functionality.
 All tests are SQLite-safe (no pg_trgm usage).
 """
-import pytest
 from datetime import date, timedelta
+
 from django.utils import timezone
+
+import pytest
 
 from apps.contacts.models import Contact, ContactMergeLog
 from apps.contacts.tests.factories import ContactFactory
-from apps.users.tests.factories import UserFactory
-from apps.gifts.tests.factories import GiftFactory, RecurringGiftFactory
-from apps.tasks.tests.factories import TaskFactory
 from apps.events.tests.factories import EventFactory
+from apps.gifts.tests.factories import GiftFactory, RecurringGiftFactory
 from apps.groups.tests.factories import GroupFactory
+from apps.tasks.tests.factories import TaskFactory
+from apps.users.tests.factories import UserFactory
 
 
 @pytest.mark.django_db
@@ -74,9 +76,7 @@ class TestMergeContacts:
         user = UserFactory()
         survivor = ContactFactory(owner=user)
         loser = ContactFactory(owner=user)
-        pi = PrayerIntention.objects.create(
-            contact=loser, title='Test prayer', description='Desc'
-        )
+        pi = PrayerIntention.objects.create(contact=loser, title="Test prayer", description="Desc")
 
         merge_contacts(survivor.id, loser.id, merged_by=user)
 
@@ -106,9 +106,7 @@ class TestMergeContacts:
         user = UserFactory()
         survivor = ContactFactory(owner=user)
         loser = ContactFactory(owner=user)
-        journal = Journal.objects.create(
-            owner=user, name='Test Journal', goal_amount=1000
-        )
+        journal = Journal.objects.create(owner=user, name="Test Journal", goal_amount=1000)
         jc = JournalContact.objects.create(journal=journal, contact=loser)
 
         merge_contacts(survivor.id, loser.id, merged_by=user)
@@ -120,16 +118,17 @@ class TestMergeContacts:
         """Both contacts in same journal: loser JC events moved to survivor JC, loser JC deleted."""
         from apps.contacts.services import merge_contacts
         from apps.journals.models import (
-            Journal, JournalContact, JournalStageEvent,
-            PipelineStage, StageEventType
+            Journal,
+            JournalContact,
+            JournalStageEvent,
+            PipelineStage,
+            StageEventType,
         )
 
         user = UserFactory()
         survivor = ContactFactory(owner=user)
         loser = ContactFactory(owner=user)
-        journal = Journal.objects.create(
-            owner=user, name='Test Journal', goal_amount=1000
-        )
+        journal = Journal.objects.create(owner=user, name="Test Journal", goal_amount=1000)
         survivor_jc = JournalContact.objects.create(journal=journal, contact=survivor)
         loser_jc = JournalContact.objects.create(journal=journal, contact=loser)
 
@@ -138,7 +137,7 @@ class TestMergeContacts:
             journal_contact=loser_jc,
             stage=PipelineStage.CONTACT,
             event_type=StageEventType.CALL_LOGGED,
-            triggered_by=user
+            triggered_by=user,
         )
 
         merge_contacts(survivor.id, loser.id, merged_by=user)
@@ -166,7 +165,7 @@ class TestMergeContacts:
         merge_contacts(survivor.id, loser.id, merged_by=user)
 
         survivor.refresh_from_db()
-        group_ids = set(survivor.groups.values_list('id', flat=True))
+        group_ids = set(survivor.groups.values_list("id", flat=True))
         assert group_a.id in group_ids
         assert group_b.id in group_ids
         assert group_shared.id in group_ids
@@ -202,35 +201,35 @@ class TestMergeContacts:
         assert log.survivor_id == survivor.id
         assert log.loser_id == loser_id
         assert log.merged_by_id == user.id
-        assert 'gifts' in log.records_migrated
+        assert "gifts" in log.records_migrated
 
     def test_merge_auto_fills_blanks(self):
         """Survivor's blank fields get filled from loser's non-empty values."""
         from apps.contacts.services import merge_contacts
 
         user = UserFactory()
-        survivor = ContactFactory(owner=user, email='survivor@example.com', phone='')
-        loser = ContactFactory(owner=user, email='loser@example.com', phone='555-1234')
+        survivor = ContactFactory(owner=user, email="survivor@example.com", phone="")
+        loser = ContactFactory(owner=user, email="loser@example.com", phone="555-1234")
 
         merge_contacts(survivor.id, loser.id, merged_by=user)
 
         survivor.refresh_from_db()
-        assert survivor.phone == '555-1234'  # Auto-filled from loser
-        assert survivor.email == 'survivor@example.com'  # Kept (non-blank)
+        assert survivor.phone == "555-1234"  # Auto-filled from loser
+        assert survivor.email == "survivor@example.com"  # Kept (non-blank)
 
     def test_merge_does_not_overwrite_survivor_fields(self):
         """Survivor's populated fields are never overwritten by loser's values."""
         from apps.contacts.services import merge_contacts
 
         user = UserFactory()
-        survivor = ContactFactory(owner=user, first_name='Alice', email='alice@example.com')
-        loser = ContactFactory(owner=user, first_name='Bob', email='bob@example.com')
+        survivor = ContactFactory(owner=user, first_name="Alice", email="alice@example.com")
+        loser = ContactFactory(owner=user, first_name="Bob", email="bob@example.com")
 
         merge_contacts(survivor.id, loser.id, merged_by=user)
 
         survivor.refresh_from_db()
-        assert survivor.first_name == 'Alice'  # Not overwritten
-        assert survivor.email == 'alice@example.com'  # Not overwritten
+        assert survivor.first_name == "Alice"  # Not overwritten
+        assert survivor.email == "alice@example.com"  # Not overwritten
 
     def test_merge_recalculates_stats(self):
         """Survivor's giving stats include transferred gifts after merge."""
@@ -255,5 +254,5 @@ class TestMergeContacts:
         survivor = ContactFactory(owner=user)
         loser = ContactFactory(owner=user, is_merged=True)
 
-        with pytest.raises(ValueError, match='already been merged'):
+        with pytest.raises(ValueError, match="already been merged"):
             merge_contacts(survivor.id, loser.id, merged_by=user)

--- a/apps/contacts/tests/test_models.py
+++ b/apps/contacts/tests/test_models.py
@@ -16,14 +16,14 @@ class TestUpdateGivingStats:
 
     def test_last_gift_amount_cleared_when_all_gifts_deleted(self):
         """Deleting all gifts should clear last_gift_amount to None."""
-        user = UserFactory(role='missionary')
+        user = UserFactory(role="missionary")
         contact = ContactFactory(owner=user)
 
         # Create a gift and update stats
         gift = GiftFactory(donor_contact=contact, amount_cents=5000)
         contact.update_giving_stats()
         contact.refresh_from_db()
-        assert contact.last_gift_amount == Decimal('50.00')
+        assert contact.last_gift_amount == Decimal("50.00")
 
         # Delete the gift and update stats
         gift.delete()
@@ -32,4 +32,4 @@ class TestUpdateGivingStats:
 
         assert contact.last_gift_amount is None
         assert contact.gift_count == 0
-        assert contact.total_given == Decimal('0')
+        assert contact.total_given == Decimal("0")

--- a/apps/contacts/tests/test_org_contact_mapping.py
+++ b/apps/contacts/tests/test_org_contact_mapping.py
@@ -12,8 +12,9 @@ They specify all behaviors that Wave 1 tasks must implement:
 6. GET /contacts/search/?q=<org> finds org contacts (search Q filter)
 7. CSV export Name column shows organization_name for org contacts
 """
-import pytest
 from rest_framework.test import APIClient
+
+import pytest
 
 from apps.contacts.serializers import ContactCreateSerializer, ContactListSerializer
 from apps.contacts.tests.factories import OrgContactFactory
@@ -32,16 +33,18 @@ class TestOrgContactSerializer:
     def test_contact_list_serializer_includes_org_name(self):
         contact = OrgContactFactory()
         data = ContactListSerializer(contact).data
-        assert 'organization_name' in data
-        assert data['organization_name'] == contact.organization_name
+        assert "organization_name" in data
+        assert data["organization_name"] == contact.organization_name
 
     def test_create_serializer_accepts_blank_names_with_org(self):
-        serializer = ContactCreateSerializer(data={
-            'first_name': '',
-            'last_name': '',
-            'organization_name': 'Acme Corp',
-            'status': 'prospect',
-        })
+        serializer = ContactCreateSerializer(
+            data={
+                "first_name": "",
+                "last_name": "",
+                "organization_name": "Acme Corp",
+                "status": "prospect",
+            }
+        )
         assert serializer.is_valid(), serializer.errors
 
 
@@ -54,25 +57,25 @@ class TestOrgContactAPIEndpoints:
         self.org_contact = OrgContactFactory(owner=self.user)
 
     def test_contact_list_api_includes_org_name(self):
-        resp = self.client.get('/api/v1/contacts/')
+        resp = self.client.get("/api/v1/contacts/")
         assert resp.status_code == 200
-        results = resp.json()['results']
-        assert any(c['id'] == str(self.org_contact.id) for c in results)
-        contact_data = next(c for c in results if c['id'] == str(self.org_contact.id))
-        assert 'organization_name' in contact_data
+        results = resp.json()["results"]
+        assert any(c["id"] == str(self.org_contact.id) for c in results)
+        contact_data = next(c for c in results if c["id"] == str(self.org_contact.id))
+        assert "organization_name" in contact_data
 
     def test_list_endpoint_search_finds_org_by_name(self):
         query = self.org_contact.organization_name[:5]
-        resp = self.client.get(f'/api/v1/contacts/?search={query}')
+        resp = self.client.get(f"/api/v1/contacts/?search={query}")
         assert resp.status_code == 200
-        ids = [c['id'] for c in resp.json()['results']]
+        ids = [c["id"] for c in resp.json()["results"]]
         assert str(self.org_contact.id) in ids
 
     def test_search_endpoint_finds_org_by_name(self):
         query = self.org_contact.organization_name[:5]
-        resp = self.client.get(f'/api/v1/contacts/search/?q={query}')
+        resp = self.client.get(f"/api/v1/contacts/search/?q={query}")
         assert resp.status_code == 200
-        ids = [c['id'] for c in resp.json()]
+        ids = [c["id"] for c in resp.json()]
         assert str(self.org_contact.id) in ids
 
 
@@ -85,10 +88,10 @@ class TestOrgContactCSVExport:
         self.org_contact = OrgContactFactory(owner=self.user)
 
     def test_csv_export_uses_full_name_for_org(self):
-        resp = self.client.get('/api/v1/contacts/export/csv/')
+        resp = self.client.get("/api/v1/contacts/export/csv/")
         assert resp.status_code == 200
-        content = b''.join(resp.streaming_content).decode()
-        lines = content.strip().split('\n')
+        content = b"".join(resp.streaming_content).decode()
+        lines = content.strip().split("\n")
         # Header row first, then data rows
         assert len(lines) >= 2
         # The org contact's name should appear in the CSV content

--- a/apps/contacts/urls.py
+++ b/apps/contacts/urls.py
@@ -16,27 +16,35 @@ from apps.contacts.views import (
     ContactSearchView,
     ContactTasksView,
     ContactThankView,
+    DismissDuplicateView,
     DuplicateCheckView,
     MergeContactsView,
-    DismissDuplicateView,
 )
 
-app_name = 'contacts'
+app_name = "contacts"
 
 urlpatterns = [
-    path('', ContactListCreateView.as_view(), name='contact-list'),
-    path('export/csv/', ContactExportCSVView.as_view(), name='contact-export-csv'),
-    path('emails/', ContactEmailsView.as_view(), name='contact-emails'),
-    path('search/', ContactSearchView.as_view(), name='contact-search'),
-    path('duplicates/check/', DuplicateCheckView.as_view(), name='duplicate-check'),
-    path('duplicates/merge/', MergeContactsView.as_view(), name='duplicate-merge'),
-    path('duplicates/dismiss/', DismissDuplicateView.as_view(), name='duplicate-dismiss'),
-    path('<uuid:pk>/', ContactDetailView.as_view(), name='contact-detail'),
-    path('<uuid:pk>/thank/', ContactThankView.as_view(), name='contact-thank'),
-    path('<uuid:pk>/donations/', ContactGiftsView.as_view(), name='contact-donations'),
-    path('<uuid:pk>/pledges/', ContactRecurringGiftsView.as_view(), name='contact-pledges'),
-    path('<uuid:pk>/tasks/', ContactTasksView.as_view(), name='contact-tasks'),
-    path('<uuid:pk>/prayer-intentions/', ContactPrayerIntentionsView.as_view(), name='contact-prayers'),
-    path('<uuid:pk>/journals/', ContactJournalsView.as_view(), name='contact-journals'),
-    path('<uuid:pk>/journal-events/', ContactJournalEventsView.as_view(), name='contact-journal-events'),
+    path("", ContactListCreateView.as_view(), name="contact-list"),
+    path("export/csv/", ContactExportCSVView.as_view(), name="contact-export-csv"),
+    path("emails/", ContactEmailsView.as_view(), name="contact-emails"),
+    path("search/", ContactSearchView.as_view(), name="contact-search"),
+    path("duplicates/check/", DuplicateCheckView.as_view(), name="duplicate-check"),
+    path("duplicates/merge/", MergeContactsView.as_view(), name="duplicate-merge"),
+    path("duplicates/dismiss/", DismissDuplicateView.as_view(), name="duplicate-dismiss"),
+    path("<uuid:pk>/", ContactDetailView.as_view(), name="contact-detail"),
+    path("<uuid:pk>/thank/", ContactThankView.as_view(), name="contact-thank"),
+    path("<uuid:pk>/donations/", ContactGiftsView.as_view(), name="contact-donations"),
+    path("<uuid:pk>/pledges/", ContactRecurringGiftsView.as_view(), name="contact-pledges"),
+    path("<uuid:pk>/tasks/", ContactTasksView.as_view(), name="contact-tasks"),
+    path(
+        "<uuid:pk>/prayer-intentions/",
+        ContactPrayerIntentionsView.as_view(),
+        name="contact-prayers",
+    ),
+    path("<uuid:pk>/journals/", ContactJournalsView.as_view(), name="contact-journals"),
+    path(
+        "<uuid:pk>/journal-events/",
+        ContactJournalEventsView.as_view(),
+        name="contact-journal-events",
+    ),
 ]

--- a/apps/contacts/views.py
+++ b/apps/contacts/views.py
@@ -515,9 +515,7 @@ class DismissDuplicateView(APIView):
             contact_a = Contact.objects.get(
                 pk=ser.validated_data["contact_a_id"], owner_id__in=visible
             )
-            contact_b = Contact.objects.get(
-                pk=ser.validated_data["contact_b_id"], owner_id__in=visible
-            )
+            Contact.objects.get(pk=ser.validated_data["contact_b_id"], owner_id__in=visible)
         except Contact.DoesNotExist:
             return Response({"detail": "Contact not found."}, status=status.HTTP_404_NOT_FOUND)
         # Only the contact owner or an admin can dismiss duplicates

--- a/apps/contacts/views.py
+++ b/apps/contacts/views.py
@@ -1,24 +1,26 @@
 """
 Views for Contact management.
 """
-from django.db.models import Q, Prefetch
-from django_filters.rest_framework import DjangoFilterBackend
-from drf_spectacular.utils import extend_schema, extend_schema_view, OpenApiParameter
+from django.db.models import Prefetch, Q
+
 from rest_framework import filters, generics, permissions, status
 from rest_framework.response import Response
 from rest_framework.views import APIView
+
+from django_filters.rest_framework import DjangoFilterBackend
+from drf_spectacular.utils import OpenApiParameter, extend_schema, extend_schema_view
 
 from apps.contacts.filters import ContactFilterSet
 from apps.contacts.models import Contact, DismissedDuplicate
 from apps.contacts.serializers import (
     ContactCreateSerializer,
     ContactDetailSerializer,
-    ContactListSerializer,
     ContactJournalMembershipSerializer,
+    ContactListSerializer,
+    DismissRequestSerializer,
     DuplicateCheckSerializer,
     DuplicateMatchSerializer,
     MergeRequestSerializer,
-    DismissRequestSerializer,
 )
 from apps.contacts.services import find_duplicates_for_contact, merge_contacts
 from apps.core.pagination import StandardPagination
@@ -339,7 +341,7 @@ class ContactJournalsView(generics.ListAPIView):
     pagination_class = None
 
     def get_queryset(self):
-        from apps.journals.models import JournalStageEvent, Decision
+        from apps.journals.models import Decision, JournalStageEvent
 
         contact_id = self.kwargs.get("pk")
         user = self.request.user

--- a/apps/core/email.py
+++ b/apps/core/email.py
@@ -12,11 +12,7 @@ logger = logging.getLogger(__name__)
 
 
 def send_email(
-    subject: str,
-    to_email: str,
-    template_name: str,
-    context: dict,
-    from_email: Optional[str] = None
+    subject: str, to_email: str, template_name: str, context: dict, from_email: Optional[str] = None
 ) -> bool:
     """
     Send an email using a template.
@@ -36,31 +32,28 @@ def send_email(
 
     try:
         # Render text version
-        text_content = render_to_string(f'emails/{template_name}.txt', context)
+        text_content = render_to_string(f"emails/{template_name}.txt", context)
 
         # Try to render HTML version (optional)
         try:
-            html_content = render_to_string(f'emails/{template_name}.html', context)
+            html_content = render_to_string(f"emails/{template_name}.html", context)
         except Exception:
             html_content = None
 
         # Create email
         email = EmailMultiAlternatives(
-            subject=subject,
-            body=text_content,
-            from_email=from_email,
-            to=[to_email]
+            subject=subject, body=text_content, from_email=from_email, to=[to_email]
         )
 
         if html_content:
-            email.attach_alternative(html_content, 'text/html')
+            email.attach_alternative(html_content, "text/html")
 
         email.send()
-        logger.info(f'Email sent to {to_email}: {subject}')
+        logger.info(f"Email sent to {to_email}: {subject}")
         return True
 
     except Exception as e:
-        logger.error(f'Failed to send email to {to_email}: {e}')
+        logger.error(f"Failed to send email to {to_email}: {e}")
         return False
 
 
@@ -76,20 +69,18 @@ def send_weekly_summary_email(user, summary_data: dict) -> bool:
         True if email sent successfully, False otherwise
     """
     context = {
-        'user': user,
-        'summary': summary_data,
-        'what_changed': summary_data.get('what_changed', {}),
-        'needs_attention': summary_data.get('needs_attention', {}),
-        'at_risk_count': summary_data.get('at_risk_count', 0),
-        'thank_you_count': summary_data.get('thank_you_count', 0),
-        'support_progress': summary_data.get('support_progress', {}),
+        "user": user,
+        "summary": summary_data,
+        "what_changed": summary_data.get("what_changed", {}),
+        "needs_attention": summary_data.get("needs_attention", {}),
+        "at_risk_count": summary_data.get("at_risk_count", 0),
+        "thank_you_count": summary_data.get("thank_you_count", 0),
+        "support_progress": summary_data.get("support_progress", {}),
     }
 
     return send_email(
-        subject=f'DonorCRM Weekly Summary - {user.first_name}',
+        subject=f"DonorCRM Weekly Summary - {user.first_name}",
         to_email=user.email,
-        template_name='weekly_summary',
-        context=context
+        template_name="weekly_summary",
+        context=context,
     )
-
-

--- a/apps/core/exceptions.py
+++ b/apps/core/exceptions.py
@@ -4,6 +4,7 @@ Custom exceptions for DonorCRM.
 import logging
 
 from django.core.exceptions import ValidationError as DjangoValidationError
+
 from rest_framework import status
 from rest_framework.exceptions import APIException
 from rest_framework.response import Response
@@ -16,29 +17,31 @@ def custom_exception_handler(exc, context):
     """Catch Django ValidationErrors and unexpected exceptions to prevent
     internal details from leaking in API responses."""
     if isinstance(exc, DjangoValidationError):
-        detail = exc.message_dict if hasattr(exc, 'message_dict') else exc.messages
-        return Response({'detail': detail}, status=status.HTTP_400_BAD_REQUEST)
+        detail = exc.message_dict if hasattr(exc, "message_dict") else exc.messages
+        return Response({"detail": detail}, status=status.HTTP_400_BAD_REQUEST)
 
     response = drf_exception_handler(exc, context)
     if response is not None:
         return response
 
-    logger.exception('Unhandled exception in API view')
+    logger.exception("Unhandled exception in API view")
     return Response(
-        {'detail': 'An unexpected error occurred.'},
+        {"detail": "An unexpected error occurred."},
         status=status.HTTP_500_INTERNAL_SERVER_ERROR,
     )
 
 
 class DuplicateRecordError(APIException):
     """Raised when attempting to create a duplicate record."""
+
     status_code = 409
-    default_detail = 'A record with this identifier already exists.'
-    default_code = 'duplicate_record'
+    default_detail = "A record with this identifier already exists."
+    default_code = "duplicate_record"
 
 
 class ImportValidationError(APIException):
     """Raised when CSV import validation fails."""
+
     status_code = 400
-    default_detail = 'Import validation failed.'
-    default_code = 'import_validation_error'
+    default_detail = "Import validation failed."
+    default_code = "import_validation_error"

--- a/apps/core/gift_utils.py
+++ b/apps/core/gift_utils.py
@@ -12,14 +12,14 @@ from apps.gifts.models import RecurringGiftFrequency
 # Frequency multipliers for SQL CASE/WHEN aggregation.
 # Must match RecurringGift.monthly_equivalent property exactly.
 FREQUENCY_MULTIPLIERS = {
-    RecurringGiftFrequency.MONTHLY: Decimal('1'),
-    RecurringGiftFrequency.QUARTERLY: Decimal('1') / Decimal('3'),
-    RecurringGiftFrequency.SEMI_ANNUALLY: Decimal('1') / Decimal('6'),
-    RecurringGiftFrequency.ANNUALLY: Decimal('1') / Decimal('12'),
-    RecurringGiftFrequency.BIMONTHLY: Decimal('1') / Decimal('2'),
-    RecurringGiftFrequency.BIWEEKLY: Decimal('26') / Decimal('12'),
-    RecurringGiftFrequency.WEEKLY: Decimal('52') / Decimal('12'),
-    RecurringGiftFrequency.IRREGULAR: Decimal('1'),
+    RecurringGiftFrequency.MONTHLY: Decimal("1"),
+    RecurringGiftFrequency.QUARTERLY: Decimal("1") / Decimal("3"),
+    RecurringGiftFrequency.SEMI_ANNUALLY: Decimal("1") / Decimal("6"),
+    RecurringGiftFrequency.ANNUALLY: Decimal("1") / Decimal("12"),
+    RecurringGiftFrequency.BIMONTHLY: Decimal("1") / Decimal("2"),
+    RecurringGiftFrequency.BIWEEKLY: Decimal("26") / Decimal("12"),
+    RecurringGiftFrequency.WEEKLY: Decimal("52") / Decimal("12"),
+    RecurringGiftFrequency.IRREGULAR: Decimal("1"),
 }
 
 
@@ -39,11 +39,11 @@ def _monthly_equivalent_aggregate(queryset):
                 When(frequency=freq, then=Value(mult))
                 for freq, mult in FREQUENCY_MULTIPLIERS.items()
             ],
-            default=Value(Decimal('1')),
+            default=Value(Decimal("1")),
             output_field=DecimalField(max_digits=20, decimal_places=10),
         ),
-        monthly_cents=F('amount_cents') * F('freq_multiplier'),
-    ).aggregate(total=Sum('monthly_cents'))
+        monthly_cents=F("amount_cents") * F("freq_multiplier"),
+    ).aggregate(total=Sum("monthly_cents"))
 
-    total_cents = result['total'] or Decimal('0')
-    return round(total_cents / Decimal('100'), 2)
+    total_cents = result["total"] or Decimal("0")
+    return round(total_cents / Decimal("100"), 2)

--- a/apps/core/late_donations.py
+++ b/apps/core/late_donations.py
@@ -78,17 +78,19 @@ def compute_late_donations(active_recurring_qs, today=None, limit=None):
         interval, reference_date, days_late = result
         contact = rg.donor_contact
         last_gift_date = contact.last_gift_date
-        late.append({
-            "id": str(rg.id),
-            "contact_id": str(contact.id),
-            "contact_name": f"{contact.first_name} {contact.last_name}".strip(),
-            "amount": float(rg.amount_dollars),
-            "frequency": rg.frequency,
-            "monthly_equivalent": float(rg.monthly_equivalent),
-            "last_gift_date": last_gift_date.isoformat() if last_gift_date else None,
-            "days_late": days_late,
-            "next_expected_date": (reference_date + timedelta(days=interval)).isoformat(),
-        })
+        late.append(
+            {
+                "id": str(rg.id),
+                "contact_id": str(contact.id),
+                "contact_name": f"{contact.first_name} {contact.last_name}".strip(),
+                "amount": float(rg.amount_dollars),
+                "frequency": rg.frequency,
+                "monthly_equivalent": float(rg.monthly_equivalent),
+                "last_gift_date": last_gift_date.isoformat() if last_gift_date else None,
+                "days_late": days_late,
+                "next_expected_date": (reference_date + timedelta(days=interval)).isoformat(),
+            }
+        )
 
     late.sort(key=lambda x: x["days_late"], reverse=True)
     return late if limit is None else late[:limit]
@@ -102,11 +104,7 @@ def count_late_donations(active_recurring_qs, today=None):
     doesn't OOM building a list that gets discarded.
     """
     today = today or timezone.localdate()
-    return sum(
-        1
-        for rg in _scoped_qs(active_recurring_qs)
-        if _is_late(rg, today) is not None
-    )
+    return sum(1 for rg in _scoped_qs(active_recurring_qs) if _is_late(rg, today) is not None)
 
 
 def base_recurring_for_owner(user):

--- a/apps/core/management/commands/create_test_accounts.py
+++ b/apps/core/management/commands/create_test_accounts.py
@@ -57,9 +57,8 @@ class Command(BaseCommand):
         )
         alex.set_password(PASSWORD)
         alex.save()
-        self.stdout.write(
-            f'  {"Created" if alex_created else "Updated"}: Alex Becker (alex.becker@spo.org) [admin]'
-        )
+        action = "Created" if alex_created else "Updated"
+        self.stdout.write(f"  {action}: Alex Becker (alex.becker@spo.org) [admin]")
         if alex_created:
             new_count += 1
 

--- a/apps/core/management/commands/create_test_accounts.py
+++ b/apps/core/management/commands/create_test_accounts.py
@@ -1,58 +1,59 @@
 from django.core.management.base import BaseCommand
+
 from apps.users.models import User, UserRole
 
 
 class Command(BaseCommand):
-    help = 'Create test missionary accounts for Render DB'
+    help = "Create test missionary accounts for Render DB"
 
     def handle(self, *args, **options):
-        PASSWORD = 'Test1234'
+        PASSWORD = "Test1234"
 
         # Tuples: (first, last, goal_cents)  — values are dollar amounts × 100
         missionaries = [
-            ('Joe', 'Man', 220000),
-            ('Frank', 'Guy', 430000),
-            ('Rachel', 'Gal', 110000),
-            ('Jimmy', 'John', 270000),
-            ('Ronald', 'McDonald', 220000),
-            ('Rose', 'Red', 55000),
-            ('Mary', 'Grace', 220000),
-            ('Simon', 'Peter', 220000),
-            ('John', 'Paul', 185000),
-            ('Sarah', 'Female', 220000),
-            ('Wendy', 'Burger', 220000),
+            ("Joe", "Man", 220000),
+            ("Frank", "Guy", 430000),
+            ("Rachel", "Gal", 110000),
+            ("Jimmy", "John", 270000),
+            ("Ronald", "McDonald", 220000),
+            ("Rose", "Red", 55000),
+            ("Mary", "Grace", 220000),
+            ("Simon", "Peter", 220000),
+            ("John", "Paul", 185000),
+            ("Sarah", "Female", 220000),
+            ("Wendy", "Burger", 220000),
         ]
 
         new_count = 0
         for first, last, goal_cents in missionaries:
-            email = f'{first.lower()}.{last.lower()}@spo.org'
+            email = f"{first.lower()}.{last.lower()}@spo.org"
             user, was_created = User.objects.get_or_create(
                 email=email,
                 defaults={
-                    'first_name': first,
-                    'last_name': last,
-                    'role': UserRole.MISSIONARY,
-                    'monthly_support_goal_cents': goal_cents,
-                    'is_active': True,
-                }
+                    "first_name": first,
+                    "last_name": last,
+                    "role": UserRole.MISSIONARY,
+                    "monthly_support_goal_cents": goal_cents,
+                    "is_active": True,
+                },
             )
             user.set_password(PASSWORD)
             user.save()
-            status = 'Created' if was_created else 'Updated'
-            self.stdout.write(f'  {status}: {first} {last} ({email})')
+            status = "Created" if was_created else "Updated"
+            self.stdout.write(f"  {status}: {first} {last} ({email})")
             if was_created:
                 new_count += 1
 
         # Alex Becker — admin account
         alex, alex_created = User.objects.get_or_create(
-            email='alex.becker@spo.org',
+            email="alex.becker@spo.org",
             defaults={
-                'first_name': 'Alex',
-                'last_name': 'Becker',
-                'role': UserRole.ADMIN,
-                'is_staff': True,
-                'is_active': True,
-            }
+                "first_name": "Alex",
+                "last_name": "Becker",
+                "role": UserRole.ADMIN,
+                "is_staff": True,
+                "is_active": True,
+            },
         )
         alex.set_password(PASSWORD)
         alex.save()
@@ -62,6 +63,6 @@ class Command(BaseCommand):
         if alex_created:
             new_count += 1
 
-        self.stdout.write(self.style.SUCCESS(
-            f'\nDone. {new_count} new account(s) created, password: {PASSWORD}'
-        ))
+        self.stdout.write(
+            self.style.SUCCESS(f"\nDone. {new_count} new account(s) created, password: {PASSWORD}")
+        )

--- a/apps/core/management/commands/generate_sample_data.py
+++ b/apps/core/management/commands/generate_sample_data.py
@@ -6,6 +6,7 @@ from datetime import timedelta
 
 from django.core.management.base import BaseCommand
 from django.utils import timezone
+
 from faker import Faker
 
 from apps.contacts.models import Contact, ContactStatus
@@ -19,37 +20,32 @@ fake = Faker()
 
 
 class Command(BaseCommand):
-    help = 'Generate sample data for testing the API'
+    help = "Generate sample data for testing the API"
 
     def add_arguments(self, parser):
         parser.add_argument(
-            '--contacts',
-            type=int,
-            default=25,
-            help='Number of contacts to create (default: 25)'
+            "--contacts", type=int, default=25, help="Number of contacts to create (default: 25)"
         )
         parser.add_argument(
-            '--clear',
-            action='store_true',
-            help='Clear existing data before generating new data'
+            "--clear", action="store_true", help="Clear existing data before generating new data"
         )
 
     def handle(self, *args, **options):
-        if options['clear']:
-            self.stdout.write('Clearing existing data...')
+        if options["clear"]:
+            self.stdout.write("Clearing existing data...")
             self._clear_data()
 
-        self.stdout.write('Generating sample data...')
+        self.stdout.write("Generating sample data...")
 
         # Create users
         users = self._create_users()
-        staff_user = users['staff']
+        staff_user = users["staff"]
 
         # Create groups
         groups = self._create_groups(staff_user)
 
         # Create contacts
-        contacts = self._create_contacts(staff_user, options['contacts'], groups)
+        contacts = self._create_contacts(staff_user, options["contacts"], groups)
 
         # Create donations and pledges
         self._create_donations_and_pledges(contacts)
@@ -57,20 +53,20 @@ class Command(BaseCommand):
         # Create tasks
         self._create_tasks(staff_user, contacts)
 
-        self.stdout.write(self.style.SUCCESS('Sample data generated successfully!'))
-        self.stdout.write('')
-        self.stdout.write('Login credentials:')
-        self.stdout.write(f'  Staff: staff@example.com / testpass123')
-        self.stdout.write(f'  Admin: admin@example.com / testpass123')
-        self.stdout.write('')
-        self.stdout.write(f'Created:')
-        self.stdout.write(f'  - 2 users (staff, admin)')
-        self.stdout.write(f'  - {len(groups)} groups')
-        self.stdout.write(f'  - {len(contacts)} contacts')
-        self.stdout.write(f'  - {Gift.objects.count()} gifts')
-        self.stdout.write(f'  - {RecurringGift.objects.count()} recurring gifts')
-        self.stdout.write(f'  - {Task.objects.count()} tasks')
-        self.stdout.write(f'  - {Event.objects.count()} events')
+        self.stdout.write(self.style.SUCCESS("Sample data generated successfully!"))
+        self.stdout.write("")
+        self.stdout.write("Login credentials:")
+        self.stdout.write(f"  Staff: staff@example.com / testpass123")
+        self.stdout.write(f"  Admin: admin@example.com / testpass123")
+        self.stdout.write("")
+        self.stdout.write(f"Created:")
+        self.stdout.write(f"  - 2 users (staff, admin)")
+        self.stdout.write(f"  - {len(groups)} groups")
+        self.stdout.write(f"  - {len(contacts)} contacts")
+        self.stdout.write(f"  - {Gift.objects.count()} gifts")
+        self.stdout.write(f"  - {RecurringGift.objects.count()} recurring gifts")
+        self.stdout.write(f"  - {Task.objects.count()} tasks")
+        self.stdout.write(f"  - {Event.objects.count()} events")
 
     def _clear_data(self):
         """Clear all existing data."""
@@ -88,61 +84,65 @@ class Command(BaseCommand):
 
         # Staff user
         staff_user, _ = User.objects.get_or_create(
-            email='staff@example.com',
+            email="staff@example.com",
             defaults={
-                'first_name': 'Sarah',
-                'last_name': 'Smith',
-                'role': UserRole.MISSIONARY,
-                'monthly_support_goal_cents': 500000,
-                'is_active': True,
-            }
+                "first_name": "Sarah",
+                "last_name": "Smith",
+                "role": UserRole.MISSIONARY,
+                "monthly_support_goal_cents": 500000,
+                "is_active": True,
+            },
         )
-        staff_user.set_password('testpass123')
+        staff_user.set_password("testpass123")
         staff_user.save()
-        users['staff'] = staff_user
+        users["staff"] = staff_user
 
         # Admin user
         admin, _ = User.objects.get_or_create(
-            email='admin@example.com',
+            email="admin@example.com",
             defaults={
-                'first_name': 'Admin',
-                'last_name': 'User',
-                'role': UserRole.ADMIN,
-                'is_staff': True,
-                'is_active': True,
-            }
+                "first_name": "Admin",
+                "last_name": "User",
+                "role": UserRole.ADMIN,
+                "is_staff": True,
+                "is_active": True,
+            },
         )
-        admin.set_password('testpass123')
+        admin.set_password("testpass123")
         admin.save()
-        users['admin'] = admin
+        users["admin"] = admin
 
-        self.stdout.write(f'  Created/updated 2 users')
+        self.stdout.write(f"  Created/updated 2 users")
         return users
 
     def _create_groups(self, owner):
         """Create sample groups."""
         group_data = [
-            {'name': 'Monthly Supporters', 'color': '#22c55e', 'description': 'Active monthly donors'},
-            {'name': 'Church Partners', 'color': '#3b82f6', 'description': 'Church congregations'},
-            {'name': 'Family & Friends', 'color': '#f97316', 'description': 'Personal connections'},
-            {'name': 'Major Donors', 'color': '#a855f7', 'description': 'Donors giving $500+'},
-            {'name': 'Prayer Partners', 'color': '#06b6d4', 'description': 'Committed to praying'},
-            {'name': 'Prospects', 'color': '#6366f1', 'description': 'Potential new supporters'},
+            {
+                "name": "Monthly Supporters",
+                "color": "#22c55e",
+                "description": "Active monthly donors",
+            },
+            {"name": "Church Partners", "color": "#3b82f6", "description": "Church congregations"},
+            {"name": "Family & Friends", "color": "#f97316", "description": "Personal connections"},
+            {"name": "Major Donors", "color": "#a855f7", "description": "Donors giving $500+"},
+            {"name": "Prayer Partners", "color": "#06b6d4", "description": "Committed to praying"},
+            {"name": "Prospects", "color": "#6366f1", "description": "Potential new supporters"},
         ]
 
         groups = []
         for data in group_data:
             group, _ = Group.objects.get_or_create(
-                name=data['name'],
+                name=data["name"],
                 owner=owner,
                 defaults={
-                    'color': data['color'],
-                    'description': data['description'],
-                }
+                    "color": data["color"],
+                    "description": data["description"],
+                },
             )
             groups.append(group)
 
-        self.stdout.write(f'  Created {len(groups)} groups')
+        self.stdout.write(f"  Created {len(groups)} groups")
         return groups
 
     def _create_contacts(self, owner, count, groups):
@@ -158,24 +158,21 @@ class Command(BaseCommand):
 
         for i in range(count):
             # Choose status based on distribution
-            status = random.choices(
-                [s[0] for s in statuses],
-                weights=[s[1] for s in statuses]
-            )[0]
+            status = random.choices([s[0] for s in statuses], weights=[s[1] for s in statuses])[0]
 
             contact = Contact.objects.create(
                 owner=owner,
                 first_name=fake.first_name(),
                 last_name=fake.last_name(),
-                email=fake.email() if random.random() > 0.1 else '',
-                phone=fake.numerify('###-###-####'),
+                email=fake.email() if random.random() > 0.1 else "",
+                phone=fake.numerify("###-###-####"),
                 street_address=fake.street_address(),
                 city=fake.city(),
                 state=fake.state_abbr(),
                 postal_code=fake.zipcode(),
-                country='USA',
+                country="USA",
                 status=status,
-                notes=fake.paragraph() if random.random() > 0.6 else '',
+                notes=fake.paragraph() if random.random() > 0.6 else "",
             )
 
             # Assign to random groups
@@ -186,7 +183,7 @@ class Command(BaseCommand):
 
             contacts.append(contact)
 
-        self.stdout.write(f'  Created {len(contacts)} contacts')
+        self.stdout.write(f"  Created {len(contacts)} contacts")
         return contacts
 
     def _create_donations_and_pledges(self, contacts):
@@ -224,11 +221,13 @@ class Command(BaseCommand):
 
                 # Create recurring gift for some donors (40% chance)
                 if random.random() > 0.6:
-                    frequency = random.choice([
-                        RecurringGiftFrequency.MONTHLY,
-                        RecurringGiftFrequency.QUARTERLY,
-                        RecurringGiftFrequency.ANNUALLY,
-                    ])
+                    frequency = random.choice(
+                        [
+                            RecurringGiftFrequency.MONTHLY,
+                            RecurringGiftFrequency.QUARTERLY,
+                            RecurringGiftFrequency.ANNUALLY,
+                        ]
+                    )
                     amount = random.choice([50, 100, 150, 200, 250])
                     start_date = today - timedelta(days=random.randint(30, 180))
 
@@ -243,8 +242,8 @@ class Command(BaseCommand):
         finally:
             enable_gift_signals()
 
-        self.stdout.write(f'  Created {gift_count} gifts')
-        self.stdout.write(f'  Created {rg_count} recurring gifts')
+        self.stdout.write(f"  Created {gift_count} gifts")
+        self.stdout.write(f"  Created {rg_count} recurring gifts")
 
     def _create_tasks(self, owner, contacts):
         """Create sample tasks."""
@@ -252,12 +251,12 @@ class Command(BaseCommand):
         task_count = 0
 
         task_templates = [
-            ('Call to thank for donation', TaskType.THANK_YOU, TaskPriority.HIGH),
-            ('Follow up on support request', TaskType.FOLLOW_UP, TaskPriority.MEDIUM),
-            ('Send monthly newsletter', TaskType.EMAIL, TaskPriority.LOW),
-            ('Schedule visit', TaskType.MEETING, TaskPriority.MEDIUM),
-            ('Check on prayer request', TaskType.CALL, TaskPriority.MEDIUM),
-            ('Send birthday card', TaskType.OTHER, TaskPriority.LOW),
+            ("Call to thank for donation", TaskType.THANK_YOU, TaskPriority.HIGH),
+            ("Follow up on support request", TaskType.FOLLOW_UP, TaskPriority.MEDIUM),
+            ("Send monthly newsletter", TaskType.EMAIL, TaskPriority.LOW),
+            ("Schedule visit", TaskType.MEETING, TaskPriority.MEDIUM),
+            ("Check on prayer request", TaskType.CALL, TaskPriority.MEDIUM),
+            ("Send birthday card", TaskType.OTHER, TaskPriority.LOW),
         ]
 
         # Create some tasks with contacts
@@ -268,14 +267,14 @@ class Command(BaseCommand):
             Task.objects.create(
                 owner=owner,
                 contact=contact,
-                title=f'{template[0]} - {contact.full_name}',
+                title=f"{template[0]} - {contact.full_name}",
                 task_type=template[1],
                 priority=template[2],
-                status=TaskStatus.PENDING if due_offset >= 0 else random.choice([
-                    TaskStatus.PENDING, TaskStatus.IN_PROGRESS
-                ]),
+                status=TaskStatus.PENDING
+                if due_offset >= 0
+                else random.choice([TaskStatus.PENDING, TaskStatus.IN_PROGRESS]),
                 due_date=today + timedelta(days=due_offset),
-                description=fake.sentence() if random.random() > 0.5 else '',
+                description=fake.sentence() if random.random() > 0.5 else "",
             )
             task_count += 1
 
@@ -291,8 +290,8 @@ class Command(BaseCommand):
                 priority=template[2],
                 status=TaskStatus.PENDING,
                 due_date=today + timedelta(days=due_offset),
-                description=fake.sentence() if random.random() > 0.5 else '',
+                description=fake.sentence() if random.random() > 0.5 else "",
             )
             task_count += 1
 
-        self.stdout.write(f'  Created {task_count} tasks')
+        self.stdout.write(f"  Created {task_count} tasks")

--- a/apps/core/management/commands/generate_sample_data.py
+++ b/apps/core/management/commands/generate_sample_data.py
@@ -56,11 +56,11 @@ class Command(BaseCommand):
         self.stdout.write(self.style.SUCCESS("Sample data generated successfully!"))
         self.stdout.write("")
         self.stdout.write("Login credentials:")
-        self.stdout.write(f"  Staff: staff@example.com / testpass123")
-        self.stdout.write(f"  Admin: admin@example.com / testpass123")
+        self.stdout.write("  Staff: staff@example.com / testpass123")
+        self.stdout.write("  Admin: admin@example.com / testpass123")
         self.stdout.write("")
-        self.stdout.write(f"Created:")
-        self.stdout.write(f"  - 2 users (staff, admin)")
+        self.stdout.write("Created:")
+        self.stdout.write("  - 2 users (staff, admin)")
         self.stdout.write(f"  - {len(groups)} groups")
         self.stdout.write(f"  - {len(contacts)} contacts")
         self.stdout.write(f"  - {Gift.objects.count()} gifts")
@@ -112,7 +112,7 @@ class Command(BaseCommand):
         admin.save()
         users["admin"] = admin
 
-        self.stdout.write(f"  Created/updated 2 users")
+        self.stdout.write("  Created/updated 2 users")
         return users
 
     def _create_groups(self, owner):

--- a/apps/core/management/commands/reset_missionaries.py
+++ b/apps/core/management/commands/reset_missionaries.py
@@ -135,7 +135,7 @@ class Command(BaseCommand):
         self._log_delete("GiftCredit", GiftCredit.objects.all())
         self._log_delete("RecurringGiftCredit", RecurringGiftCredit.objects.all())
 
-        # --- PROTECT: Gifts/RecurringGifts -> Contact (CASCADE), but Solicitor PROTECT is cleared ---
+        # --- PROTECT: Gifts/RecurringGifts -> Contact (CASCADE), Solicitor PROTECT cleared ---
         # Now delete all gifts (contact CASCADE will handle if we delete contacts)
         self._log_delete("Gift", Gift.objects.exclude(donor_contact__owner_id__in=kept_ids))
         self._log_delete(
@@ -143,7 +143,7 @@ class Command(BaseCommand):
         )
 
         # --- Journal sub-models (all CASCADE from JournalContact/Journal) ---
-        # NextStep, Decision, DecisionHistory, JournalStageEvent -> journal_contact -> journal -> owner
+        # NextStep, Decision, DecisionHistory, JournalStageEvent -> journal_contact -> journal
         journals_to_delete = Journal.objects.exclude(owner_id__in=kept_ids)
         jc_to_delete = JournalContact.objects.filter(journal__in=journals_to_delete)
         self._log_delete("NextStep", NextStep.objects.filter(journal_contact__in=jc_to_delete))

--- a/apps/core/management/commands/reset_missionaries.py
+++ b/apps/core/management/commands/reset_missionaries.py
@@ -15,8 +15,8 @@ from apps.groups.models import Group
 from apps.imports.models import (
     Fund,
     ImportBatch,
-    ImportRun,
     ImportRowError,
+    ImportRun,
     MissionaryAlias,
     MPDSnapshot,
     MPDUpload,
@@ -33,51 +33,51 @@ from apps.prayers.models import PrayerIntention
 from apps.tasks.models import Task
 from apps.users.models import GoalJournalSelection, User, UserRole
 
-PASSWORD = os.environ.get('DEMO_USER_PASSWORD', 'changeme')
+PASSWORD = os.environ.get("DEMO_USER_PASSWORD", "changeme")
 GOAL_CENTS = 220000
 
 MISSIONARIES = [
-    ('John', 'Smith'),
-    ('Sarah', 'Johnson'),
-    ('Michael', 'Williams'),
-    ('Emily', 'Brown'),
-    ('David', 'Jones'),
-    ('Jessica', 'Davis'),
-    ('Daniel', 'Miller'),
-    ('Ashley', 'Wilson'),
-    ('Matthew', 'Taylor'),
-    ('Amanda', 'Anderson'),
-    ('Christopher', 'Thomas'),
-    ('Jennifer', 'Martinez'),
-    ('Joshua', 'Garcia'),
-    ('Nicole', 'Robinson'),
-    ('Andrew', 'Clark'),
-    ('Stephanie', 'Lewis'),
-    ('Ryan', 'Walker'),
-    ('Lauren', 'Hall'),
-    ('Kevin', 'Young'),
-    ('Michelle', 'King'),
+    ("John", "Smith"),
+    ("Sarah", "Johnson"),
+    ("Michael", "Williams"),
+    ("Emily", "Brown"),
+    ("David", "Jones"),
+    ("Jessica", "Davis"),
+    ("Daniel", "Miller"),
+    ("Ashley", "Wilson"),
+    ("Matthew", "Taylor"),
+    ("Amanda", "Anderson"),
+    ("Christopher", "Thomas"),
+    ("Jennifer", "Martinez"),
+    ("Joshua", "Garcia"),
+    ("Nicole", "Robinson"),
+    ("Andrew", "Clark"),
+    ("Stephanie", "Lewis"),
+    ("Ryan", "Walker"),
+    ("Lauren", "Hall"),
+    ("Kevin", "Young"),
+    ("Michelle", "King"),
 ]
 
 # Users to keep: admins, superusers, and these specific people
 KEEP_NAMES = [
-    ('matthew', 'kukla'),
-    ('jonathan', 'ryan'),
+    ("matthew", "kukla"),
+    ("jonathan", "ryan"),
 ]
 
 
 class Command(BaseCommand):
-    help = 'Wipe all data, remove non-kept users, and create fresh missionary accounts'
+    help = "Wipe all data, remove non-kept users, and create fresh missionary accounts"
 
     def add_arguments(self, parser):
         parser.add_argument(
-            '--confirm',
-            action='store_true',
-            help='Actually execute (dry-run by default)',
+            "--confirm",
+            action="store_true",
+            help="Actually execute (dry-run by default)",
         )
 
     def handle(self, *args, **options):
-        dry_run = not options['confirm']
+        dry_run = not options["confirm"]
 
         # Build keep filter: superusers OR admins OR specific names
         keep_q = Q(is_superuser=True) | Q(role=UserRole.ADMIN)
@@ -85,122 +85,135 @@ class Command(BaseCommand):
             keep_q |= Q(first_name__iexact=first, last_name__iexact=last)
 
         kept_users = User.objects.filter(keep_q)
-        users_to_delete = User.objects.exclude(pk__in=kept_users.values_list('pk', flat=True))
+        users_to_delete = User.objects.exclude(pk__in=kept_users.values_list("pk", flat=True))
 
-        self.stdout.write('\n=== Users to KEEP ===')
+        self.stdout.write("\n=== Users to KEEP ===")
         for u in kept_users:
-            self.stdout.write(f'  {u.role:12} {u.full_name:25} {u.email}')
+            self.stdout.write(f"  {u.role:12} {u.full_name:25} {u.email}")
 
-        self.stdout.write(f'\n=== Users to DELETE ({users_to_delete.count()}) ===')
+        self.stdout.write(f"\n=== Users to DELETE ({users_to_delete.count()}) ===")
         for u in users_to_delete:
-            self.stdout.write(f'  {u.role:12} {u.full_name:25} {u.email}')
+            self.stdout.write(f"  {u.role:12} {u.full_name:25} {u.email}")
 
-        self.stdout.write(f'\n=== New missionaries to CREATE ({len(MISSIONARIES)}) ===')
+        self.stdout.write(f"\n=== New missionaries to CREATE ({len(MISSIONARIES)}) ===")
         for first, last in MISSIONARIES:
-            email = f'{first.lower()}.{last.lower()}@spo.org'
-            self.stdout.write(f'  {first} {last} ({email})')
+            email = f"{first.lower()}.{last.lower()}@spo.org"
+            self.stdout.write(f"  {first} {last} ({email})")
 
         if dry_run:
-            self.stdout.write(self.style.WARNING(
-                '\nDRY RUN — no changes made. Pass --confirm to execute.'
-            ))
+            self.stdout.write(
+                self.style.WARNING("\nDRY RUN — no changes made. Pass --confirm to execute.")
+            )
             return
 
         with transaction.atomic():
             self._delete_data(users_to_delete, kept_users)
             self._create_missionaries()
 
-        self.stdout.write(self.style.SUCCESS('\nDone.'))
+        self.stdout.write(self.style.SUCCESS("\nDone."))
 
     def _delete_data(self, users_to_delete, kept_users):
         """Delete all data for removed users, then orphan data, then the users."""
-        kept_ids = set(kept_users.values_list('pk', flat=True))
-        delete_ids = set(users_to_delete.values_list('pk', flat=True))
+        kept_ids = set(kept_users.values_list("pk", flat=True))
+        delete_ids = set(users_to_delete.values_list("pk", flat=True))
 
         # --- SET_NULL references pointing to users being deleted ---
         n = Solicitor.objects.filter(user_id__in=delete_ids).update(user=None)
-        self.stdout.write(f'  SET_NULL Solicitor.user: {n}')
+        self.stdout.write(f"  SET_NULL Solicitor.user: {n}")
         n = Task.objects.filter(completed_by_id__in=delete_ids).update(completed_by=None)
-        self.stdout.write(f'  SET_NULL Task.completed_by: {n}')
+        self.stdout.write(f"  SET_NULL Task.completed_by: {n}")
         # Event has no triggered_by — only user (CASCADE), so no SET_NULL needed
-        n = JournalStageEvent.objects.filter(triggered_by_id__in=delete_ids).update(triggered_by=None)
-        self.stdout.write(f'  SET_NULL JournalStageEvent.triggered_by: {n}')
+        n = JournalStageEvent.objects.filter(triggered_by_id__in=delete_ids).update(
+            triggered_by=None
+        )
+        self.stdout.write(f"  SET_NULL JournalStageEvent.triggered_by: {n}")
         n = DecisionHistory.objects.filter(changed_by_id__in=delete_ids).update(changed_by=None)
-        self.stdout.write(f'  SET_NULL DecisionHistory.changed_by: {n}')
+        self.stdout.write(f"  SET_NULL DecisionHistory.changed_by: {n}")
 
         # --- PROTECT: GiftCredit/RecurringGiftCredit (solicitor FK is PROTECT) ---
         # Delete all gift credits first (they PROTECT solicitors)
-        self._log_delete('GiftCredit', GiftCredit.objects.all())
-        self._log_delete('RecurringGiftCredit', RecurringGiftCredit.objects.all())
+        self._log_delete("GiftCredit", GiftCredit.objects.all())
+        self._log_delete("RecurringGiftCredit", RecurringGiftCredit.objects.all())
 
         # --- PROTECT: Gifts/RecurringGifts -> Contact (CASCADE), but Solicitor PROTECT is cleared ---
         # Now delete all gifts (contact CASCADE will handle if we delete contacts)
-        self._log_delete('Gift', Gift.objects.exclude(donor_contact__owner_id__in=kept_ids))
-        self._log_delete('RecurringGift', RecurringGift.objects.exclude(donor_contact__owner_id__in=kept_ids))
+        self._log_delete("Gift", Gift.objects.exclude(donor_contact__owner_id__in=kept_ids))
+        self._log_delete(
+            "RecurringGift", RecurringGift.objects.exclude(donor_contact__owner_id__in=kept_ids)
+        )
 
         # --- Journal sub-models (all CASCADE from JournalContact/Journal) ---
         # NextStep, Decision, DecisionHistory, JournalStageEvent -> journal_contact -> journal -> owner
         journals_to_delete = Journal.objects.exclude(owner_id__in=kept_ids)
         jc_to_delete = JournalContact.objects.filter(journal__in=journals_to_delete)
-        self._log_delete('NextStep', NextStep.objects.filter(journal_contact__in=jc_to_delete))
-        self._log_delete('DecisionHistory',
-                         DecisionHistory.objects.filter(decision__journal_contact__in=jc_to_delete))
-        self._log_delete('Decision', Decision.objects.filter(journal_contact__in=jc_to_delete))
-        self._log_delete('JournalStageEvent', JournalStageEvent.objects.filter(journal_contact__in=jc_to_delete))
-        self._log_delete('JournalContact', jc_to_delete)
-        self._log_delete('GoalJournalSelection', GoalJournalSelection.objects.filter(user_id__in=delete_ids))
-        self._log_delete('Journal', journals_to_delete)
+        self._log_delete("NextStep", NextStep.objects.filter(journal_contact__in=jc_to_delete))
+        self._log_delete(
+            "DecisionHistory",
+            DecisionHistory.objects.filter(decision__journal_contact__in=jc_to_delete),
+        )
+        self._log_delete("Decision", Decision.objects.filter(journal_contact__in=jc_to_delete))
+        self._log_delete(
+            "JournalStageEvent", JournalStageEvent.objects.filter(journal_contact__in=jc_to_delete)
+        )
+        self._log_delete("JournalContact", jc_to_delete)
+        self._log_delete(
+            "GoalJournalSelection", GoalJournalSelection.objects.filter(user_id__in=delete_ids)
+        )
+        self._log_delete("Journal", journals_to_delete)
 
         # --- PrayerIntention (CASCADE from Contact) ---
-        self._log_delete('PrayerIntention',
-                         PrayerIntention.objects.exclude(contact__owner_id__in=kept_ids))
+        self._log_delete(
+            "PrayerIntention", PrayerIntention.objects.exclude(contact__owner_id__in=kept_ids)
+        )
 
         # --- Event, Task (CASCADE from User or have owner FK) ---
-        self._log_delete('Event', Event.objects.exclude(user_id__in=kept_ids))
-        self._log_delete('Task', Task.objects.exclude(owner_id__in=kept_ids))
+        self._log_delete("Event", Event.objects.exclude(user_id__in=kept_ids))
+        self._log_delete("Task", Task.objects.exclude(owner_id__in=kept_ids))
 
         # --- Legacy tables (donations, pledges) not in Django models ---
         # These FK to contacts and funds; must be cleared before those tables.
-        allowed_tables = ('donations', 'pledges')
+        allowed_tables = ("donations", "pledges")
         existing_tables = connection.introspection.table_names()
         with connection.cursor() as cursor:
             for table in allowed_tables:
                 if table in existing_tables:
                     cursor.execute("DELETE FROM %s" % connection.ops.quote_name(table))
-                    self.stdout.write(f'  Deleted legacy {table}: {cursor.rowcount}')
+                    self.stdout.write(f"  Deleted legacy {table}: {cursor.rowcount}")
 
         # --- Contact (PROTECT from User — must delete before user) ---
-        self._log_delete('Contact', Contact.objects.exclude(owner_id__in=kept_ids))
+        self._log_delete("Contact", Contact.objects.exclude(owner_id__in=kept_ids))
 
         # --- Group (CASCADE from User) ---
-        self._log_delete('Group', Group.objects.exclude(owner_id__in=kept_ids))
+        self._log_delete("Group", Group.objects.exclude(owner_id__in=kept_ids))
 
         # --- Import models (PROTECT from User) ---
-        self._log_delete('ImportRowError',
-                         ImportRowError.objects.exclude(import_run__uploaded_by_id__in=kept_ids))
-        self._log_delete('ImportRun', ImportRun.objects.exclude(uploaded_by_id__in=kept_ids))
-        self._log_delete('ImportBatch', ImportBatch.objects.exclude(uploaded_by_id__in=kept_ids))
-        self._log_delete('MPDUpload', MPDUpload.objects.exclude(uploaded_by_id__in=kept_ids))
-        self._log_delete('MPDSnapshot', MPDSnapshot.objects.filter(user_id__in=delete_ids))
-        self._log_delete('MissionaryAlias', MissionaryAlias.objects.filter(user_id__in=delete_ids))
+        self._log_delete(
+            "ImportRowError",
+            ImportRowError.objects.exclude(import_run__uploaded_by_id__in=kept_ids),
+        )
+        self._log_delete("ImportRun", ImportRun.objects.exclude(uploaded_by_id__in=kept_ids))
+        self._log_delete("ImportBatch", ImportBatch.objects.exclude(uploaded_by_id__in=kept_ids))
+        self._log_delete("MPDUpload", MPDUpload.objects.exclude(uploaded_by_id__in=kept_ids))
+        self._log_delete("MPDSnapshot", MPDSnapshot.objects.filter(user_id__in=delete_ids))
+        self._log_delete("MissionaryAlias", MissionaryAlias.objects.filter(user_id__in=delete_ids))
 
         # --- Fund (PROTECT from User, nullable owner) ---
-        self._log_delete('Fund', Fund.objects.filter(
-            Q(owner_id__in=delete_ids) | Q(owner__isnull=True)
-        ))
+        self._log_delete(
+            "Fund", Fund.objects.filter(Q(owner_id__in=delete_ids) | Q(owner__isnull=True))
+        )
         # Also delete Solicitor records with no user link
-        self._log_delete('Solicitor (unlinked)', Solicitor.objects.filter(user__isnull=True))
+        self._log_delete("Solicitor (unlinked)", Solicitor.objects.filter(user__isnull=True))
 
         # --- Finally delete the users ---
         count = len(delete_ids)
         User.objects.filter(pk__in=delete_ids).delete()
-        self.stdout.write(f'\n  Deleted {count} user(s)')
+        self.stdout.write(f"\n  Deleted {count} user(s)")
 
     def _create_missionaries(self):
         """Create the new missionary accounts."""
-        self.stdout.write('\nCreating missionary accounts...')
+        self.stdout.write("\nCreating missionary accounts...")
         for first, last in MISSIONARIES:
-            email = f'{first.lower()}.{last.lower()}@spo.org'
+            email = f"{first.lower()}.{last.lower()}@spo.org"
             user = User.objects.create_user(
                 email=email,
                 first_name=first,
@@ -210,10 +223,10 @@ class Command(BaseCommand):
                 monthly_support_goal_cents=GOAL_CENTS,
                 is_active=True,
             )
-            self.stdout.write(f'  Created: {user.full_name} ({email})')
+            self.stdout.write(f"  Created: {user.full_name} ({email})")
 
     def _log_delete(self, label, qs):
         count = qs.count()
         if count:
             qs.delete()
-            self.stdout.write(f'  Deleted {label}: {count}')
+            self.stdout.write(f"  Deleted {label}: {count}")

--- a/apps/core/management/commands/set_missionary_goals.py
+++ b/apps/core/management/commands/set_missionary_goals.py
@@ -9,43 +9,43 @@ from apps.users.models import User
 
 # (email, goal_cents) — goal in cents, derived from actual test_data recurring totals
 MISSIONARY_GOALS = [
-    ('nicole.robinson@spo.org', 420000),
-    ('jessica.davis@spo.org', 380000),
-    ('kevin.young@spo.org', 390000),
-    ('emily.brown@spo.org', 340000),
-    ('amanda.anderson@spo.org', 320000),
-    ('lauren.hall@spo.org', 340000),
-    ('joshua.garcia@spo.org', 350000),
-    ('andrew.clark@spo.org', 340000),
-    ('john.smith@spo.org', 490000),
-    ('daniel.miller@spo.org', 410000),
-    ('jennifer.martinez@spo.org', 430000),
-    ('stephanie.lewis@spo.org', 410000),
-    ('david.jones@spo.org', 450000),
-    ('sarah.johnson@spo.org', 480000),
-    ('ashley.wilson@spo.org', 470000),
-    ('christopher.thomas@spo.org', 430000),
-    ('matthew.taylor@spo.org', 450000),
-    ('ryan.walker@spo.org', 440000),
-    ('michael.williams@spo.org', 450000),
-    ('michelle.king@spo.org', 280000),
+    ("nicole.robinson@spo.org", 420000),
+    ("jessica.davis@spo.org", 380000),
+    ("kevin.young@spo.org", 390000),
+    ("emily.brown@spo.org", 340000),
+    ("amanda.anderson@spo.org", 320000),
+    ("lauren.hall@spo.org", 340000),
+    ("joshua.garcia@spo.org", 350000),
+    ("andrew.clark@spo.org", 340000),
+    ("john.smith@spo.org", 490000),
+    ("daniel.miller@spo.org", 410000),
+    ("jennifer.martinez@spo.org", 430000),
+    ("stephanie.lewis@spo.org", 410000),
+    ("david.jones@spo.org", 450000),
+    ("sarah.johnson@spo.org", 480000),
+    ("ashley.wilson@spo.org", 470000),
+    ("christopher.thomas@spo.org", 430000),
+    ("matthew.taylor@spo.org", 450000),
+    ("ryan.walker@spo.org", 440000),
+    ("michael.williams@spo.org", 450000),
+    ("michelle.king@spo.org", 280000),
 ]
 
 
 class Command(BaseCommand):
-    help = 'Set realistic monthly support goals for test missionary accounts'
+    help = "Set realistic monthly support goals for test missionary accounts"
 
     def add_arguments(self, parser):
         parser.add_argument(
-            '--dry-run',
-            action='store_true',
-            help='Preview changes without writing to the database.',
+            "--dry-run",
+            action="store_true",
+            help="Preview changes without writing to the database.",
         )
 
     def handle(self, *args, **options):
-        dry_run = options['dry_run']
+        dry_run = options["dry_run"]
         if dry_run:
-            self.stdout.write(self.style.WARNING('DRY RUN — no changes will be saved.\n'))
+            self.stdout.write(self.style.WARNING("DRY RUN — no changes will be saved.\n"))
 
         updated = 0
         skipped = 0
@@ -54,7 +54,7 @@ class Command(BaseCommand):
             try:
                 user = User.objects.get(email=email)
             except User.DoesNotExist:
-                self.stdout.write(f'  SKIP {email} — user not found')
+                self.stdout.write(f"  SKIP {email} — user not found")
                 skipped += 1
                 continue
 
@@ -63,20 +63,16 @@ class Command(BaseCommand):
             old_dollars = old_goal / 100 if old_goal else 0
 
             self.stdout.write(
-                f'  {user.full_name} ({email}): '
-                f'${old_dollars:,.0f}/mo → ${goal_dollars:,.0f}/mo'
+                f"  {user.full_name} ({email}): "
+                f"${old_dollars:,.0f}/mo → ${goal_dollars:,.0f}/mo"
             )
 
             if not dry_run:
                 user.monthly_support_goal_cents = goal_cents
-                user.save(update_fields=['monthly_support_goal_cents'])
+                user.save(update_fields=["monthly_support_goal_cents"])
             updated += 1
 
-        self.stdout.write(
-            self.style.SUCCESS(
-                f'\n{updated} goal(s) updated, {skipped} skipped.'
-            )
-        )
+        self.stdout.write(self.style.SUCCESS(f"\n{updated} goal(s) updated, {skipped} skipped."))
 
         if dry_run:
-            self.stdout.write(self.style.WARNING('Dry run complete — no changes written.'))
+            self.stdout.write(self.style.WARNING("Dry run complete — no changes written."))

--- a/apps/core/pagination.py
+++ b/apps/core/pagination.py
@@ -8,8 +8,7 @@ class StandardPagination(PageNumberPagination):
     """
     Standard pagination for list endpoints.
     """
+
     page_size = 25
-    page_size_query_param = 'page_size'
+    page_size_query_param = "page_size"
     max_page_size = 100
-
-

--- a/apps/core/tests/test_access_log.py
+++ b/apps/core/tests/test_access_log.py
@@ -7,8 +7,6 @@ from __future__ import annotations
 
 from django.urls import reverse
 
-from rest_framework.test import APIClient
-
 import pytest
 
 from apps.core import access_log_middleware

--- a/apps/core/tests/test_access_log.py
+++ b/apps/core/tests/test_access_log.py
@@ -5,9 +5,11 @@ the right resource_type / resource_id, and that non-PII paths are skipped.
 """
 from __future__ import annotations
 
-import pytest
 from django.urls import reverse
+
 from rest_framework.test import APIClient
+
+import pytest
 
 from apps.core import access_log_middleware
 from apps.core.models import DataAccessLog

--- a/apps/core/tests/test_fiscal_year.py
+++ b/apps/core/tests/test_fiscal_year.py
@@ -8,8 +8,6 @@ apps/core/fiscal_year.py exists. Tests fail at runtime with ImportError (correct
 """
 from datetime import date
 
-import pytest
-
 # FISC-01: fiscal_year_start boundary cases
 
 

--- a/apps/core/tests/test_middleware.py
+++ b/apps/core/tests/test_middleware.py
@@ -11,11 +11,12 @@ Test coverage:
   - VIEWAS-07: Mutation blocking (POST/PUT/PATCH/DELETE blocked when header present)
   - VIEWAS-08: Permission validation (only admin/supervisor can use header; target must be valid)
 """
-import pytest
 from rest_framework.test import APIClient
 
+import pytest
 
 # --- MUTATION BLOCKING (VIEWAS-07) ---
+
 
 @pytest.mark.django_db
 def test_mutation_blocked_post():
@@ -28,12 +29,12 @@ def test_mutation_blocked_post():
     client = APIClient()
     client.force_authenticate(user=admin)
     response = client.post(
-        '/api/v1/contacts/',
-        data={'name': 'Test'},
+        "/api/v1/contacts/",
+        data={"name": "Test"},
         HTTP_X_VIEW_AS_USER_ID=str(target.id),
     )
     assert response.status_code == 403
-    assert response.data['detail'] == 'Mutations are not allowed in View As mode.'
+    assert response.data["detail"] == "Mutations are not allowed in View As mode."
 
 
 @pytest.mark.django_db
@@ -47,12 +48,12 @@ def test_mutation_blocked_put():
     client = APIClient()
     client.force_authenticate(user=admin)
     response = client.put(
-        '/api/v1/contacts/',
-        data={'name': 'Test'},
+        "/api/v1/contacts/",
+        data={"name": "Test"},
         HTTP_X_VIEW_AS_USER_ID=str(target.id),
     )
     assert response.status_code == 403
-    assert response.data['detail'] == 'Mutations are not allowed in View As mode.'
+    assert response.data["detail"] == "Mutations are not allowed in View As mode."
 
 
 @pytest.mark.django_db
@@ -66,12 +67,12 @@ def test_mutation_blocked_patch():
     client = APIClient()
     client.force_authenticate(user=admin)
     response = client.patch(
-        '/api/v1/contacts/',
-        data={'name': 'Test'},
+        "/api/v1/contacts/",
+        data={"name": "Test"},
         HTTP_X_VIEW_AS_USER_ID=str(target.id),
     )
     assert response.status_code == 403
-    assert response.data['detail'] == 'Mutations are not allowed in View As mode.'
+    assert response.data["detail"] == "Mutations are not allowed in View As mode."
 
 
 @pytest.mark.django_db
@@ -85,14 +86,15 @@ def test_mutation_blocked_delete():
     client = APIClient()
     client.force_authenticate(user=admin)
     response = client.delete(
-        '/api/v1/contacts/',
+        "/api/v1/contacts/",
         HTTP_X_VIEW_AS_USER_ID=str(target.id),
     )
     assert response.status_code == 403
-    assert response.data['detail'] == 'Mutations are not allowed in View As mode.'
+    assert response.data["detail"] == "Mutations are not allowed in View As mode."
 
 
 # --- GET ALLOWED IN VIEW AS ---
+
 
 @pytest.mark.django_db
 def test_get_allowed_in_view_as():
@@ -105,7 +107,7 @@ def test_get_allowed_in_view_as():
     client = APIClient()
     client.force_authenticate(user=admin)
     response = client.get(
-        '/api/v1/contacts/',
+        "/api/v1/contacts/",
         HTTP_X_VIEW_AS_USER_ID=str(target.id),
     )
     # Should not be 403 from middleware (may be 200, 404, etc. from the view)
@@ -113,6 +115,7 @@ def test_get_allowed_in_view_as():
 
 
 # --- PERMISSION VALIDATION (VIEWAS-08) ---
+
 
 @pytest.mark.django_db
 def test_unauthorized_role_blocked():
@@ -125,11 +128,11 @@ def test_unauthorized_role_blocked():
     client = APIClient()
     client.force_authenticate(user=missionary)
     response = client.get(
-        '/api/v1/contacts/',
+        "/api/v1/contacts/",
         HTTP_X_VIEW_AS_USER_ID=str(target.id),
     )
     assert response.status_code == 403
-    assert response.data['detail'] == 'You do not have permission to view as this user.'
+    assert response.data["detail"] == "You do not have permission to view as this user."
 
 
 @pytest.mark.django_db
@@ -143,7 +146,7 @@ def test_admin_can_view_as_any_missionary():
     client = APIClient()
     client.force_authenticate(user=admin)
     response = client.get(
-        '/api/v1/contacts/',
+        "/api/v1/contacts/",
         HTTP_X_VIEW_AS_USER_ID=str(target.id),
     )
     # Middleware should not block this — admin can view any missionary
@@ -161,11 +164,11 @@ def test_supervisor_blocked_for_unassigned():
     client = APIClient()
     client.force_authenticate(user=supervisor)
     response = client.get(
-        '/api/v1/contacts/',
+        "/api/v1/contacts/",
         HTTP_X_VIEW_AS_USER_ID=str(unassigned_missionary.id),
     )
     assert response.status_code == 403
-    assert response.data['detail'] == 'You do not have permission to view as this user.'
+    assert response.data["detail"] == "You do not have permission to view as this user."
 
 
 @pytest.mark.django_db
@@ -180,7 +183,7 @@ def test_supervisor_allowed_for_assigned():
     client = APIClient()
     client.force_authenticate(user=supervisor)
     response = client.get(
-        '/api/v1/contacts/',
+        "/api/v1/contacts/",
         HTTP_X_VIEW_AS_USER_ID=str(assigned_missionary.id),
     )
     # Middleware should not block — supervisor can view assigned missionary
@@ -191,6 +194,7 @@ def test_supervisor_allowed_for_assigned():
 def test_invalid_user_id_returns_403():
     """Non-existent UUID in header returns 403 with invalid target error."""
     import uuid
+
     from apps.users.tests.factories import AdminUserFactory
 
     admin = AdminUserFactory()
@@ -199,11 +203,11 @@ def test_invalid_user_id_returns_403():
     client = APIClient()
     client.force_authenticate(user=admin)
     response = client.get(
-        '/api/v1/contacts/',
+        "/api/v1/contacts/",
         HTTP_X_VIEW_AS_USER_ID=non_existent_id,
     )
     assert response.status_code == 403
-    assert response.data['detail'] == 'Invalid View As target.'
+    assert response.data["detail"] == "Invalid View As target."
 
 
 @pytest.mark.django_db
@@ -217,11 +221,11 @@ def test_inactive_target_returns_403():
     client = APIClient()
     client.force_authenticate(user=admin)
     response = client.get(
-        '/api/v1/contacts/',
+        "/api/v1/contacts/",
         HTTP_X_VIEW_AS_USER_ID=str(inactive_target.id),
     )
     assert response.status_code == 403
-    assert response.data['detail'] == 'Invalid View As target.'
+    assert response.data["detail"] == "Invalid View As target."
 
 
 @pytest.mark.django_db
@@ -234,7 +238,7 @@ def test_unauthenticated_with_header():
     client = APIClient()
     # No force_authenticate — unauthenticated request
     response = client.get(
-        '/api/v1/contacts/',
+        "/api/v1/contacts/",
         HTTP_X_VIEW_AS_USER_ID=some_id,
     )
     # Middleware should pass through (not 403); DRF authentication returns 401

--- a/apps/core/tests/test_permissions.py
+++ b/apps/core/tests/test_permissions.py
@@ -17,12 +17,13 @@ from apps.users.tests.factories import (
     UserFactory,
 )
 
-
 # --- ADMIN ---
+
 
 def test_admin_sees_only_own_data():
     """Admin defaults to own data, returns {admin.id}."""
     from apps.core.permissions import get_visible_user_ids
+
     admin = AdminUserFactory.build()
     result = get_visible_user_ids(admin)
     assert result == {admin.id}
@@ -31,10 +32,12 @@ def test_admin_sees_only_own_data():
 
 # --- SUPERVISOR ---
 
+
 @pytest.mark.django_db
 def test_supervisor_sees_only_own_data():
     """Supervisor defaults to own data, returns {sup.id}."""
     from apps.core.permissions import get_visible_user_ids
+
     sup = SupervisorUserFactory()
     missionary = UserFactory()
     missionary.supervisors.add(sup)
@@ -45,10 +48,12 @@ def test_supervisor_sees_only_own_data():
 
 # --- COACH ---
 
+
 @pytest.mark.django_db
 def test_coach_sees_own_and_coached():
     """Coach role returns {coach.id} union {coached user IDs}."""
     from apps.core.permissions import get_visible_user_ids
+
     coach = CoachUserFactory()
     coached = UserFactory()
     coached.coaches.add(coach)
@@ -60,9 +65,11 @@ def test_coach_sees_own_and_coached():
 
 # --- MISSIONARY ---
 
+
 def test_missionary_sees_only_own_data():
     """Missionary role returns {missionary.id}."""
     from apps.core.permissions import get_visible_user_ids
+
     missionary = UserFactory.build()
     result = get_visible_user_ids(missionary)
     assert result == {missionary.id}
@@ -71,10 +78,12 @@ def test_missionary_sees_only_own_data():
 
 # --- VIEW AS OVERRIDE ---
 
+
 def test_view_as_overrides_scoping():
     """When request.view_as_user is set, returns {view_as_user.id} regardless of viewer role."""
-    from apps.core.permissions import get_visible_user_ids
     import types
+
+    from apps.core.permissions import get_visible_user_ids
 
     admin = AdminUserFactory.build()
     view_as_user = UserFactory.build()

--- a/apps/core/tests/test_rotate_pii_encryption.py
+++ b/apps/core/tests/test_rotate_pii_encryption.py
@@ -82,6 +82,7 @@ class TestRotatePiiEncryption:
 
     def _raw_set_notes(self, pk, value):
         from django.db import connection
+
         from apps.contacts.models import Contact
 
         with connection.cursor() as cur:
@@ -92,6 +93,7 @@ class TestRotatePiiEncryption:
 
     def _raw_notes(self, pk):
         from django.db import connection
+
         from apps.contacts.models import Contact
 
         with connection.cursor() as cur:

--- a/apps/core/utils.py
+++ b/apps/core/utils.py
@@ -17,7 +17,7 @@ def get_safe_int_param(request, key, default, min_val=1, max_val=1000):
     return max(min_val, min(value, max_val))
 
 
-def validate_date_params(request, param_names=('date_from', 'date_to')):
+def validate_date_params(request, param_names=("date_from", "date_to")):
     """Validate and parse date query params in YYYY-MM-DD format.
 
     Returns a tuple of (values_dict, error_response).
@@ -41,10 +41,10 @@ def validate_date_params(request, param_names=('date_from', 'date_to')):
         raw = request.query_params.get(name)
         if raw:
             try:
-                values[name] = datetime.strptime(raw, '%Y-%m-%d').date()
+                values[name] = datetime.strptime(raw, "%Y-%m-%d").date()
             except ValueError:
                 return values, Response(
-                    {'detail': f'Invalid {name} format. Use YYYY-MM-DD.'},
+                    {"detail": f"Invalid {name} format. Use YYYY-MM-DD."},
                     status=status.HTTP_400_BAD_REQUEST,
                 )
         else:
@@ -52,7 +52,7 @@ def validate_date_params(request, param_names=('date_from', 'date_to')):
     return values, None
 
 
-def get_safe_year_param(request, key='year', default=None):
+def get_safe_year_param(request, key="year", default=None):
     """Safely parse a year query parameter.
 
     Returns None (or the given default) if the parameter is missing or
@@ -66,5 +66,3 @@ def get_safe_year_param(request, key='year', default=None):
     except (ValueError, TypeError):
         return default
     return max(2000, min(value, 2100))
-
-

--- a/apps/core/validators.py
+++ b/apps/core/validators.py
@@ -13,15 +13,15 @@ class AlphanumericPasswordValidator:
     """
 
     def validate(self, password, user=None):
-        if not re.search(r'[a-zA-Z]', password):
+        if not re.search(r"[a-zA-Z]", password):
             raise ValidationError(
                 _("Your password must contain at least one letter."),
-                code='password_no_letter',
+                code="password_no_letter",
             )
-        if not re.search(r'[0-9]', password):
+        if not re.search(r"[0-9]", password):
             raise ValidationError(
                 _("Your password must contain at least one number."),
-                code='password_no_number',
+                code="password_no_number",
             )
 
     def get_help_text(self):

--- a/apps/dashboard/apps.py
+++ b/apps/dashboard/apps.py
@@ -2,6 +2,6 @@ from django.apps import AppConfig
 
 
 class DashboardConfig(AppConfig):
-    default_auto_field = 'django.db.models.BigAutoField'
-    name = 'apps.dashboard'
-    verbose_name = 'Dashboard'
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "apps.dashboard"
+    verbose_name = "Dashboard"

--- a/apps/dashboard/services.py
+++ b/apps/dashboard/services.py
@@ -5,7 +5,7 @@ import logging
 from datetime import date, timedelta
 from decimal import Decimal
 
-from django.db.models import Count, DecimalField, ExpressionWrapper, F, Q, Sum, Value
+from django.db.models import Count, DecimalField, ExpressionWrapper, F, Sum, Value
 from django.db.models.functions import TruncMonth
 
 from dateutil.relativedelta import relativedelta
@@ -344,7 +344,9 @@ def get_dashboard_summary(user):
     thank_you_count = thank_you_qs.count()
 
     logger.debug(
-        f"Dashboard data fetched: {late_donations_count} late donations, {thank_you_count} thank-you needed"
+        "Dashboard data fetched: %d late donations, %d thank-you needed",
+        late_donations_count,
+        thank_you_count,
     )
 
     # Pre-aggregate total of ALL recent gifts (not just the limited list)

--- a/apps/dashboard/services.py
+++ b/apps/dashboard/services.py
@@ -5,17 +5,18 @@ import logging
 from datetime import date, timedelta
 from decimal import Decimal
 
-from dateutil.relativedelta import relativedelta
 from django.db.models import Count, DecimalField, ExpressionWrapper, F, Q, Sum, Value
 from django.db.models.functions import TruncMonth
+
+from dateutil.relativedelta import relativedelta
 
 from apps.contacts.models import Contact
 from apps.core.fiscal_year import fiscal_year_end, fiscal_year_start, months_elapsed_in_fiscal_year
 from apps.core.gift_utils import _monthly_equivalent_aggregate
 from apps.core.permissions import get_visible_user_ids
 from apps.events.models import Event
-from apps.imports.models import ImportBatch, ImportBatchStatus, ImportBatchType, MPDSnapshot
 from apps.gifts.models import Gift, RecurringGift, RecurringGiftStatus
+from apps.imports.models import ImportBatch, ImportBatchStatus, ImportBatchType, MPDSnapshot
 from apps.tasks.models import Task, TaskStatus
 
 logger = logging.getLogger(__name__)

--- a/apps/dashboard/tests/test_services.py
+++ b/apps/dashboard/tests/test_services.py
@@ -4,8 +4,9 @@ Tests for dashboard service functions.
 from datetime import date, timedelta
 from decimal import Decimal
 
-import pytest
 from django.utils import timezone
+
+import pytest
 
 from apps.contacts.tests.factories import ContactFactory
 from apps.dashboard.services import (
@@ -328,7 +329,9 @@ class TestGetGivingSummary:
         fy_start = fiscal_year_start(today)
 
         # Gift in current fiscal year
-        GiftFactory(donor_contact=contact, amount_cents=5000, gift_date=fy_start + timedelta(days=30))
+        GiftFactory(
+            donor_contact=contact, amount_cents=5000, gift_date=fy_start + timedelta(days=30)
+        )
         # Gift before fiscal year start — should be excluded
         GiftFactory(
             donor_contact=contact, amount_cents=9999, gift_date=fy_start - timedelta(days=30)

--- a/apps/dashboard/tests/test_services.py
+++ b/apps/dashboard/tests/test_services.py
@@ -22,7 +22,7 @@ from apps.dashboard.services import (
 )
 from apps.events.tests.factories import EventFactory
 from apps.gifts.tests.factories import GiftFactory, RecurringGiftFactory
-from apps.tasks.tests.factories import OverdueTaskFactory, TaskFactory
+from apps.tasks.tests.factories import OverdueTaskFactory
 from apps.users.tests.factories import AdminUserFactory, UserFactory
 
 

--- a/apps/dashboard/tests/test_views.py
+++ b/apps/dashboard/tests/test_views.py
@@ -1,9 +1,10 @@
 """
 Tests for Dashboard API views.
 """
-import pytest
 from rest_framework import status
 from rest_framework.test import APIClient
+
+import pytest
 
 from apps.users.tests.factories import AdminUserFactory, SupervisorUserFactory, UserFactory
 
@@ -14,22 +15,22 @@ class TestDashboardView:
 
     def test_get_dashboard(self):
         """Test getting full dashboard data."""
-        user = UserFactory(role='missionary')
+        user = UserFactory(role="missionary")
 
         client = APIClient()
         client.force_authenticate(user=user)
 
-        response = client.get('/api/v1/dashboard/')
+        response = client.get("/api/v1/dashboard/")
 
         assert response.status_code == status.HTTP_200_OK
-        assert 'what_changed' in response.data
-        assert 'needs_attention' in response.data
-        assert 'support_progress' in response.data
+        assert "what_changed" in response.data
+        assert "needs_attention" in response.data
+        assert "support_progress" in response.data
 
     def test_get_dashboard_unauthenticated(self):
         """Test that unauthenticated requests are rejected."""
         client = APIClient()
-        response = client.get('/api/v1/dashboard/')
+        response = client.get("/api/v1/dashboard/")
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
 
@@ -39,15 +40,15 @@ class TestWhatChangedView:
 
     def test_get_what_changed(self):
         """Test getting what changed data."""
-        user = UserFactory(role='missionary')
+        user = UserFactory(role="missionary")
 
         client = APIClient()
         client.force_authenticate(user=user)
 
-        response = client.get('/api/v1/dashboard/what-changed/')
+        response = client.get("/api/v1/dashboard/what-changed/")
 
         assert response.status_code == status.HTTP_200_OK
-        assert 'total_new' in response.data
+        assert "total_new" in response.data
 
 
 @pytest.mark.django_db
@@ -56,16 +57,16 @@ class TestNeedsAttentionView:
 
     def test_get_needs_attention(self):
         """Test getting needs attention data."""
-        user = UserFactory(role='missionary')
+        user = UserFactory(role="missionary")
 
         client = APIClient()
         client.force_authenticate(user=user)
 
-        response = client.get('/api/v1/dashboard/needs-attention/')
+        response = client.get("/api/v1/dashboard/needs-attention/")
 
         assert response.status_code == status.HTTP_200_OK
-        assert 'late_pledge_count' in response.data
-        assert 'overdue_task_count' in response.data
+        assert "late_pledge_count" in response.data
+        assert "overdue_task_count" in response.data
 
 
 @pytest.mark.django_db
@@ -74,16 +75,16 @@ class TestLateDonationsView:
 
     def test_get_late_donations(self):
         """Test getting late donations."""
-        user = UserFactory(role='missionary')
+        user = UserFactory(role="missionary")
 
         client = APIClient()
         client.force_authenticate(user=user)
 
-        response = client.get('/api/v1/dashboard/late-donations/')
+        response = client.get("/api/v1/dashboard/late-donations/")
 
         assert response.status_code == status.HTTP_200_OK
-        assert 'late_donations' in response.data
-        assert 'total_count' in response.data
+        assert "late_donations" in response.data
+        assert "total_count" in response.data
 
 
 @pytest.mark.django_db
@@ -92,12 +93,12 @@ class TestThankYouQueueView:
 
     def test_get_thank_you_queue(self):
         """Test getting thank you queue."""
-        user = UserFactory(role='missionary')
+        user = UserFactory(role="missionary")
 
         client = APIClient()
         client.force_authenticate(user=user)
 
-        response = client.get('/api/v1/dashboard/thank-you-queue/')
+        response = client.get("/api/v1/dashboard/thank-you-queue/")
 
         assert response.status_code == status.HTTP_200_OK
 
@@ -108,17 +109,17 @@ class TestSupportProgressView:
 
     def test_get_support_progress(self):
         """Test getting support progress."""
-        user = UserFactory(role='missionary')
+        user = UserFactory(role="missionary")
 
         client = APIClient()
         client.force_authenticate(user=user)
 
-        response = client.get('/api/v1/dashboard/support-progress/')
+        response = client.get("/api/v1/dashboard/support-progress/")
 
         assert response.status_code == status.HTTP_200_OK
-        assert 'current_monthly_support' in response.data
-        assert 'monthly_goal' in response.data
-        assert 'percentage' in response.data
+        assert "current_monthly_support" in response.data
+        assert "monthly_goal" in response.data
+        assert "percentage" in response.data
 
 
 @pytest.mark.django_db
@@ -128,48 +129,49 @@ class TestResolveTargetUser:
     def test_supervisor_can_view_missionary_dashboard(self):
         """Supervisor may select any missionary via ?user_id= (dashboard dropdown)."""
         supervisor = SupervisorUserFactory()
-        missionary = UserFactory(role='missionary')
+        missionary = UserFactory(role="missionary")
 
         client = APIClient()
         client.force_authenticate(user=supervisor)
 
-        response = client.get(f'/api/v1/dashboard/?user_id={missionary.id}')
+        response = client.get(f"/api/v1/dashboard/?user_id={missionary.id}")
 
         assert response.status_code == status.HTTP_200_OK
 
     def test_admin_can_view_missionary_dashboard(self):
         """Admin may select any missionary via ?user_id= (dashboard dropdown)."""
         admin = AdminUserFactory()
-        missionary = UserFactory(role='missionary')
+        missionary = UserFactory(role="missionary")
 
         client = APIClient()
         client.force_authenticate(user=admin)
 
-        response = client.get(f'/api/v1/dashboard/?user_id={missionary.id}')
+        response = client.get(f"/api/v1/dashboard/?user_id={missionary.id}")
 
         assert response.status_code == status.HTTP_200_OK
 
     def test_missionary_cannot_view_other_missionary_dashboard(self):
         """Missionary may not pass a different user's ID — receives 403."""
-        missionary1 = UserFactory(role='missionary')
-        missionary2 = UserFactory(role='missionary')
+        missionary1 = UserFactory(role="missionary")
+        missionary2 = UserFactory(role="missionary")
 
         client = APIClient()
         client.force_authenticate(user=missionary1)
 
-        response = client.get(f'/api/v1/dashboard/?user_id={missionary2.id}')
+        response = client.get(f"/api/v1/dashboard/?user_id={missionary2.id}")
 
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
     def test_supervisor_with_nonexistent_user_id_returns_404(self):
         """Supervisor passing a non-existent user_id receives 404 (not 403)."""
         import uuid
+
         supervisor = SupervisorUserFactory()
 
         client = APIClient()
         client.force_authenticate(user=supervisor)
 
         nonexistent_id = uuid.uuid4()
-        response = client.get(f'/api/v1/dashboard/?user_id={nonexistent_id}')
+        response = client.get(f"/api/v1/dashboard/?user_id={nonexistent_id}")
 
         assert response.status_code == status.HTTP_404_NOT_FOUND

--- a/apps/dashboard/urls.py
+++ b/apps/dashboard/urls.py
@@ -17,18 +17,18 @@ from apps.dashboard.views import (
     WhatChangedView,
 )
 
-app_name = 'dashboard'
+app_name = "dashboard"
 
 urlpatterns = [
-    path('', DashboardView.as_view(), name='dashboard'),
-    path('mark-seen/', MarkEventsSeenView.as_view(), name='mark-events-seen'),
-    path('what-changed/', WhatChangedView.as_view(), name='what-changed'),
-    path('needs-attention/', NeedsAttentionView.as_view(), name='needs-attention'),
-    path('late-donations/', LateDonationsView.as_view(), name='late-donations'),
-    path('thank-you-queue/', ThankYouQueueView.as_view(), name='thank-you-queue'),
-    path('support-progress/', SupportProgressView.as_view(), name='support-progress'),
-    path('recent-gifts/', RecentGiftsView.as_view(), name='recent-gifts'),
-    path('giving-summary/', GivingSummaryView.as_view(), name='giving-summary'),
-    path('monthly-gifts/', MonthlyGiftsView.as_view(), name='monthly-gifts'),
-    path('user/<uuid:pk>/layout/', UserDashboardLayoutView.as_view(), name='user-dashboard-layout'),
+    path("", DashboardView.as_view(), name="dashboard"),
+    path("mark-seen/", MarkEventsSeenView.as_view(), name="mark-events-seen"),
+    path("what-changed/", WhatChangedView.as_view(), name="what-changed"),
+    path("needs-attention/", NeedsAttentionView.as_view(), name="needs-attention"),
+    path("late-donations/", LateDonationsView.as_view(), name="late-donations"),
+    path("thank-you-queue/", ThankYouQueueView.as_view(), name="thank-you-queue"),
+    path("support-progress/", SupportProgressView.as_view(), name="support-progress"),
+    path("recent-gifts/", RecentGiftsView.as_view(), name="recent-gifts"),
+    path("giving-summary/", GivingSummaryView.as_view(), name="giving-summary"),
+    path("monthly-gifts/", MonthlyGiftsView.as_view(), name="monthly-gifts"),
+    path("user/<uuid:pk>/layout/", UserDashboardLayoutView.as_view(), name="user-dashboard-layout"),
 ]

--- a/apps/dashboard/views.py
+++ b/apps/dashboard/views.py
@@ -3,16 +3,15 @@ Views for Dashboard data.
 """
 import uuid
 
-from drf_spectacular.utils import extend_schema, OpenApiParameter
 from rest_framework import permissions
 from rest_framework.exceptions import NotFound, PermissionDenied
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from drf_spectacular.utils import OpenApiParameter, extend_schema
+
 from apps.core.permissions import get_visible_user_ids
 from apps.core.utils import get_safe_int_param
-from apps.users.models import User
-
 from apps.dashboard.services import (
     get_dashboard_summary,
     get_giving_summary,
@@ -25,6 +24,7 @@ from apps.dashboard.services import (
     get_what_changed,
 )
 from apps.events.services import mark_events_as_not_new
+from apps.users.models import User
 
 
 def _resolve_target_user(request):
@@ -39,27 +39,23 @@ def _resolve_target_user(request):
     get_visible_user_ids() and is not affected by this function.
     """
     user = request.user
-    target_user_id = request.query_params.get('user_id')
+    target_user_id = request.query_params.get("user_id")
 
     if target_user_id and str(target_user_id) != str(user.id):
         try:
             target_uuid = uuid.UUID(target_user_id)
         except ValueError:
-            raise NotFound('User not found.')
+            raise NotFound("User not found.")
         # Admin and supervisor may explicitly select any active user via the
         # dashboard dropdown. This is distinct from default data scoping
         # (get_visible_user_ids), which governs list views, not dashboard selection.
-        if user.role not in ['admin', 'supervisor']:
+        if user.role not in ["admin", "supervisor"]:
             visible = get_visible_user_ids(user, request=request)
             if target_uuid not in visible:
-                raise PermissionDenied(
-                    'You do not have permission to view this user\'s dashboard.'
-                )
-        target_user = User.objects.filter(
-            id=target_user_id, is_active=True
-        ).first()
+                raise PermissionDenied("You do not have permission to view this user's dashboard.")
+        target_user = User.objects.filter(id=target_user_id, is_active=True).first()
         if not target_user:
-            raise NotFound('User not found.')
+            raise NotFound("User not found.")
         return target_user
     return user
 
@@ -68,9 +64,10 @@ class DashboardView(APIView):
     """
     GET: Get complete dashboard data
     """
+
     permission_classes = [permissions.IsAuthenticated]
 
-    @extend_schema(tags=['dashboard'], summary='Get complete dashboard data')
+    @extend_schema(tags=["dashboard"], summary="Get complete dashboard data")
     def get(self, request):
         target = _resolve_target_user(request)
         data = get_dashboard_summary(target)
@@ -82,28 +79,31 @@ class MarkEventsSeenView(APIView):
     POST: Mark all new events as seen for the authenticated user.
     Separated from DashboardView.get() to avoid GET side effects (QAL-09).
     """
+
     permission_classes = [permissions.IsAuthenticated]
 
-    @extend_schema(tags=['dashboard'], summary='Mark events as seen')
+    @extend_schema(tags=["dashboard"], summary="Mark events as seen")
     def post(self, request):
         mark_events_as_not_new(request.user)
-        return Response({'detail': 'Events marked as seen.'})
+        return Response({"detail": "Events marked as seen."})
 
 
 class WhatChangedView(APIView):
     """
     GET: Get events/changes since last login
     """
+
     permission_classes = [permissions.IsAuthenticated]
 
-    @extend_schema(tags=['dashboard'], summary='Get changes since last login')
+    @extend_schema(tags=["dashboard"], summary="Get changes since last login")
     def get(self, request):
         target = _resolve_target_user(request)
         data = get_what_changed(target)
 
         # Serialize events
         from apps.events.serializers import EventSerializer
-        data['recent_events'] = EventSerializer(data['recent_events'], many=True).data
+
+        data["recent_events"] = EventSerializer(data["recent_events"], many=True).data
 
         return Response(data)
 
@@ -112,22 +112,23 @@ class NeedsAttentionView(APIView):
     """
     GET: Get items requiring action
     """
+
     permission_classes = [permissions.IsAuthenticated]
 
-    @extend_schema(tags=['dashboard'], summary='Get items needing attention')
+    @extend_schema(tags=["dashboard"], summary="Get items needing attention")
     def get(self, request):
         target = _resolve_target_user(request)
         data = get_needs_attention(target)
 
         # Serialize related objects
-        from apps.tasks.serializers import TaskSerializer
         from apps.contacts.serializers import ContactListSerializer
+        from apps.tasks.serializers import TaskSerializer
 
         # late_pledges is already an empty list (no serialization needed)
-        data['overdue_tasks'] = TaskSerializer(data['overdue_tasks'], many=True).data
-        data['tasks_due_today'] = TaskSerializer(data['tasks_due_today'], many=True).data
-        data['broadcast_tasks'] = TaskSerializer(data['broadcast_tasks'], many=True).data
-        data['thank_you_needed'] = ContactListSerializer(data['thank_you_needed'], many=True).data
+        data["overdue_tasks"] = TaskSerializer(data["overdue_tasks"], many=True).data
+        data["tasks_due_today"] = TaskSerializer(data["tasks_due_today"], many=True).data
+        data["broadcast_tasks"] = TaskSerializer(data["broadcast_tasks"], many=True).data
+        data["thank_you_needed"] = ContactListSerializer(data["thank_you_needed"], many=True).data
 
         return Response(data)
 
@@ -136,52 +137,57 @@ class LateDonationsView(APIView):
     """
     GET: Get late donations (active pledges past due)
     """
+
     permission_classes = [permissions.IsAuthenticated]
 
     @extend_schema(
-        tags=['dashboard'],
-        summary='Get late donations',
-        parameters=[OpenApiParameter(name='limit', description='Max results (default: 10)', type=int)]
+        tags=["dashboard"],
+        summary="Get late donations",
+        parameters=[
+            OpenApiParameter(name="limit", description="Max results (default: 10)", type=int)
+        ],
     )
     def get(self, request):
         target = _resolve_target_user(request)
-        limit = get_safe_int_param(request, 'limit', default=10, min_val=1, max_val=100)
+        limit = get_safe_int_param(request, "limit", default=10, min_val=1, max_val=100)
 
         late_donations = get_late_donations(target, limit=limit)
 
-        return Response({
-            'late_donations': late_donations,
-            'total_count': len(late_donations),
-        })
+        return Response(
+            {
+                "late_donations": late_donations,
+                "total_count": len(late_donations),
+            }
+        )
 
 
 class ThankYouQueueView(APIView):
     """
     GET: Get thank-you queue
     """
+
     permission_classes = [permissions.IsAuthenticated]
 
-    @extend_schema(tags=['dashboard'], summary='Get thank-you queue')
+    @extend_schema(tags=["dashboard"], summary="Get thank-you queue")
     def get(self, request):
         target = _resolve_target_user(request)
         contacts = get_thank_you_queue(target)
 
         from apps.contacts.serializers import ContactListSerializer
+
         serializer = ContactListSerializer(contacts[:20], many=True)
 
-        return Response({
-            'thank_you_queue': serializer.data,
-            'total_count': contacts.count()
-        })
+        return Response({"thank_you_queue": serializer.data, "total_count": contacts.count()})
 
 
 class SupportProgressView(APIView):
     """
     GET: Get support progress toward goal
     """
+
     permission_classes = [permissions.IsAuthenticated]
 
-    @extend_schema(tags=['dashboard'], summary='Get support progress toward goal')
+    @extend_schema(tags=["dashboard"], summary="Get support progress toward goal")
     def get(self, request):
         target = _resolve_target_user(request)
         data = get_support_progress(target)
@@ -192,41 +198,41 @@ class RecentGiftsView(APIView):
     """
     GET: Get recent donations
     """
+
     permission_classes = [permissions.IsAuthenticated]
 
     @extend_schema(
-        tags=['dashboard'],
-        summary='Get recent gifts',
+        tags=["dashboard"],
+        summary="Get recent gifts",
         parameters=[
-            OpenApiParameter(name='days', description='Number of days (default: 30)', type=int),
-            OpenApiParameter(name='limit', description='Max results (default: 10)', type=int),
-        ]
+            OpenApiParameter(name="days", description="Number of days (default: 30)", type=int),
+            OpenApiParameter(name="limit", description="Max results (default: 10)", type=int),
+        ],
     )
     def get(self, request):
         target = _resolve_target_user(request)
-        days = get_safe_int_param(request, 'days', default=30, min_val=1, max_val=365)
-        limit = get_safe_int_param(request, 'limit', default=10, min_val=1, max_val=100)
+        days = get_safe_int_param(request, "days", default=30, min_val=1, max_val=365)
+        limit = get_safe_int_param(request, "limit", default=10, min_val=1, max_val=100)
 
         gifts = get_recent_gifts(target, days=days, limit=limit)
 
         from apps.gifts.serializers import GiftSerializer
+
         serializer = GiftSerializer(gifts, many=True)
 
-        return Response({
-            'recent_gifts': serializer.data,
-            'days': days
-        })
+        return Response({"recent_gifts": serializer.data, "days": days})
 
 
 class GivingSummaryView(APIView):
     """
     GET: Get giving summary (Given & Expecting widget data)
     """
+
     permission_classes = [permissions.IsAuthenticated]
 
     @extend_schema(
-        tags=['dashboard'],
-        summary='Get giving summary (fiscal year Jun 1 - May 31)',
+        tags=["dashboard"],
+        summary="Get giving summary (fiscal year Jun 1 - May 31)",
     )
     def get(self, request):
         target = _resolve_target_user(request)
@@ -237,34 +243,38 @@ class MonthlyGiftsView(APIView):
     """
     GET: Get monthly gift totals for bar chart
     """
+
     permission_classes = [permissions.IsAuthenticated]
 
     @extend_schema(
-        tags=['dashboard'],
-        summary='Get monthly gifts',
-        parameters=[OpenApiParameter(name='months', description='Number of months (default: 12)', type=int)]
+        tags=["dashboard"],
+        summary="Get monthly gifts",
+        parameters=[
+            OpenApiParameter(name="months", description="Number of months (default: 12)", type=int)
+        ],
     )
     def get(self, request):
         target = _resolve_target_user(request)
-        months = get_safe_int_param(request, 'months', default=12, min_val=1, max_val=60)
+        months = get_safe_int_param(request, "months", default=12, min_val=1, max_val=60)
         return Response(get_monthly_gifts(target, months=months))
 
 
 class UserDashboardLayoutView(APIView):
     """GET: Get a specific user's dashboard layout (for supervisor/admin viewing)."""
+
     permission_classes = [permissions.IsAuthenticated]
 
-    @extend_schema(tags=['dashboard'], summary='Get user dashboard layout')
+    @extend_schema(tags=["dashboard"], summary="Get user dashboard layout")
     def get(self, request, pk):
         try:
             pk = uuid.UUID(pk) if not isinstance(pk, uuid.UUID) else pk
         except ValueError:
-            raise NotFound('User not found.')
-        if request.user.role not in ['admin', 'supervisor']:
+            raise NotFound("User not found.")
+        if request.user.role not in ["admin", "supervisor"]:
             visible = get_visible_user_ids(request.user, request=request)
             if pk not in visible:
-                raise PermissionDenied('You do not have permission to view this user\'s dashboard.')
+                raise PermissionDenied("You do not have permission to view this user's dashboard.")
         target = User.objects.filter(id=pk, is_active=True).first()
         if not target:
-            raise NotFound('User not found.')
-        return Response({'dashboard_layout': target.dashboard_layout or {}})
+            raise NotFound("User not found.")
+        return Response({"dashboard_layout": target.dashboard_layout or {}})

--- a/apps/events/admin.py
+++ b/apps/events/admin.py
@@ -9,11 +9,17 @@ from apps.events.models import Event
 @admin.register(Event)
 class EventAdmin(admin.ModelAdmin):
     list_display = (
-        'title', 'user', 'event_type', 'severity',
-        'contact', 'is_read', 'is_new', 'created_at'
+        "title",
+        "user",
+        "event_type",
+        "severity",
+        "contact",
+        "is_read",
+        "is_new",
+        "created_at",
     )
-    list_filter = ('event_type', 'severity', 'is_read', 'is_new', 'created_at')
-    search_fields = ('title', 'message', 'user__email')
-    ordering = ('-created_at',)
+    list_filter = ("event_type", "severity", "is_read", "is_new", "created_at")
+    search_fields = ("title", "message", "user__email")
+    ordering = ("-created_at",)
 
-    readonly_fields = ('created_at', 'read_at')
+    readonly_fields = ("created_at", "read_at")

--- a/apps/events/apps.py
+++ b/apps/events/apps.py
@@ -2,6 +2,6 @@ from django.apps import AppConfig
 
 
 class EventsConfig(AppConfig):
-    default_auto_field = 'django.db.models.BigAutoField'
-    name = 'apps.events'
-    verbose_name = 'Events'
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "apps.events"
+    verbose_name = "Events"

--- a/apps/events/models.py
+++ b/apps/events/models.py
@@ -12,47 +12,49 @@ from apps.core.models import TimeStampedModel
 
 class EventType(models.TextChoices):
     """Types of events in the system."""
+
     # Donation events
-    DONATION_RECEIVED = 'donation_received', 'Donation Received'
-    FIRST_DONATION = 'first_donation', 'First Donation'
+    DONATION_RECEIVED = "donation_received", "Donation Received"
+    FIRST_DONATION = "first_donation", "First Donation"
 
     # Pledge events
-    PLEDGE_CREATED = 'pledge_created', 'Pledge Created'
-    PLEDGE_UPDATED = 'pledge_updated', 'Pledge Updated'
-    PLEDGE_LATE = 'pledge_late', 'Pledge Late'
-    PLEDGE_CANCELLED = 'pledge_cancelled', 'Pledge Cancelled'
+    PLEDGE_CREATED = "pledge_created", "Pledge Created"
+    PLEDGE_UPDATED = "pledge_updated", "Pledge Updated"
+    PLEDGE_LATE = "pledge_late", "Pledge Late"
+    PLEDGE_CANCELLED = "pledge_cancelled", "Pledge Cancelled"
 
     # Contact events
-    CONTACT_CREATED = 'contact_created', 'Contact Created'
-    CONTACT_UPDATED = 'contact_updated', 'Contact Updated'
-    CONTACT_STATUS_CHANGED = 'contact_status_changed', 'Contact Status Changed'
+    CONTACT_CREATED = "contact_created", "Contact Created"
+    CONTACT_UPDATED = "contact_updated", "Contact Updated"
+    CONTACT_STATUS_CHANGED = "contact_status_changed", "Contact Status Changed"
 
     # Alert events
-    DONOR_LAPSED = 'donor_lapsed', 'Donor Lapsed'
-    GIFT_LATE = 'gift_late', 'Gift Late'
-    AT_RISK = 'at_risk', 'At Risk Donor'
+    DONOR_LAPSED = "donor_lapsed", "Donor Lapsed"
+    GIFT_LATE = "gift_late", "Gift Late"
+    AT_RISK = "at_risk", "At Risk Donor"
 
     # Task events
-    TASK_DUE = 'task_due', 'Task Due'
-    TASK_OVERDUE = 'task_overdue', 'Task Overdue'
-    TASK_COMPLETED = 'task_completed', 'Task Completed'
+    TASK_DUE = "task_due", "Task Due"
+    TASK_OVERDUE = "task_overdue", "Task Overdue"
+    TASK_COMPLETED = "task_completed", "Task Completed"
 
     # System events
-    IMPORT_COMPLETED = 'import_completed', 'Import Completed'
-    USER_LOGIN = 'user_login', 'User Login'
+    IMPORT_COMPLETED = "import_completed", "Import Completed"
+    USER_LOGIN = "user_login", "User Login"
 
     # Journal events
-    JOURNAL_CREATED = 'journal_created', 'Journal Created'
-    JOURNAL_ARCHIVED = 'journal_archived', 'Journal Archived'
-    JOURNAL_STAGE_EVENT = 'journal_stage_event', 'Journal Stage Event'
+    JOURNAL_CREATED = "journal_created", "Journal Created"
+    JOURNAL_ARCHIVED = "journal_archived", "Journal Archived"
+    JOURNAL_STAGE_EVENT = "journal_stage_event", "Journal Stage Event"
 
 
 class EventSeverity(models.TextChoices):
     """Severity level of events."""
-    INFO = 'info', 'Info'
-    SUCCESS = 'success', 'Success'
-    WARNING = 'warning', 'Warning'
-    ALERT = 'alert', 'Alert'
+
+    INFO = "info", "Info"
+    SUCCESS = "success", "Success"
+    WARNING = "warning", "Warning"
+    ALERT = "alert", "Alert"
 
 
 class Event(TimeStampedModel):
@@ -60,79 +62,60 @@ class Event(TimeStampedModel):
     Audit trail and notification feed entry.
     Uses GenericForeignKey to link to any model.
     """
+
     # Who this event is for (notification recipient)
     user = models.ForeignKey(
-        settings.AUTH_USER_MODEL,
-        on_delete=models.CASCADE,
-        related_name='events',
-        db_index=True
+        settings.AUTH_USER_MODEL, on_delete=models.CASCADE, related_name="events", db_index=True
     )
 
     # Event classification
-    event_type = models.CharField(
-        'type',
-        max_length=30,
-        choices=EventType.choices,
-        db_index=True
-    )
+    event_type = models.CharField("type", max_length=30, choices=EventType.choices, db_index=True)
 
     severity = models.CharField(
-        'severity',
-        max_length=20,
-        choices=EventSeverity.choices,
-        default=EventSeverity.INFO
+        "severity", max_length=20, choices=EventSeverity.choices, default=EventSeverity.INFO
     )
 
     # Human-readable message
-    title = models.CharField('title', max_length=255)
-    message = models.TextField('message', blank=True)
+    title = models.CharField("title", max_length=255)
+    message = models.TextField("message", blank=True)
 
     # Generic relation to source object
-    content_type = models.ForeignKey(
-        ContentType,
-        on_delete=models.CASCADE,
-        null=True,
-        blank=True
-    )
+    content_type = models.ForeignKey(ContentType, on_delete=models.CASCADE, null=True, blank=True)
     object_id = models.UUIDField(null=True, blank=True, db_index=True)
-    content_object = GenericForeignKey('content_type', 'object_id')
+    content_object = GenericForeignKey("content_type", "object_id")
 
     # Optional direct contact link for quick access
     contact = models.ForeignKey(
-        'contacts.Contact',
-        on_delete=models.CASCADE,
-        null=True,
-        blank=True,
-        related_name='events'
+        "contacts.Contact", on_delete=models.CASCADE, null=True, blank=True, related_name="events"
     )
 
     # Read/seen tracking
-    is_read = models.BooleanField('read', default=False, db_index=True)
-    read_at = models.DateTimeField('read at', null=True, blank=True)
+    is_read = models.BooleanField("read", default=False, db_index=True)
+    read_at = models.DateTimeField("read at", null=True, blank=True)
 
     # For dashboard "What Changed" since last login
-    is_new = models.BooleanField('new', default=True, db_index=True)
+    is_new = models.BooleanField("new", default=True, db_index=True)
 
     # Additional context data (JSON)
-    metadata = models.JSONField('metadata', default=dict, blank=True)
+    metadata = models.JSONField("metadata", default=dict, blank=True)
 
     class Meta:
-        db_table = 'events'
-        verbose_name = 'event'
-        verbose_name_plural = 'events'
-        ordering = ['-created_at']
+        db_table = "events"
+        verbose_name = "event"
+        verbose_name_plural = "events"
+        ordering = ["-created_at"]
         indexes = [
-            models.Index(fields=['user', 'is_read', 'created_at']),
-            models.Index(fields=['user', 'event_type']),
-            models.Index(fields=['user', 'is_new']),
-            models.Index(fields=['contact', 'created_at']),
+            models.Index(fields=["user", "is_read", "created_at"]),
+            models.Index(fields=["user", "event_type"]),
+            models.Index(fields=["user", "is_new"]),
+            models.Index(fields=["contact", "created_at"]),
         ]
 
     def __str__(self):
-        return f'{self.event_type}: {self.title}'
+        return f"{self.event_type}: {self.title}"
 
     def mark_read(self):
         """Mark event as read."""
         self.is_read = True
         self.read_at = timezone.now()
-        self.save(update_fields=['is_read', 'read_at'])
+        self.save(update_fields=["is_read", "read_at"])

--- a/apps/events/serializers.py
+++ b/apps/events/serializers.py
@@ -10,17 +10,26 @@ class EventSerializer(serializers.ModelSerializer):
     """
     Serializer for Event model.
     """
-    contact_name = serializers.CharField(source='contact.full_name', read_only=True, allow_null=True)
+
+    contact_name = serializers.CharField(
+        source="contact.full_name", read_only=True, allow_null=True
+    )
 
     class Meta:
         model = Event
         fields = [
-            'id', 'user', 'event_type', 'severity',
-            'title', 'message',
-            'contact', 'contact_name',
-            'is_read', 'read_at', 'is_new',
-            'metadata', 'created_at'
+            "id",
+            "user",
+            "event_type",
+            "severity",
+            "title",
+            "message",
+            "contact",
+            "contact_name",
+            "is_read",
+            "read_at",
+            "is_new",
+            "metadata",
+            "created_at",
         ]
         read_only_fields = fields
-
-

--- a/apps/events/tests/factories.py
+++ b/apps/events/tests/factories.py
@@ -29,23 +29,27 @@ class EventFactory(factory.django.DjangoModelFactory):
 
 class DonationEventFactory(EventFactory):
     """Factory for donation received events."""
+
     event_type = EventType.DONATION_RECEIVED
     severity = EventSeverity.SUCCESS
 
 
 class PledgeLateEventFactory(EventFactory):
     """Factory for late pledge events."""
+
     event_type = EventType.PLEDGE_LATE
     severity = EventSeverity.WARNING
 
 
 class AtRiskEventFactory(EventFactory):
     """Factory for at-risk donor events."""
+
     event_type = EventType.AT_RISK
     severity = EventSeverity.WARNING
 
 
 class AlertEventFactory(EventFactory):
     """Factory for alert events."""
+
     event_type = EventType.DONOR_LAPSED
     severity = EventSeverity.ALERT

--- a/apps/events/tests/test_models.py
+++ b/apps/events/tests/test_models.py
@@ -1,8 +1,6 @@
 """
 Tests for Event model.
 """
-from django.utils import timezone
-
 import pytest
 
 from apps.events.models import Event, EventSeverity, EventType

--- a/apps/events/tests/test_models.py
+++ b/apps/events/tests/test_models.py
@@ -1,8 +1,9 @@
 """
 Tests for Event model.
 """
-import pytest
 from django.utils import timezone
+
+import pytest
 
 from apps.events.models import Event, EventSeverity, EventType
 from apps.events.tests.factories import EventFactory
@@ -15,12 +16,9 @@ class TestEventModel:
 
     def test_event_str(self):
         """Test event string representation."""
-        event = EventFactory(
-            event_type=EventType.DONATION_RECEIVED,
-            title='Donation from John'
-        )
-        assert 'donation_received' in str(event)
-        assert 'Donation from John' in str(event)
+        event = EventFactory(event_type=EventType.DONATION_RECEIVED, title="Donation from John")
+        assert "donation_received" in str(event)
+        assert "Donation from John" in str(event)
 
     def test_mark_read(self):
         """Test marking event as read."""
@@ -36,34 +34,32 @@ class TestEventModel:
     def test_event_types(self):
         """Test event type choices."""
         # Donation events
-        assert EventType.DONATION_RECEIVED == 'donation_received'
-        assert EventType.FIRST_DONATION == 'first_donation'
+        assert EventType.DONATION_RECEIVED == "donation_received"
+        assert EventType.FIRST_DONATION == "first_donation"
 
         # Pledge events
-        assert EventType.PLEDGE_CREATED == 'pledge_created'
-        assert EventType.PLEDGE_LATE == 'pledge_late'
+        assert EventType.PLEDGE_CREATED == "pledge_created"
+        assert EventType.PLEDGE_LATE == "pledge_late"
 
         # Contact events
-        assert EventType.CONTACT_CREATED == 'contact_created'
-        assert EventType.DONOR_LAPSED == 'donor_lapsed'
+        assert EventType.CONTACT_CREATED == "contact_created"
+        assert EventType.DONOR_LAPSED == "donor_lapsed"
 
         # Alert events
-        assert EventType.AT_RISK == 'at_risk'
+        assert EventType.AT_RISK == "at_risk"
 
     def test_event_severities(self):
         """Test event severity choices."""
-        assert EventSeverity.INFO == 'info'
-        assert EventSeverity.SUCCESS == 'success'
-        assert EventSeverity.WARNING == 'warning'
-        assert EventSeverity.ALERT == 'alert'
+        assert EventSeverity.INFO == "info"
+        assert EventSeverity.SUCCESS == "success"
+        assert EventSeverity.WARNING == "warning"
+        assert EventSeverity.ALERT == "alert"
 
     def test_event_defaults(self):
         """Test event default values."""
         user = UserFactory()
         event = Event.objects.create(
-            user=user,
-            event_type=EventType.DONATION_RECEIVED,
-            title='Test event'
+            user=user, event_type=EventType.DONATION_RECEIVED, title="Test event"
         )
 
         assert event.severity == EventSeverity.INFO
@@ -74,14 +70,14 @@ class TestEventModel:
     def test_event_with_metadata(self):
         """Test event with metadata."""
         user = UserFactory()
-        metadata = {'amount': '100.00', 'date': '2024-01-15'}
+        metadata = {"amount": "100.00", "date": "2024-01-15"}
 
         event = Event.objects.create(
             user=user,
             event_type=EventType.DONATION_RECEIVED,
-            title='Donation received',
-            metadata=metadata
+            title="Donation received",
+            metadata=metadata,
         )
 
-        assert event.metadata['amount'] == '100.00'
-        assert event.metadata['date'] == '2024-01-15'
+        assert event.metadata["amount"] == "100.00"
+        assert event.metadata["date"] == "2024-01-15"

--- a/apps/events/tests/test_views.py
+++ b/apps/events/tests/test_views.py
@@ -1,9 +1,10 @@
 """
 Tests for Event API views.
 """
-import pytest
 from rest_framework import status
 from rest_framework.test import APIClient
+
+import pytest
 
 from apps.events.models import Event
 from apps.events.tests.factories import EventFactory
@@ -16,37 +17,37 @@ class TestEventListView:
 
     def test_list_events_authenticated(self):
         """Test listing events for authenticated user."""
-        user = UserFactory(role='missionary')
+        user = UserFactory(role="missionary")
         EventFactory.create_batch(3, user=user)
 
         client = APIClient()
         client.force_authenticate(user=user)
 
-        response = client.get('/api/v1/events/')
+        response = client.get("/api/v1/events/")
 
         assert response.status_code == status.HTTP_200_OK
-        assert response.data['count'] == 3
+        assert response.data["count"] == 3
 
     def test_list_events_unauthenticated(self):
         """Test that unauthenticated requests are rejected."""
         client = APIClient()
-        response = client.get('/api/v1/events/')
+        response = client.get("/api/v1/events/")
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
     def test_user_only_sees_own_events(self):
         """Test that users only see their own events."""
-        user1 = UserFactory(role='missionary')
-        user2 = UserFactory(role='missionary')
+        user1 = UserFactory(role="missionary")
+        user2 = UserFactory(role="missionary")
         EventFactory.create_batch(2, user=user1)
         EventFactory.create_batch(3, user=user2)
 
         client = APIClient()
         client.force_authenticate(user=user1)
 
-        response = client.get('/api/v1/events/')
+        response = client.get("/api/v1/events/")
 
         assert response.status_code == status.HTTP_200_OK
-        assert response.data['count'] == 2
+        assert response.data["count"] == 2
 
 
 @pytest.mark.django_db
@@ -55,16 +56,16 @@ class TestEventDetailView:
 
     def test_get_event_detail(self):
         """Test getting event detail."""
-        user = UserFactory(role='missionary')
-        event = EventFactory(user=user, title='Important event')
+        user = UserFactory(role="missionary")
+        event = EventFactory(user=user, title="Important event")
 
         client = APIClient()
         client.force_authenticate(user=user)
 
-        response = client.get(f'/api/v1/events/{event.id}/')
+        response = client.get(f"/api/v1/events/{event.id}/")
 
         assert response.status_code == status.HTTP_200_OK
-        assert response.data['title'] == 'Important event'
+        assert response.data["title"] == "Important event"
 
 
 @pytest.mark.django_db
@@ -73,13 +74,13 @@ class TestEventMarkReadView:
 
     def test_mark_event_read(self):
         """Test marking a single event as read."""
-        user = UserFactory(role='missionary')
+        user = UserFactory(role="missionary")
         event = EventFactory(user=user, is_read=False)
 
         client = APIClient()
         client.force_authenticate(user=user)
 
-        response = client.post(f'/api/v1/events/{event.id}/read/')
+        response = client.post(f"/api/v1/events/{event.id}/read/")
 
         assert response.status_code == status.HTTP_200_OK
         event.refresh_from_db()
@@ -92,13 +93,13 @@ class TestEventMarkAllReadView:
 
     def test_mark_all_events_read(self):
         """Test marking all events as read."""
-        user = UserFactory(role='missionary')
+        user = UserFactory(role="missionary")
         EventFactory.create_batch(5, user=user, is_read=False)
 
         client = APIClient()
         client.force_authenticate(user=user)
 
-        response = client.post('/api/v1/events/read-all/')
+        response = client.post("/api/v1/events/read-all/")
 
         assert response.status_code == status.HTTP_200_OK
 
@@ -113,14 +114,14 @@ class TestUnreadEventCountView:
 
     def test_get_unread_count(self):
         """Test getting unread event count."""
-        user = UserFactory(role='missionary')
+        user = UserFactory(role="missionary")
         EventFactory.create_batch(3, user=user, is_read=False)
         EventFactory.create_batch(2, user=user, is_read=True)
 
         client = APIClient()
         client.force_authenticate(user=user)
 
-        response = client.get('/api/v1/events/unread-count/')
+        response = client.get("/api/v1/events/unread-count/")
 
         assert response.status_code == status.HTTP_200_OK
-        assert response.data['unread_count'] == 3
+        assert response.data["unread_count"] == 3

--- a/apps/events/urls.py
+++ b/apps/events/urls.py
@@ -11,12 +11,12 @@ from apps.events.views import (
     UnreadEventCountView,
 )
 
-app_name = 'events'
+app_name = "events"
 
 urlpatterns = [
-    path('', EventListView.as_view(), name='event-list'),
-    path('unread-count/', UnreadEventCountView.as_view(), name='event-unread-count'),
-    path('read-all/', EventMarkAllReadView.as_view(), name='event-read-all'),
-    path('<uuid:pk>/', EventDetailView.as_view(), name='event-detail'),
-    path('<uuid:pk>/read/', EventMarkReadView.as_view(), name='event-read'),
+    path("", EventListView.as_view(), name="event-list"),
+    path("unread-count/", UnreadEventCountView.as_view(), name="event-unread-count"),
+    path("read-all/", EventMarkAllReadView.as_view(), name="event-read-all"),
+    path("<uuid:pk>/", EventDetailView.as_view(), name="event-detail"),
+    path("<uuid:pk>/read/", EventMarkReadView.as_view(), name="event-read"),
 ]

--- a/apps/events/views.py
+++ b/apps/events/views.py
@@ -3,10 +3,12 @@ Views for Event management.
 """
 from django.db import models
 from django.db.models import Count
-from django_filters.rest_framework import DjangoFilterBackend
+
 from rest_framework import filters, generics, permissions, status
 from rest_framework.response import Response
 from rest_framework.views import APIView
+
+from django_filters.rest_framework import DjangoFilterBackend
 
 from apps.core.permissions import get_visible_user_ids
 from apps.events.models import Event
@@ -17,24 +19,26 @@ class EventListView(generics.ListAPIView):
     """
     GET: List events/notifications for current user
     """
+
     serializer_class = EventSerializer
     permission_classes = [permissions.IsAuthenticated]
     filter_backends = [DjangoFilterBackend, filters.OrderingFilter]
-    ordering_fields = ['created_at']
-    ordering = ['-created_at']
-    filterset_fields = ['event_type', 'severity', 'is_read', 'is_new']
+    ordering_fields = ["created_at"]
+    ordering = ["-created_at"]
+    filterset_fields = ["event_type", "severity", "is_read", "is_new"]
 
     def get_queryset(self):
         user = self.request.user
 
         visible = get_visible_user_ids(user, request=self.request)
-        return Event.objects.filter(user_id__in=visible).select_related('contact')
+        return Event.objects.filter(user_id__in=visible).select_related("contact")
 
 
 class EventDetailView(generics.RetrieveAPIView):
     """
     GET: Retrieve event details
     """
+
     serializer_class = EventSerializer
     permission_classes = [permissions.IsAuthenticated]
 
@@ -48,50 +52,46 @@ class EventMarkReadView(APIView):
     """
     POST: Mark event as read
     """
+
     permission_classes = [permissions.IsAuthenticated]
 
     def post(self, request, pk):
         try:
             event = Event.objects.get(pk=pk, user=request.user)
         except Event.DoesNotExist:
-            return Response(
-                {'detail': 'Event not found.'},
-                status=status.HTTP_404_NOT_FOUND
-            )
+            return Response({"detail": "Event not found."}, status=status.HTTP_404_NOT_FOUND)
 
         event.mark_read()
-        return Response({'detail': 'Event marked as read.'})
+        return Response({"detail": "Event marked as read."})
 
 
 class EventMarkAllReadView(APIView):
     """
     POST: Mark all events as read
     """
+
     permission_classes = [permissions.IsAuthenticated]
 
     def post(self, request):
-        count = Event.objects.filter(
-            user=request.user,
-            is_read=False
-        ).update(is_read=True)
+        count = Event.objects.filter(user=request.user, is_read=False).update(is_read=True)
 
-        return Response({'detail': f'Marked {count} events as read.'})
+        return Response({"detail": f"Marked {count} events as read."})
 
 
 class UnreadEventCountView(APIView):
     """
     GET: Get count of unread events
     """
+
     permission_classes = [permissions.IsAuthenticated]
 
     def get(self, request):
-        effective_user = getattr(request, 'view_as_user', None) or request.user
+        effective_user = getattr(request, "view_as_user", None) or request.user
         counts = Event.objects.filter(user=effective_user).aggregate(
-            unread_count=Count('id', filter=models.Q(is_read=False)),
-            new_count=Count('id', filter=models.Q(is_new=True))
+            unread_count=Count("id", filter=models.Q(is_read=False)),
+            new_count=Count("id", filter=models.Q(is_new=True)),
         )
 
-        return Response({
-            'unread_count': counts['unread_count'] or 0,
-            'new_count': counts['new_count'] or 0
-        })
+        return Response(
+            {"unread_count": counts["unread_count"] or 0, "new_count": counts["new_count"] or 0}
+        )

--- a/apps/gifts/tests/test_recurring_utils.py
+++ b/apps/gifts/tests/test_recurring_utils.py
@@ -2,7 +2,6 @@
 Tests for recurring gift payment generation utilities.
 """
 from datetime import date
-from decimal import Decimal
 
 import pytest
 
@@ -14,7 +13,6 @@ from apps.gifts.recurring_utils import (
     make_recurring_external_id,
     sync_recurring_gift_payments,
 )
-from apps.gifts.tests.factories import RecurringGiftFactory
 from apps.users.tests.factories import UserFactory
 
 

--- a/apps/gifts/tests/test_signals.py
+++ b/apps/gifts/tests/test_signals.py
@@ -13,7 +13,7 @@ from decimal import Decimal
 
 import pytest
 
-from apps.contacts.models import Contact, ContactStatus
+from apps.contacts.models import ContactStatus
 from apps.contacts.tests.factories import ContactFactory
 from apps.events.models import Event, EventType
 from apps.gifts.models import Gift, RecurringGift, RecurringGiftFrequency, RecurringGiftStatus

--- a/apps/gifts/tests/test_views.py
+++ b/apps/gifts/tests/test_views.py
@@ -15,10 +15,7 @@ import pytest
 
 from apps.contacts.tests.factories import ContactFactory
 from apps.gifts.models import Gift, RecurringGift, RecurringGiftFrequency, RecurringGiftStatus
-from apps.users.tests.factories import (
-    AdminUserFactory,
-    UserFactory,
-)
+from apps.users.tests.factories import AdminUserFactory, UserFactory
 
 
 @pytest.fixture
@@ -150,7 +147,11 @@ class TestGiftPermissionScoping:
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
     def test_admin_sees_own_gifts_only(
-        self, admin_user, admin_gift, user1_gift, user2_gift,
+        self,
+        admin_user,
+        admin_gift,
+        user1_gift,
+        user2_gift,
     ):
         """Admin sees only own data by default; cross-user access is via View As."""
         client = _client_for(admin_user)
@@ -162,7 +163,9 @@ class TestGiftPermissionScoping:
         assert str(user2_gift.id) not in gift_ids
 
     def test_admin_cannot_access_other_users_gift_detail(
-        self, admin_user, user2_gift,
+        self,
+        admin_user,
+        user2_gift,
     ):
         client = _client_for(admin_user)
         response = client.get(f"/api/v1/gifts/{user2_gift.id}/")
@@ -207,7 +210,11 @@ class TestRecurringGiftPermissionScoping:
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
     def test_admin_sees_own_recurring_gifts_only(
-        self, admin_user, admin_recurring, user1_recurring, user2_recurring,
+        self,
+        admin_user,
+        admin_recurring,
+        user1_recurring,
+        user2_recurring,
     ):
         """Admin sees only own data by default; cross-user access is via View As."""
         client = _client_for(admin_user)
@@ -219,7 +226,9 @@ class TestRecurringGiftPermissionScoping:
         assert str(user2_recurring.id) not in rg_ids
 
     def test_admin_cannot_access_other_users_recurring_gift_detail(
-        self, admin_user, user2_recurring,
+        self,
+        admin_user,
+        user2_recurring,
     ):
         client = _client_for(admin_user)
         response = client.get(f"/api/v1/gifts/recurring/{user2_recurring.id}/")

--- a/apps/groups/admin.py
+++ b/apps/groups/admin.py
@@ -8,11 +8,12 @@ from apps.groups.models import Group
 
 @admin.register(Group)
 class GroupAdmin(admin.ModelAdmin):
-    list_display = ('name', 'owner', 'is_system', 'contact_count', 'created_at')
-    list_filter = ('is_system', 'owner')
-    search_fields = ('name', 'description')
-    ordering = ('name',)
+    list_display = ("name", "owner", "is_system", "contact_count", "created_at")
+    list_filter = ("is_system", "owner")
+    search_fields = ("name", "description")
+    ordering = ("name",)
 
     def contact_count(self, obj):
         return obj.contacts.count()
-    contact_count.short_description = 'Contacts'
+
+    contact_count.short_description = "Contacts"

--- a/apps/groups/apps.py
+++ b/apps/groups/apps.py
@@ -2,6 +2,6 @@ from django.apps import AppConfig
 
 
 class GroupsConfig(AppConfig):
-    default_auto_field = 'django.db.models.BigAutoField'
-    name = 'apps.groups'
-    verbose_name = 'Groups'
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "apps.groups"
+    verbose_name = "Groups"

--- a/apps/groups/models.py
+++ b/apps/groups/models.py
@@ -12,13 +12,11 @@ class Group(TimeStampedModel):
     Tag or segment for organizing contacts.
     Can be organization-wide (owner=None) or private to a user.
     """
-    name = models.CharField('name', max_length=100)
-    description = models.TextField('description', blank=True)
+
+    name = models.CharField("name", max_length=100)
+    description = models.TextField("description", blank=True)
     color = models.CharField(
-        'color',
-        max_length=7,
-        default='#6366f1',
-        help_text='Hex color code for UI display'
+        "color", max_length=7, default="#6366f1", help_text="Hex color code for UI display"
     )
 
     # Ownership - null means organization-wide (shared)
@@ -27,23 +25,20 @@ class Group(TimeStampedModel):
         on_delete=models.CASCADE,
         null=True,
         blank=True,
-        related_name='owned_groups',
-        help_text='If set, group is private to this user'
+        related_name="owned_groups",
+        help_text="If set, group is private to this user",
     )
 
     # System groups can\'t be deleted by users
-    is_system = models.BooleanField('system group', default=False)
+    is_system = models.BooleanField("system group", default=False)
 
     class Meta:
-        db_table = 'groups'
-        verbose_name = 'group'
-        verbose_name_plural = 'groups'
-        ordering = ['name']
+        db_table = "groups"
+        verbose_name = "group"
+        verbose_name_plural = "groups"
+        ordering = ["name"]
         constraints = [
-            models.UniqueConstraint(
-                fields=['name', 'owner'],
-                name='unique_group_name_per_owner'
-            )
+            models.UniqueConstraint(fields=["name", "owner"], name="unique_group_name_per_owner")
         ]
 
     def __str__(self):

--- a/apps/groups/serializers.py
+++ b/apps/groups/serializers.py
@@ -10,31 +10,40 @@ class GroupSerializer(serializers.ModelSerializer):
     """
     Serializer for Group model.
     """
-    contact_count = serializers.IntegerField(source='annotated_contact_count', read_only=True)
+
+    contact_count = serializers.IntegerField(source="annotated_contact_count", read_only=True)
     is_shared = serializers.BooleanField(read_only=True)
 
     class Meta:
         model = Group
         fields = [
-            'id', 'name', 'description', 'color',
-            'owner', 'is_system', 'is_shared',
-            'contact_count', 'created_at', 'updated_at'
+            "id",
+            "name",
+            "description",
+            "color",
+            "owner",
+            "is_system",
+            "is_shared",
+            "contact_count",
+            "created_at",
+            "updated_at",
         ]
-        read_only_fields = ['id', 'owner', 'is_system', 'created_at', 'updated_at']
+        read_only_fields = ["id", "owner", "is_system", "created_at", "updated_at"]
 
 
 class GroupCreateSerializer(serializers.ModelSerializer):
     """
     Serializer for creating groups.
     """
+
     class Meta:
         model = Group
-        fields = ['id', 'name', 'description', 'color']
-        read_only_fields = ['id']
+        fields = ["id", "name", "description", "color"]
+        read_only_fields = ["id"]
 
     def validate_name(self, value):
         """Check that group name is unique for this user."""
-        request = self.context.get('request')
+        request = self.context.get("request")
         if request and request.user.is_authenticated:
             if Group.objects.filter(name=value, owner=request.user).exists():
                 raise serializers.ValidationError(
@@ -45,7 +54,7 @@ class GroupCreateSerializer(serializers.ModelSerializer):
     def create(self, validated_data):
         # Set owner to current user (private group)
         # To create shared groups, admin must set owner=None separately
-        request = self.context.get('request')
+        request = self.context.get("request")
         if request and request.user.is_authenticated:
-            validated_data['owner'] = request.user
+            validated_data["owner"] = request.user
         return super().create(validated_data)

--- a/apps/groups/tests/factories.py
+++ b/apps/groups/tests/factories.py
@@ -16,7 +16,7 @@ class GroupFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = Group
 
-    name = factory.LazyFunction(lambda: fake.word().title() + ' Group')
+    name = factory.LazyFunction(lambda: fake.word().title() + " Group")
     description = factory.LazyFunction(fake.sentence)
     color = factory.LazyFunction(fake.hex_color)
     owner = factory.SubFactory(UserFactory)
@@ -25,9 +25,11 @@ class GroupFactory(factory.django.DjangoModelFactory):
 
 class SharedGroupFactory(GroupFactory):
     """Factory for organization-wide shared groups."""
+
     owner = None
 
 
 class SystemGroupFactory(GroupFactory):
     """Factory for system-managed groups."""
+
     is_system = True

--- a/apps/groups/tests/test_models.py
+++ b/apps/groups/tests/test_models.py
@@ -15,8 +15,8 @@ class TestGroupModel:
 
     def test_group_str(self):
         """Test group string representation."""
-        group = GroupFactory(name='Monthly Supporters')
-        assert str(group) == 'Monthly Supporters'
+        group = GroupFactory(name="Monthly Supporters")
+        assert str(group) == "Monthly Supporters"
 
     def test_contact_count_empty(self):
         """Test contact count for empty group."""
@@ -47,25 +47,25 @@ class TestGroupModel:
     def test_group_default_color(self):
         """Test group default color."""
         user = UserFactory()
-        group = Group.objects.create(name='Test Group', owner=user)
-        assert group.color == '#6366f1'
+        group = Group.objects.create(name="Test Group", owner=user)
+        assert group.color == "#6366f1"
 
     def test_unique_name_per_owner(self):
         """Test unique name constraint per owner."""
         user = UserFactory()
-        GroupFactory(name='Unique Name', owner=user)
+        GroupFactory(name="Unique Name", owner=user)
 
         # Same name with same owner should fail
         with pytest.raises(Exception):  # IntegrityError
-            GroupFactory(name='Unique Name', owner=user)
+            GroupFactory(name="Unique Name", owner=user)
 
     def test_same_name_different_owners(self):
         """Test same name allowed for different owners."""
         user1 = UserFactory()
         user2 = UserFactory()
 
-        group1 = GroupFactory(name='Same Name', owner=user1)
-        group2 = GroupFactory(name='Same Name', owner=user2)
+        group1 = GroupFactory(name="Same Name", owner=user1)
+        group2 = GroupFactory(name="Same Name", owner=user2)
 
         assert group1.name == group2.name
         assert group1.owner != group2.owner

--- a/apps/groups/tests/test_views.py
+++ b/apps/groups/tests/test_views.py
@@ -1,9 +1,10 @@
 """
 Tests for Group API views.
 """
-import pytest
 from rest_framework import status
 from rest_framework.test import APIClient
+
+import pytest
 
 from apps.contacts.tests.factories import ContactFactory
 from apps.groups.models import Group
@@ -17,44 +18,40 @@ class TestGroupListCreateView:
 
     def test_list_groups_authenticated(self):
         """Test listing groups for authenticated user."""
-        user = UserFactory(role='missionary')
+        user = UserFactory(role="missionary")
         GroupFactory.create_batch(3, owner=user)
 
         client = APIClient()
         client.force_authenticate(user=user)
 
-        response = client.get('/api/v1/groups/')
+        response = client.get("/api/v1/groups/")
 
         assert response.status_code == status.HTTP_200_OK
         # Response is paginated
-        assert response.data['count'] == 3
+        assert response.data["count"] == 3
         # Check that results have contact_count annotated
-        assert 'contact_count' in response.data['results'][0]
+        assert "contact_count" in response.data["results"][0]
 
     def test_list_groups_unauthenticated(self):
         """Test that unauthenticated requests are rejected."""
         client = APIClient()
-        response = client.get('/api/v1/groups/')
+        response = client.get("/api/v1/groups/")
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
     def test_create_group(self):
         """Test creating a group."""
-        user = UserFactory(role='missionary')
+        user = UserFactory(role="missionary")
 
         client = APIClient()
         client.force_authenticate(user=user)
 
-        data = {
-            'name': 'New Group',
-            'description': 'A test group',
-            'color': '#ff5733'
-        }
+        data = {"name": "New Group", "description": "A test group", "color": "#ff5733"}
 
-        response = client.post('/api/v1/groups/', data)
+        response = client.post("/api/v1/groups/", data)
 
         assert response.status_code == status.HTTP_201_CREATED
-        assert response.data['name'] == 'New Group'
-        assert response.data['color'] == '#ff5733'
+        assert response.data["name"] == "New Group"
+        assert response.data["color"] == "#ff5733"
 
 
 @pytest.mark.django_db
@@ -63,43 +60,40 @@ class TestGroupDetailView:
 
     def test_get_group_detail(self):
         """Test getting group detail."""
-        user = UserFactory(role='missionary')
-        group = GroupFactory(owner=user, name='My Group')
+        user = UserFactory(role="missionary")
+        group = GroupFactory(owner=user, name="My Group")
 
         client = APIClient()
         client.force_authenticate(user=user)
 
-        response = client.get(f'/api/v1/groups/{group.id}/')
+        response = client.get(f"/api/v1/groups/{group.id}/")
 
         assert response.status_code == status.HTTP_200_OK
-        assert response.data['name'] == 'My Group'
+        assert response.data["name"] == "My Group"
 
     def test_update_group(self):
         """Test updating a group."""
-        user = UserFactory(role='missionary')
+        user = UserFactory(role="missionary")
         group = GroupFactory(owner=user)
 
         client = APIClient()
         client.force_authenticate(user=user)
 
-        response = client.patch(
-            f'/api/v1/groups/{group.id}/',
-            {'name': 'Updated Name'}
-        )
+        response = client.patch(f"/api/v1/groups/{group.id}/", {"name": "Updated Name"})
 
         assert response.status_code == status.HTTP_200_OK
         group.refresh_from_db()
-        assert group.name == 'Updated Name'
+        assert group.name == "Updated Name"
 
     def test_delete_group(self):
         """Test deleting a group."""
-        user = UserFactory(role='missionary')
+        user = UserFactory(role="missionary")
         group = GroupFactory(owner=user)
 
         client = APIClient()
         client.force_authenticate(user=user)
 
-        response = client.delete(f'/api/v1/groups/{group.id}/')
+        response = client.delete(f"/api/v1/groups/{group.id}/")
 
         assert response.status_code == status.HTTP_204_NO_CONTENT
         assert not Group.objects.filter(id=group.id).exists()
@@ -111,7 +105,7 @@ class TestGroupContactsView:
 
     def test_list_contacts_in_group(self):
         """Test listing contacts in a group."""
-        user = UserFactory(role='missionary')
+        user = UserFactory(role="missionary")
         group = GroupFactory(owner=user)
         contact1 = ContactFactory(owner=user)
         contact2 = ContactFactory(owner=user)
@@ -121,7 +115,7 @@ class TestGroupContactsView:
         client = APIClient()
         client.force_authenticate(user=user)
 
-        response = client.get(f'/api/v1/groups/{group.id}/contacts/')
+        response = client.get(f"/api/v1/groups/{group.id}/contacts/")
 
         assert response.status_code == status.HTTP_200_OK
         # Response is a list, not paginated
@@ -129,7 +123,7 @@ class TestGroupContactsView:
 
     def test_add_contact_to_group(self):
         """Test adding a contact to a group via POST."""
-        user = UserFactory(role='missionary')
+        user = UserFactory(role="missionary")
         group = GroupFactory(owner=user)
         contact = ContactFactory(owner=user)
 
@@ -138,9 +132,9 @@ class TestGroupContactsView:
 
         # POST to /contacts/ endpoint adds contacts
         response = client.post(
-            f'/api/v1/groups/{group.id}/contacts/',
-            {'contact_ids': [str(contact.id)]},
-            format='json'
+            f"/api/v1/groups/{group.id}/contacts/",
+            {"contact_ids": [str(contact.id)]},
+            format="json",
         )
 
         assert response.status_code == status.HTTP_200_OK
@@ -148,7 +142,7 @@ class TestGroupContactsView:
 
     def test_add_contact_to_group_admin_own_contacts(self):
         """Test that admin can add their own contact to a group."""
-        admin = UserFactory(role='admin')
+        admin = UserFactory(role="admin")
         group = GroupFactory(owner=admin)
         contact = ContactFactory(owner=admin)
 
@@ -156,9 +150,9 @@ class TestGroupContactsView:
         client.force_authenticate(user=admin)
 
         response = client.post(
-            f'/api/v1/groups/{group.id}/contacts/',
-            {'contact_ids': [str(contact.id)]},
-            format='json'
+            f"/api/v1/groups/{group.id}/contacts/",
+            {"contact_ids": [str(contact.id)]},
+            format="json",
         )
 
         assert response.status_code == status.HTTP_200_OK
@@ -166,8 +160,8 @@ class TestGroupContactsView:
 
     def test_add_contact_to_group_admin_cannot_add_others_without_view_as(self):
         """Test that admin cannot add another user's contact without View As."""
-        admin = UserFactory(role='admin')
-        missionary = UserFactory(role='missionary')
+        admin = UserFactory(role="admin")
+        missionary = UserFactory(role="missionary")
         group = GroupFactory(owner=admin)
         contact = ContactFactory(owner=missionary)
 
@@ -175,9 +169,9 @@ class TestGroupContactsView:
         client.force_authenticate(user=admin)
 
         response = client.post(
-            f'/api/v1/groups/{group.id}/contacts/',
-            {'contact_ids': [str(contact.id)]},
-            format='json'
+            f"/api/v1/groups/{group.id}/contacts/",
+            {"contact_ids": [str(contact.id)]},
+            format="json",
         )
 
         # Request fails with 400 because the contact is not visible to admin without View As
@@ -186,8 +180,8 @@ class TestGroupContactsView:
 
     def test_add_contact_to_group_missionary_cannot_add_others(self):
         """Test that a missionary cannot add another user's contact to a group."""
-        missionary1 = UserFactory(role='missionary')
-        missionary2 = UserFactory(role='missionary')
+        missionary1 = UserFactory(role="missionary")
+        missionary2 = UserFactory(role="missionary")
         group = GroupFactory(owner=missionary1)
         contact = ContactFactory(owner=missionary2)
 
@@ -195,9 +189,9 @@ class TestGroupContactsView:
         client.force_authenticate(user=missionary1)
 
         response = client.post(
-            f'/api/v1/groups/{group.id}/contacts/',
-            {'contact_ids': [str(contact.id)]},
-            format='json'
+            f"/api/v1/groups/{group.id}/contacts/",
+            {"contact_ids": [str(contact.id)]},
+            format="json",
         )
 
         # The request fails with 400 because no visible contacts were found
@@ -206,7 +200,7 @@ class TestGroupContactsView:
 
     def test_remove_contact_from_group(self):
         """Test removing a contact from a group via DELETE."""
-        user = UserFactory(role='missionary')
+        user = UserFactory(role="missionary")
         group = GroupFactory(owner=user)
         contact = ContactFactory(owner=user)
         contact.groups.add(group)
@@ -216,9 +210,9 @@ class TestGroupContactsView:
 
         # DELETE to /contacts/ endpoint removes contacts
         response = client.delete(
-            f'/api/v1/groups/{group.id}/contacts/',
-            {'contact_ids': [str(contact.id)]},
-            format='json'
+            f"/api/v1/groups/{group.id}/contacts/",
+            {"contact_ids": [str(contact.id)]},
+            format="json",
         )
 
         assert response.status_code == status.HTTP_200_OK
@@ -226,8 +220,8 @@ class TestGroupContactsView:
 
     def test_missionary_cannot_add_contacts_to_another_users_group(self):
         """Missionary gets 404 for a group they can't see (security: don't reveal existence)."""
-        owner = UserFactory(role='missionary')
-        other = UserFactory(role='missionary')
+        owner = UserFactory(role="missionary")
+        other = UserFactory(role="missionary")
         group = GroupFactory(owner=owner)
         contact = ContactFactory(owner=other)
 
@@ -235,9 +229,9 @@ class TestGroupContactsView:
         client.force_authenticate(user=other)
 
         response = client.post(
-            f'/api/v1/groups/{group.id}/contacts/',
-            {'contact_ids': [str(contact.id)]},
-            format='json'
+            f"/api/v1/groups/{group.id}/contacts/",
+            {"contact_ids": [str(contact.id)]},
+            format="json",
         )
 
         assert response.status_code == status.HTTP_404_NOT_FOUND
@@ -245,7 +239,7 @@ class TestGroupContactsView:
 
     def test_missionary_can_add_contacts_to_shared_group(self):
         """Missionary should be allowed to mutate a shared group (owner=None)."""
-        user = UserFactory(role='missionary')
+        user = UserFactory(role="missionary")
         group = SharedGroupFactory()
         contact = ContactFactory(owner=user)
 
@@ -253,9 +247,9 @@ class TestGroupContactsView:
         client.force_authenticate(user=user)
 
         response = client.post(
-            f'/api/v1/groups/{group.id}/contacts/',
-            {'contact_ids': [str(contact.id)]},
-            format='json'
+            f"/api/v1/groups/{group.id}/contacts/",
+            {"contact_ids": [str(contact.id)]},
+            format="json",
         )
 
         assert response.status_code == status.HTTP_200_OK
@@ -263,7 +257,7 @@ class TestGroupContactsView:
 
     def test_coach_cannot_write_contacts_to_group(self):
         """Coach role must be blocked from write operations on group contacts."""
-        coach = UserFactory(role='coach')
+        coach = UserFactory(role="coach")
         group = GroupFactory(owner=coach)
         contact = ContactFactory(owner=coach)
 
@@ -271,9 +265,9 @@ class TestGroupContactsView:
         client.force_authenticate(user=coach)
 
         response = client.post(
-            f'/api/v1/groups/{group.id}/contacts/',
-            {'contact_ids': [str(contact.id)]},
-            format='json'
+            f"/api/v1/groups/{group.id}/contacts/",
+            {"contact_ids": [str(contact.id)]},
+            format="json",
         )
 
         assert response.status_code == status.HTTP_403_FORBIDDEN

--- a/apps/groups/urls.py
+++ b/apps/groups/urls.py
@@ -10,11 +10,13 @@ from apps.groups.views import (
     GroupListCreateView,
 )
 
-app_name = 'groups'
+app_name = "groups"
 
 urlpatterns = [
-    path('', GroupListCreateView.as_view(), name='group-list'),
-    path('<uuid:pk>/', GroupDetailView.as_view(), name='group-detail'),
-    path('<uuid:pk>/contacts/', GroupContactsView.as_view(), name='group-contacts'),
-    path('<uuid:pk>/contacts/emails/', GroupContactEmailsView.as_view(), name='group-contact-emails'),
+    path("", GroupListCreateView.as_view(), name="group-list"),
+    path("<uuid:pk>/", GroupDetailView.as_view(), name="group-detail"),
+    path("<uuid:pk>/contacts/", GroupContactsView.as_view(), name="group-contacts"),
+    path(
+        "<uuid:pk>/contacts/emails/", GroupContactEmailsView.as_view(), name="group-contact-emails"
+    ),
 ]

--- a/apps/groups/views.py
+++ b/apps/groups/views.py
@@ -2,13 +2,19 @@
 Views for Group management.
 """
 from django.db.models import Count, Q
+
 from rest_framework import generics, permissions, status
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from apps.contacts.models import Contact
 from apps.contacts.serializers import ContactListSerializer
-from apps.core.permissions import IsOwnerOrAdmin, IsStaffOrAbove, IsSupervisorWriteRestricted, get_visible_user_ids
+from apps.core.permissions import (
+    IsOwnerOrAdmin,
+    IsStaffOrAbove,
+    IsSupervisorWriteRestricted,
+    get_visible_user_ids,
+)
 from apps.groups.models import Group
 from apps.groups.serializers import GroupCreateSerializer, GroupSerializer
 
@@ -18,20 +24,17 @@ class GroupListCreateView(generics.ListCreateAPIView):
     GET: List groups (own groups + shared groups)
     POST: Create a new group (private to user)
     """
+
     permission_classes = [permissions.IsAuthenticated]
 
     def get_queryset(self):
         user = self.request.user
         visible = get_visible_user_ids(user, request=self.request)
-        queryset = Group.objects.filter(
-            Q(owner_id__in=visible) | Q(owner__isnull=True)
-        )
-        return queryset.annotate(
-            annotated_contact_count=Count('contacts')
-        ).order_by('name')
+        queryset = Group.objects.filter(Q(owner_id__in=visible) | Q(owner__isnull=True))
+        return queryset.annotate(annotated_contact_count=Count("contacts")).order_by("name")
 
     def get_serializer_class(self):
-        if self.request.method == 'POST':
+        if self.request.method == "POST":
             return GroupCreateSerializer
         return GroupSerializer
 
@@ -42,25 +45,21 @@ class GroupDetailView(generics.RetrieveUpdateDestroyAPIView):
     PATCH/PUT: Update group
     DELETE: Delete group (if not system group)
     """
+
     serializer_class = GroupSerializer
     permission_classes = [permissions.IsAuthenticated, IsOwnerOrAdmin, IsSupervisorWriteRestricted]
 
     def get_queryset(self):
         user = self.request.user
         visible = get_visible_user_ids(user, request=self.request)
-        queryset = Group.objects.filter(
-            Q(owner_id__in=visible) | Q(owner__isnull=True)
-        )
-        return queryset.annotate(
-            annotated_contact_count=Count('contacts')
-        )
+        queryset = Group.objects.filter(Q(owner_id__in=visible) | Q(owner__isnull=True))
+        return queryset.annotate(annotated_contact_count=Count("contacts"))
 
     def destroy(self, request, *args, **kwargs):
         group = self.get_object()
         if group.is_system:
             return Response(
-                {'detail': 'System groups cannot be deleted.'},
-                status=status.HTTP_400_BAD_REQUEST
+                {"detail": "System groups cannot be deleted."}, status=status.HTTP_400_BAD_REQUEST
             )
         return super().destroy(request, *args, **kwargs)
 
@@ -84,21 +83,16 @@ class GroupContactsView(APIView):
         user = self.request.user
         visible = get_visible_user_ids(user, request=self.request)
         try:
-            return Group.objects.get(
-                Q(pk=pk) & (Q(owner_id__in=visible) | Q(owner__isnull=True))
-            )
+            return Group.objects.get(Q(pk=pk) & (Q(owner_id__in=visible) | Q(owner__isnull=True)))
         except Group.DoesNotExist:
             return None
 
     def get(self, request, pk):
         group = self.get_group(pk)
         if not group:
-            return Response(
-                {'detail': 'Group not found.'},
-                status=status.HTTP_404_NOT_FOUND
-            )
+            return Response({"detail": "Group not found."}, status=status.HTTP_404_NOT_FOUND)
 
-        contacts = group.contacts.filter(is_merged=False).select_related('owner')
+        contacts = group.contacts.filter(is_merged=False).select_related("owner")
         serializer = ContactListSerializer(contacts, many=True)
         return Response(serializer.data)
 
@@ -106,22 +100,18 @@ class GroupContactsView(APIView):
         """Add contacts to group."""
         group = self.get_group(pk)
         if not group:
-            return Response(
-                {'detail': 'Group not found.'},
-                status=status.HTTP_404_NOT_FOUND
-            )
+            return Response({"detail": "Group not found."}, status=status.HTTP_404_NOT_FOUND)
 
         if group.is_system:
             return Response(
-                {'detail': 'Cannot modify membership of system groups.'},
-                status=status.HTTP_400_BAD_REQUEST
+                {"detail": "Cannot modify membership of system groups."},
+                status=status.HTTP_400_BAD_REQUEST,
             )
 
-        contact_ids = request.data.get('contact_ids', [])
+        contact_ids = request.data.get("contact_ids", [])
         if not contact_ids:
             return Response(
-                {'detail': 'No contact_ids provided.'},
-                status=status.HTTP_400_BAD_REQUEST
+                {"detail": "No contact_ids provided."}, status=status.HTTP_400_BAD_REQUEST
             )
 
         contacts = Contact.objects.filter(id__in=contact_ids, owner=request.user, is_merged=False)
@@ -129,64 +119,57 @@ class GroupContactsView(APIView):
         added_count = contacts.count()
         if added_count == 0:
             return Response(
-                {'detail': 'None of the requested contacts were visible to you.'},
-                status=status.HTTP_400_BAD_REQUEST
+                {"detail": "None of the requested contacts were visible to you."},
+                status=status.HTTP_400_BAD_REQUEST,
             )
 
         group.contacts.add(*contacts)
-        return Response({'detail': f'Added {added_count} contacts to group.'})
+        return Response({"detail": f"Added {added_count} contacts to group."})
 
     def delete(self, request, pk):
         """Remove contacts from group."""
         group = self.get_group(pk)
         if not group:
-            return Response(
-                {'detail': 'Group not found.'},
-                status=status.HTTP_404_NOT_FOUND
-            )
+            return Response({"detail": "Group not found."}, status=status.HTTP_404_NOT_FOUND)
 
         if group.is_system:
             return Response(
-                {'detail': 'Cannot modify membership of system groups.'},
-                status=status.HTTP_400_BAD_REQUEST
+                {"detail": "Cannot modify membership of system groups."},
+                status=status.HTTP_400_BAD_REQUEST,
             )
 
-        contact_ids = request.data.get('contact_ids', [])
+        contact_ids = request.data.get("contact_ids", [])
         if not contact_ids:
             return Response(
-                {'detail': 'No contact_ids provided.'},
-                status=status.HTTP_400_BAD_REQUEST
+                {"detail": "No contact_ids provided."}, status=status.HTTP_400_BAD_REQUEST
             )
 
         visible = get_visible_user_ids(request.user, request=request)
         contacts = Contact.objects.filter(id__in=contact_ids, owner_id__in=visible)
         group.contacts.remove(*contacts)
 
-        return Response({'detail': f'Removed contacts from group.'})
+        return Response({"detail": f"Removed contacts from group."})
 
 
 class GroupContactEmailsView(APIView):
     """
     GET: Return all email addresses for contacts in a group.
     """
+
     permission_classes = [permissions.IsAuthenticated]
 
     def get(self, request, pk):
         user = request.user
         visible = get_visible_user_ids(user, request=request)
         try:
-            group = Group.objects.get(
-                Q(pk=pk) & (Q(owner_id__in=visible) | Q(owner__isnull=True))
-            )
+            group = Group.objects.get(Q(pk=pk) & (Q(owner_id__in=visible) | Q(owner__isnull=True)))
         except Group.DoesNotExist:
-            return Response(
-                {'detail': 'Group not found.'},
-                status=status.HTTP_404_NOT_FOUND
-            )
+            return Response({"detail": "Group not found."}, status=status.HTTP_404_NOT_FOUND)
 
         emails = list(
-            group.contacts.exclude(email__isnull=True).exclude(email='')
-            .values_list('email', flat=True)
-            .order_by('email')
+            group.contacts.exclude(email__isnull=True)
+            .exclude(email="")
+            .values_list("email", flat=True)
+            .order_by("email")
         )
-        return Response({'emails': emails, 'count': len(emails)})
+        return Response({"emails": emails, "count": len(emails)})

--- a/apps/groups/views.py
+++ b/apps/groups/views.py
@@ -148,7 +148,7 @@ class GroupContactsView(APIView):
         contacts = Contact.objects.filter(id__in=contact_ids, owner_id__in=visible)
         group.contacts.remove(*contacts)
 
-        return Response({"detail": f"Removed contacts from group."})
+        return Response({"detail": "Removed contacts from group."})
 
 
 class GroupContactEmailsView(APIView):

--- a/apps/imports/admin.py
+++ b/apps/imports/admin.py
@@ -4,85 +4,116 @@ Admin configuration for import infrastructure models.
 from django.contrib import admin
 
 from apps.imports.models import (
-    Fund, ImportRun, ImportRowError, ImportBatch,
-    MPDUpload, MPDSnapshot, MissionaryAlias
+    Fund,
+    ImportBatch,
+    ImportRowError,
+    ImportRun,
+    MissionaryAlias,
+    MPDSnapshot,
+    MPDUpload,
 )
 
 
 @admin.register(Fund)
 class FundAdmin(admin.ModelAdmin):
     """Admin configuration for Fund model."""
-    list_display = ['name', 'external_id', 'status', 'owner', 'created_at']
-    list_filter = ['status', 'owner']
-    search_fields = ['name', 'external_id']
-    readonly_fields = ['id', 'created_at', 'updated_at']
+
+    list_display = ["name", "external_id", "status", "owner", "created_at"]
+    list_filter = ["status", "owner"]
+    search_fields = ["name", "external_id"]
+    readonly_fields = ["id", "created_at", "updated_at"]
 
 
 @admin.register(ImportRun)
 class ImportRunAdmin(admin.ModelAdmin):
     """Admin configuration for ImportRun model."""
+
     list_display = [
-        'id', 'type', 'status', 'filename', 'total_rows',
-        'created_count', 'updated_count', 'error_count',
-        'uploaded_by', 'created_at'
+        "id",
+        "type",
+        "status",
+        "filename",
+        "total_rows",
+        "created_count",
+        "updated_count",
+        "error_count",
+        "uploaded_by",
+        "created_at",
     ]
-    list_filter = ['type', 'status', 'uploaded_by']
-    search_fields = ['filename']
-    readonly_fields = ['id', 'created_at', 'updated_at', 'error_summary']
-    date_hierarchy = 'created_at'
+    list_filter = ["type", "status", "uploaded_by"]
+    search_fields = ["filename"]
+    readonly_fields = ["id", "created_at", "updated_at", "error_summary"]
+    date_hierarchy = "created_at"
 
 
 @admin.register(ImportRowError)
 class ImportRowErrorAdmin(admin.ModelAdmin):
     """Admin configuration for ImportRowError model."""
-    list_display = ['id', 'import_run', 'row_number', 'created_at']
-    list_filter = ['import_run__type']
-    readonly_fields = ['id', 'created_at', 'updated_at', 'error_messages', 'row_data']
+
+    list_display = ["id", "import_run", "row_number", "created_at"]
+    list_filter = ["import_run__type"]
+    readonly_fields = ["id", "created_at", "updated_at", "error_messages", "row_data"]
 
 
 @admin.register(ImportBatch)
 class ImportBatchAdmin(admin.ModelAdmin):
     """Admin configuration for ImportBatch model."""
+
     list_display = [
-        'id', 'import_type', 'status', 'filename',
-        'total_rows', 'created_count', 'updated_count', 'error_count',
-        'uploaded_by', 'created_at'
+        "id",
+        "import_type",
+        "status",
+        "filename",
+        "total_rows",
+        "created_count",
+        "updated_count",
+        "error_count",
+        "uploaded_by",
+        "created_at",
     ]
-    list_filter = ['import_type', 'status', 'uploaded_by']
-    search_fields = ['filename', 'sha256_hash']
-    readonly_fields = ['id', 'created_at', 'updated_at', 'summary']
-    date_hierarchy = 'created_at'
+    list_filter = ["import_type", "status", "uploaded_by"]
+    search_fields = ["filename", "sha256_hash"]
+    readonly_fields = ["id", "created_at", "updated_at", "summary"]
+    date_hierarchy = "created_at"
 
 
 @admin.register(MPDUpload)
 class MPDUploadAdmin(admin.ModelAdmin):
     """Admin configuration for MPDUpload model."""
+
     list_display = [
-        'id', 'filename', 'file_format', 'status',
-        'total_rows', 'matched_count', 'unmatched_count',
-        'uploaded_by', 'created_at'
+        "id",
+        "filename",
+        "file_format",
+        "status",
+        "total_rows",
+        "matched_count",
+        "unmatched_count",
+        "uploaded_by",
+        "created_at",
     ]
-    list_filter = ['status', 'file_format', 'uploaded_by']
-    search_fields = ['filename']
-    readonly_fields = ['id', 'created_at', 'updated_at', 'unmatched_rows']
-    date_hierarchy = 'created_at'
+    list_filter = ["status", "file_format", "uploaded_by"]
+    search_fields = ["filename"]
+    readonly_fields = ["id", "created_at", "updated_at", "unmatched_rows"]
+    date_hierarchy = "created_at"
 
 
 class UnresolvedAliasFilter(admin.SimpleListFilter):
     """Filter MissionaryAlias by whether user is resolved or unresolved."""
-    title = 'resolution status'
-    parameter_name = 'resolved'
+
+    title = "resolution status"
+    parameter_name = "resolved"
 
     def lookups(self, request, model_admin):
         return [
-            ('yes', 'Resolved'),
-            ('no', 'Unresolved (user=None)'),
+            ("yes", "Resolved"),
+            ("no", "Unresolved (user=None)"),
         ]
 
     def queryset(self, request, queryset):
-        if self.value() == 'yes':
+        if self.value() == "yes":
             return queryset.filter(user__isnull=False)
-        if self.value() == 'no':
+        if self.value() == "no":
             return queryset.filter(user__isnull=True)
         return queryset
 
@@ -90,21 +121,28 @@ class UnresolvedAliasFilter(admin.SimpleListFilter):
 @admin.register(MissionaryAlias)
 class MissionaryAliasAdmin(admin.ModelAdmin):
     """Admin configuration for MissionaryAlias model."""
-    list_display = ['source_name', 'user', 'notes', 'created_at']
-    search_fields = ['source_name']
+
+    list_display = ["source_name", "user", "notes", "created_at"]
+    search_fields = ["source_name"]
     list_filter = [UnresolvedAliasFilter]
-    raw_id_fields = ['user']
-    readonly_fields = ['id', 'created_at', 'updated_at']
+    raw_id_fields = ["user"]
+    readonly_fields = ["id", "created_at", "updated_at"]
 
 
 @admin.register(MPDSnapshot)
 class MPDSnapshotAdmin(admin.ModelAdmin):
     """Admin configuration for MPDSnapshot model."""
+
     list_display = [
-        'id', 'user', 'upload', 'active_recurring_gifts',
-        'mpd_standard', 'met_mpd_standard', 'current_mpd_cap',
-        'created_at'
+        "id",
+        "user",
+        "upload",
+        "active_recurring_gifts",
+        "mpd_standard",
+        "met_mpd_standard",
+        "current_mpd_cap",
+        "created_at",
     ]
-    list_filter = ['met_mpd_standard', 'met_maximum', 'match_met']
-    search_fields = ['user__first_name', 'user__last_name', 'user__email']
-    readonly_fields = ['id', 'created_at', 'updated_at']
+    list_filter = ["met_mpd_standard", "met_maximum", "match_met"]
+    search_fields = ["user__first_name", "user__last_name", "user__email"]
+    readonly_fields = ["id", "created_at", "updated_at"]

--- a/apps/imports/apps.py
+++ b/apps/imports/apps.py
@@ -2,6 +2,6 @@ from django.apps import AppConfig
 
 
 class ImportsConfig(AppConfig):
-    default_auto_field = 'django.db.models.BigAutoField'
-    name = 'apps.imports'
-    verbose_name = 'Imports'
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "apps.imports"
+    verbose_name = "Imports"

--- a/apps/imports/generic_services.py
+++ b/apps/imports/generic_services.py
@@ -603,7 +603,6 @@ def import_generic_donations(
     # Step 5: Iterate rows with error collection
     errors: list[dict] = []
     created_count = 0
-    error_count_rows = 0
     total_rows = 0
 
     try:

--- a/apps/imports/management/commands/audit_import_health.py
+++ b/apps/imports/management/commands/audit_import_health.py
@@ -17,48 +17,44 @@ from django.core.management.base import BaseCommand
 from django.db.models import Count, Q, Sum
 
 from apps.contacts.models import Contact
-from apps.gifts.models import (
-    Gift,
-    GiftCredit,
-    RecurringGift,
-    RecurringGiftCredit,
-)
-from apps.gifts.models import Solicitor
+from apps.gifts.models import Gift, GiftCredit, RecurringGift, RecurringGiftCredit, Solicitor
 from apps.imports.models import MissionaryAlias
 from apps.users.models import User
 
 
 class Command(BaseCommand):
-    help = 'Audit import pipeline data quality across 5 diagnostic sections'
+    help = "Audit import pipeline data quality across 5 diagnostic sections"
 
     def add_arguments(self, parser):
         parser.add_argument(
-            '--verbose',
-            action='store_true',
-            help='Show per-record detail lists',
+            "--verbose",
+            action="store_true",
+            help="Show per-record detail lists",
         )
         parser.add_argument(
-            '--json',
-            action='store_true',
-            dest='json_output',
-            help='Output machine-readable JSON instead of text',
+            "--json",
+            action="store_true",
+            dest="json_output",
+            help="Output machine-readable JSON instead of text",
         )
 
     def handle(self, *args, **options):
-        verbose = options['verbose']
-        json_output = options['json_output']
+        verbose = options["verbose"]
+        json_output = options["json_output"]
 
         # Edge case: no solicitors
         if Solicitor.objects.count() == 0:
             if json_output:
-                self.stdout.write(json.dumps(
-                    {'message': 'No solicitors found. Import solicitors first.'},
-                    indent=2,
-                ))
+                self.stdout.write(
+                    json.dumps(
+                        {"message": "No solicitors found. Import solicitors first."},
+                        indent=2,
+                    )
+                )
             else:
-                self.stdout.write(self.style.WARNING(
-                    'No solicitors found. Import solicitors first.'
-                ))
+                self.stdout.write(
+                    self.style.WARNING("No solicitors found. Import solicitors first.")
+                )
             return
 
         # Collect all report data
@@ -67,38 +63,38 @@ class Command(BaseCommand):
 
         # --- Section 1: Solicitor Linking ---
         section1 = self._section1_solicitor_linking()
-        report['solicitor_linking'] = section1
-        issue_count += section1['unlinked']
+        report["solicitor_linking"] = section1
+        issue_count += section1["unlinked"]
 
         # --- Section 2: Contact Ownership ---
         section2 = self._section2_contact_ownership()
-        report['contact_ownership'] = section2
-        issue_count += len(section2['misattributions'])
+        report["contact_ownership"] = section2
+        issue_count += len(section2["misattributions"])
 
         # --- Section 3: Gift Credit Integrity ---
         section3 = self._section3_gift_credit_integrity()
-        report['gift_credit_integrity'] = section3
-        issue_count += section3['orphaned_count']
+        report["gift_credit_integrity"] = section3
+        issue_count += section3["orphaned_count"]
 
         # --- Section 4: Recurring Gift Credit Integrity ---
         section4 = self._section4_recurring_gift_credit_integrity()
-        report['recurring_gift_credit_integrity'] = section4
-        issue_count += section4['orphaned_count']
+        report["recurring_gift_credit_integrity"] = section4
+        issue_count += section4["orphaned_count"]
 
         # --- Section 5: Dashboard Impact Estimate ---
         section5 = self._section5_dashboard_impact()
-        report['dashboard_impact'] = section5
-        issue_count += len(section5['flagged'])
+        report["dashboard_impact"] = section5
+        issue_count += len(section5["flagged"])
 
         # --- Verdict ---
         if issue_count == 0:
-            verdict = 'HEALTHY -- All import data is clean.'
+            verdict = "HEALTHY -- All import data is clean."
         else:
-            verdict = f'NEEDS ATTENTION -- {issue_count} issue(s) detected.'
-        report['verdict'] = {
-            'status': 'HEALTHY' if issue_count == 0 else 'NEEDS ATTENTION',
-            'issue_count': issue_count,
-            'message': verdict,
+            verdict = f"NEEDS ATTENTION -- {issue_count} issue(s) detected."
+        report["verdict"] = {
+            "status": "HEALTHY" if issue_count == 0 else "NEEDS ATTENTION",
+            "issue_count": issue_count,
+            "message": verdict,
         }
 
         # Output
@@ -120,8 +116,9 @@ class Command(BaseCommand):
 
         # Unlinked solicitor details for verbose output
         unlinked_solicitors = list(
-            Solicitor.objects.filter(user__isnull=True)
-            .values('id', 'normalized_name', 'external_solicitor_id')
+            Solicitor.objects.filter(user__isnull=True).values(
+                "id", "normalized_name", "external_solicitor_id"
+            )
         )
 
         # Near-miss detection
@@ -129,33 +126,37 @@ class Command(BaseCommand):
         if unlinked_solicitors:
             # Build candidate list: "First Last", "Last, First", and aliases
             candidates = []
-            for fn, ln in User.objects.values_list('first_name', 'last_name'):
-                candidates.append({'name': f'{fn} {ln}', 'format': 'first_last'})
-                candidates.append({'name': f'{ln}, {fn}', 'format': 'last_first'})
-            for alias in MissionaryAlias.objects.filter(user__isnull=False).values_list('source_name', flat=True):
-                candidates.append({'name': alias, 'format': 'alias'})
+            for fn, ln in User.objects.values_list("first_name", "last_name"):
+                candidates.append({"name": f"{fn} {ln}", "format": "first_last"})
+                candidates.append({"name": f"{ln}, {fn}", "format": "last_first"})
+            for alias in MissionaryAlias.objects.filter(user__isnull=False).values_list(
+                "source_name", flat=True
+            ):
+                candidates.append({"name": alias, "format": "alias"})
 
             for sol in unlinked_solicitors:
                 for c in candidates:
                     ratio = difflib.SequenceMatcher(
-                        None, sol['normalized_name'].lower(), c['name'].lower()
+                        None, sol["normalized_name"].lower(), c["name"].lower()
                     ).ratio()
                     if ratio >= 0.8:
-                        near_misses.append({
-                            'solicitor_name': sol['normalized_name'],
-                            'candidate': c['name'],
-                            'format': c['format'],
-                            'score': round(ratio, 3),
-                        })
+                        near_misses.append(
+                            {
+                                "solicitor_name": sol["normalized_name"],
+                                "candidate": c["name"],
+                                "format": c["format"],
+                                "score": round(ratio, 3),
+                            }
+                        )
 
         return {
-            'total': total,
-            'linked': linked,
-            'unlinked': unlinked,
-            'linked_pct': linked_pct,
-            'unlinked_pct': unlinked_pct,
-            'unlinked_solicitors': unlinked_solicitors,
-            'near_misses': near_misses,
+            "total": total,
+            "linked": linked,
+            "unlinked": unlinked,
+            "linked_pct": linked_pct,
+            "unlinked_pct": unlinked_pct,
+            "unlinked_solicitors": unlinked_solicitors,
+            "near_misses": near_misses,
         }
 
     # -----------------------------------------------------------------
@@ -165,45 +166,51 @@ class Command(BaseCommand):
     def _section2_contact_ownership(self):
         # Group contacts by owner role
         role_counts = list(
-            Contact.objects.values('owner__role')
-            .annotate(count=Count('id'))
-            .order_by('owner__role')
+            Contact.objects.values("owner__role")
+            .annotate(count=Count("id"))
+            .order_by("owner__role")
         )
 
         # Misattribution detection: admin/supervisor-owned contacts with
         # gift credits OR recurring gift credits pointing to a missionary
         misattributed_contacts = (
             Contact.objects.filter(
-                owner__role__in=['admin', 'supervisor'],
+                owner__role__in=["admin", "supervisor"],
             )
             .filter(
-                Q(gifts__credits__solicitor__user__role='missionary')
-                | Q(recurring_gifts__credits__solicitor__user__role='missionary')
+                Q(gifts__credits__solicitor__user__role="missionary")
+                | Q(recurring_gifts__credits__solicitor__user__role="missionary")
             )
             .distinct()
-            .select_related('owner')
+            .select_related("owner")
         )
 
         misattributions = []
         for contact in misattributed_contacts:
             # Find missionary user(s) credited via solicitor (gifts + recurring)
-            missionary_solicitors = Solicitor.objects.filter(
-                Q(gift_credits__gift__donor_contact=contact)
-                | Q(recurring_gift_credits__recurring_gift__donor_contact=contact),
-                user__role='missionary',
-            ).distinct().select_related('user')
-            misattributions.append({
-                'contact_id': contact.id,
-                'contact_name': f'{contact.first_name} {contact.last_name}',
-                'external_constituent_id': contact.external_constituent_id,
-                'owner_email': contact.owner.email,
-                'owner_role': contact.owner.role,
-                'missionary_emails': [s.user.email for s in missionary_solicitors],
-            })
+            missionary_solicitors = (
+                Solicitor.objects.filter(
+                    Q(gift_credits__gift__donor_contact=contact)
+                    | Q(recurring_gift_credits__recurring_gift__donor_contact=contact),
+                    user__role="missionary",
+                )
+                .distinct()
+                .select_related("user")
+            )
+            misattributions.append(
+                {
+                    "contact_id": contact.id,
+                    "contact_name": f"{contact.first_name} {contact.last_name}",
+                    "external_constituent_id": contact.external_constituent_id,
+                    "owner_email": contact.owner.email,
+                    "owner_role": contact.owner.role,
+                    "missionary_emails": [s.user.email for s in missionary_solicitors],
+                }
+            )
 
         return {
-            'role_counts': role_counts,
-            'misattributions': misattributions,
+            "role_counts": role_counts,
+            "misattributions": misattributions,
         }
 
     # -----------------------------------------------------------------
@@ -213,38 +220,35 @@ class Command(BaseCommand):
     def _section3_gift_credit_integrity(self):
         total_gifts = Gift.objects.count()
         total_credits = GiftCredit.objects.count()
-        linked_credits = GiftCredit.objects.filter(
-            solicitor__user__isnull=False
-        ).count()
+        linked_credits = GiftCredit.objects.filter(solicitor__user__isnull=False).count()
         unlinked_credits = total_credits - linked_credits
 
-        orphaned_gifts = Gift.objects.annotate(
-            credit_count=Count('credits')
-        ).filter(credit_count=0)
+        orphaned_gifts = Gift.objects.annotate(credit_count=Count("credits")).filter(credit_count=0)
         orphaned_count = orphaned_gifts.count()
 
         # Dollar value of orphaned gifts (no credits — cannot route to any missionary)
-        orphaned_value = (
-            orphaned_gifts.aggregate(total=Sum('amount_cents'))['total'] or 0
-        )
+        orphaned_value = orphaned_gifts.aggregate(total=Sum("amount_cents"))["total"] or 0
         unlinked_dollars = Decimal(orphaned_value) / Decimal(100)
 
         # Orphaned gift details for verbose
         orphaned_details = list(
             orphaned_gifts.values_list(
-                'id', 'donor_contact__first_name',
-                'donor_contact__last_name', 'amount_cents', 'gift_date',
+                "id",
+                "donor_contact__first_name",
+                "donor_contact__last_name",
+                "amount_cents",
+                "gift_date",
             )[:20]
         )
 
         return {
-            'total_gifts': total_gifts,
-            'total_credits': total_credits,
-            'linked_credits': linked_credits,
-            'unlinked_credits': unlinked_credits,
-            'orphaned_count': orphaned_count,
-            'unlinked_dollars': f'{unlinked_dollars:.2f}',
-            'orphaned_details': orphaned_details,
+            "total_gifts": total_gifts,
+            "total_credits": total_credits,
+            "linked_credits": linked_credits,
+            "unlinked_credits": unlinked_credits,
+            "orphaned_count": orphaned_count,
+            "unlinked_dollars": f"{unlinked_dollars:.2f}",
+            "orphaned_details": orphaned_details,
         }
 
     # -----------------------------------------------------------------
@@ -252,44 +256,41 @@ class Command(BaseCommand):
     # -----------------------------------------------------------------
 
     def _section4_recurring_gift_credit_integrity(self):
-        active_recurring = RecurringGift.objects.filter(status='active')
+        active_recurring = RecurringGift.objects.filter(status="active")
         total_active = active_recurring.count()
-        total_credits = RecurringGiftCredit.objects.filter(
-            recurring_gift__status='active'
-        ).count()
+        total_credits = RecurringGiftCredit.objects.filter(recurring_gift__status="active").count()
         linked_credits = RecurringGiftCredit.objects.filter(
-            recurring_gift__status='active',
+            recurring_gift__status="active",
             solicitor__user__isnull=False,
         ).count()
         unlinked_credits = total_credits - linked_credits
 
-        orphaned = active_recurring.annotate(
-            credit_count=Count('credits')
-        ).filter(credit_count=0)
+        orphaned = active_recurring.annotate(credit_count=Count("credits")).filter(credit_count=0)
         orphaned_count = orphaned.count()
 
         # Dollar value of orphaned active recurring gifts (no credits)
-        orphaned_value = (
-            orphaned.aggregate(total=Sum('amount_cents'))['total'] or 0
-        )
+        orphaned_value = orphaned.aggregate(total=Sum("amount_cents"))["total"] or 0
         unlinked_dollars = Decimal(orphaned_value) / Decimal(100)
 
         # Orphaned details for verbose
         orphaned_details = list(
             orphaned.values_list(
-                'id', 'donor_contact__first_name',
-                'donor_contact__last_name', 'amount_cents', 'frequency',
+                "id",
+                "donor_contact__first_name",
+                "donor_contact__last_name",
+                "amount_cents",
+                "frequency",
             )[:20]
         )
 
         return {
-            'total_active': total_active,
-            'total_credits': total_credits,
-            'linked_credits': linked_credits,
-            'unlinked_credits': unlinked_credits,
-            'orphaned_count': orphaned_count,
-            'unlinked_dollars': f'{unlinked_dollars:.2f}',
-            'orphaned_details': orphaned_details,
+            "total_active": total_active,
+            "total_credits": total_credits,
+            "linked_credits": linked_credits,
+            "unlinked_credits": unlinked_credits,
+            "orphaned_count": orphaned_count,
+            "unlinked_dollars": f"{unlinked_dollars:.2f}",
+            "orphaned_details": orphaned_details,
         }
 
     # -----------------------------------------------------------------
@@ -297,63 +298,59 @@ class Command(BaseCommand):
     # -----------------------------------------------------------------
 
     def _section5_dashboard_impact(self):
-        missionaries = User.objects.filter(role='missionary')
+        missionaries = User.objects.filter(role="missionary")
         rows = []
         flagged = []
 
         for user in missionaries:
             contacts_count = Contact.objects.filter(owner=user).count()
             gift_sum = (
-                Gift.objects.filter(donor_contact__owner=user)
-                .aggregate(total=Sum('amount_cents'))['total'] or 0
+                Gift.objects.filter(donor_contact__owner=user).aggregate(total=Sum("amount_cents"))[
+                    "total"
+                ]
+                or 0
             )
             active_recurring_qs = RecurringGift.objects.filter(
-                donor_contact__owner=user, status='active'
+                donor_contact__owner=user, status="active"
             )
             recurring_count = active_recurring_qs.count()
-            recurring_sum = (
-                active_recurring_qs.aggregate(total=Sum('amount_cents'))['total'] or 0
-            )
-            credit_count = GiftCredit.objects.filter(
-                solicitor__user=user
-            ).count()
+            recurring_sum = active_recurring_qs.aggregate(total=Sum("amount_cents"))["total"] or 0
+            credit_count = GiftCredit.objects.filter(solicitor__user=user).count()
 
             row = {
-                'user_name': user.full_name,
-                'user_email': user.email,
-                'contacts': contacts_count,
-                'gift_dollars': str(Decimal(gift_sum) / Decimal(100)),
-                'active_recurring_count': recurring_count,
-                'recurring_dollars': str(Decimal(recurring_sum) / Decimal(100)),
-                'credit_count': credit_count,
-                'flagged': False,
-                'flag_reasons': [],
+                "user_name": user.full_name,
+                "user_email": user.email,
+                "contacts": contacts_count,
+                "gift_dollars": str(Decimal(gift_sum) / Decimal(100)),
+                "active_recurring_count": recurring_count,
+                "recurring_dollars": str(Decimal(recurring_sum) / Decimal(100)),
+                "credit_count": credit_count,
+                "flagged": False,
+                "flag_reasons": [],
             }
 
             flag_reasons = []
             if contacts_count == 0:
-                flag_reasons.append(
-                    '0 contacts — will see empty dashboard'
-                )
+                flag_reasons.append("0 contacts — will see empty dashboard")
             if contacts_count == 0 and credit_count > 0:
                 flag_reasons.append(
-                    '0 contacts but has gift credits via solicitor — suggests contact ownership not reassigned'
+                    "0 contacts but has gift credits via solicitor — suggests contact ownership not reassigned"
                 )
             if gift_sum == 0 and credit_count > 0:
                 flag_reasons.append(
-                    '0 gifts (by ownership) but has gift credits via solicitor — suggests contact ownership not reassigned'
+                    "0 gifts (by ownership) but has gift credits via solicitor — suggests contact ownership not reassigned"
                 )
 
             if flag_reasons:
-                row['flagged'] = True
-                row['flag_reasons'] = flag_reasons
+                row["flagged"] = True
+                row["flag_reasons"] = flag_reasons
                 flagged.append(row)
 
             rows.append(row)
 
         return {
-            'missionaries': rows,
-            'flagged': flagged,
+            "missionaries": rows,
+            "flagged": flagged,
         }
 
     # -----------------------------------------------------------------
@@ -362,50 +359,40 @@ class Command(BaseCommand):
 
     def _print_text(self, report, verbose):
         # Section 1
-        s1 = report['solicitor_linking']
-        self.stdout.write(self.style.MIGRATE_HEADING(
-            '\n=== Section 1: Solicitor Linking ==='
-        ))
+        s1 = report["solicitor_linking"]
+        self.stdout.write(self.style.MIGRATE_HEADING("\n=== Section 1: Solicitor Linking ==="))
         self.stdout.write(f'  Total: {s1["total"]}')
         self.stdout.write(f'  Linked: {s1["linked"]} ({s1["linked_pct"]}%)')
         self.stdout.write(f'  Unlinked: {s1["unlinked"]} ({s1["unlinked_pct"]}%)')
 
-        if s1['near_misses']:
-            self.stdout.write(self.style.WARNING(
-                f'  Near-misses found: {len(s1["near_misses"])}'
-            ))
+        if s1["near_misses"]:
+            self.stdout.write(self.style.WARNING(f'  Near-misses found: {len(s1["near_misses"])}'))
             if verbose:
-                for nm in s1['near_misses']:
+                for nm in s1["near_misses"]:
                     self.stdout.write(
                         f'    - "{nm["solicitor_name"]}" ~ '
                         f'"{nm["candidate"]}" ({nm["format"]}, score: {nm["score"]})'
                     )
 
-        if verbose and s1['unlinked_solicitors']:
-            self.stdout.write('  Unlinked solicitors:')
-            for sol in s1['unlinked_solicitors']:
-                ext_id = sol['external_solicitor_id']
-                id_str = f', ext_id={ext_id}' if ext_id else ''
-                self.stdout.write(
-                    f'    - #{sol["id"]} {sol["normalized_name"]}{id_str}'
-                )
+        if verbose and s1["unlinked_solicitors"]:
+            self.stdout.write("  Unlinked solicitors:")
+            for sol in s1["unlinked_solicitors"]:
+                ext_id = sol["external_solicitor_id"]
+                id_str = f", ext_id={ext_id}" if ext_id else ""
+                self.stdout.write(f'    - #{sol["id"]} {sol["normalized_name"]}{id_str}')
 
         # Section 2
-        s2 = report['contact_ownership']
-        self.stdout.write(self.style.MIGRATE_HEADING(
-            '\n=== Section 2: Contact Ownership ==='
-        ))
-        for rc in s2['role_counts']:
-            self.stdout.write(
-                f'  {rc["owner__role"]}: {rc["count"]} contacts'
-            )
+        s2 = report["contact_ownership"]
+        self.stdout.write(self.style.MIGRATE_HEADING("\n=== Section 2: Contact Ownership ==="))
+        for rc in s2["role_counts"]:
+            self.stdout.write(f'  {rc["owner__role"]}: {rc["count"]} contacts')
 
-        if s2['misattributions']:
-            self.stdout.write(self.style.WARNING(
-                f'  Misattributions found: {len(s2["misattributions"])}'
-            ))
+        if s2["misattributions"]:
+            self.stdout.write(
+                self.style.WARNING(f'  Misattributions found: {len(s2["misattributions"])}')
+            )
             if verbose:
-                for ma in s2['misattributions']:
+                for ma in s2["misattributions"]:
                     self.stdout.write(
                         f'    - {ma["contact_name"]} '
                         f'(ext: {ma["external_constituent_id"] or "N/A"}) '
@@ -413,15 +400,11 @@ class Command(BaseCommand):
                         f'but credited to {", ".join(ma["missionary_emails"])}'
                     )
         else:
-            self.stdout.write(self.style.SUCCESS(
-                '  No misattributions detected.'
-            ))
+            self.stdout.write(self.style.SUCCESS("  No misattributions detected."))
 
         # Section 3
-        s3 = report['gift_credit_integrity']
-        self.stdout.write(self.style.MIGRATE_HEADING(
-            '\n=== Section 3: Gift Credit Integrity ==='
-        ))
+        s3 = report["gift_credit_integrity"]
+        self.stdout.write(self.style.MIGRATE_HEADING("\n=== Section 3: Gift Credit Integrity ==="))
         self.stdout.write(f'  Total gifts: {s3["total_gifts"]}')
         self.stdout.write(f'  Total credits: {s3["total_credits"]}')
         self.stdout.write(f'  Credits linked: {s3["linked_credits"]}')
@@ -429,65 +412,51 @@ class Command(BaseCommand):
         self.stdout.write(f'  Orphaned gifts (no credits): {s3["orphaned_count"]}')
         self.stdout.write(f'  Unlinked credit dollar value: ${s3["unlinked_dollars"]}')
 
-        if verbose and s3['orphaned_details']:
-            self.stdout.write('  Orphaned gift details:')
-            for gid, fn, ln, cents, gdate in s3['orphaned_details']:
+        if verbose and s3["orphaned_details"]:
+            self.stdout.write("  Orphaned gift details:")
+            for gid, fn, ln, cents, gdate in s3["orphaned_details"]:
                 dollars = Decimal(cents) / Decimal(100)
-                self.stdout.write(
-                    f'    - Gift #{gid}: {fn} {ln}, ${dollars:.2f} on {gdate}'
-                )
+                self.stdout.write(f"    - Gift #{gid}: {fn} {ln}, ${dollars:.2f} on {gdate}")
 
         # Section 4
-        s4 = report['recurring_gift_credit_integrity']
-        self.stdout.write(self.style.MIGRATE_HEADING(
-            '\n=== Section 4: Recurring Gift Credit Integrity ==='
-        ))
+        s4 = report["recurring_gift_credit_integrity"]
+        self.stdout.write(
+            self.style.MIGRATE_HEADING("\n=== Section 4: Recurring Gift Credit Integrity ===")
+        )
         self.stdout.write(f'  Active recurring gifts: {s4["total_active"]}')
         self.stdout.write(f'  Active recurring credits: {s4["total_credits"]}')
         self.stdout.write(f'  Credits linked: {s4["linked_credits"]}')
         self.stdout.write(f'  Credits unlinked: {s4["unlinked_credits"]}')
-        self.stdout.write(
-            f'  Orphaned active recurring gifts: {s4["orphaned_count"]}'
-        )
-        self.stdout.write(
-            f'  Unlinked credit dollar value: ${s4["unlinked_dollars"]}'
-        )
+        self.stdout.write(f'  Orphaned active recurring gifts: {s4["orphaned_count"]}')
+        self.stdout.write(f'  Unlinked credit dollar value: ${s4["unlinked_dollars"]}')
 
-        if verbose and s4['orphaned_details']:
-            self.stdout.write('  Orphaned recurring gift details:')
-            for rgid, fn, ln, cents, freq in s4['orphaned_details']:
+        if verbose and s4["orphaned_details"]:
+            self.stdout.write("  Orphaned recurring gift details:")
+            for rgid, fn, ln, cents, freq in s4["orphaned_details"]:
                 dollars = Decimal(cents) / Decimal(100)
-                self.stdout.write(
-                    f'    - RecurringGift #{rgid}: {fn} {ln}, ${dollars:.2f}/{freq}'
-                )
+                self.stdout.write(f"    - RecurringGift #{rgid}: {fn} {ln}, ${dollars:.2f}/{freq}")
 
         # Section 5
-        s5 = report['dashboard_impact']
-        self.stdout.write(self.style.MIGRATE_HEADING(
-            '\n=== Section 5: Dashboard Impact Estimate ==='
-        ))
+        s5 = report["dashboard_impact"]
         self.stdout.write(
-            f'  Missionaries: {len(s5["missionaries"])}'
+            self.style.MIGRATE_HEADING("\n=== Section 5: Dashboard Impact Estimate ===")
         )
-        if s5['flagged']:
-            self.stdout.write(self.style.WARNING(
-                f'  Flagged missionaries: {len(s5["flagged"])}'
-            ))
+        self.stdout.write(f'  Missionaries: {len(s5["missionaries"])}')
+        if s5["flagged"]:
+            self.stdout.write(self.style.WARNING(f'  Flagged missionaries: {len(s5["flagged"])}'))
             if verbose:
-                for f in s5['flagged']:
+                for f in s5["flagged"]:
                     self.stdout.write(
                         f'    - {f["user_name"]} ({f["user_email"]}): '
                         f'{", ".join(f["flag_reasons"])}'
                     )
         else:
-            self.stdout.write(self.style.SUCCESS(
-                '  No flagged missionaries.'
-            ))
+            self.stdout.write(self.style.SUCCESS("  No flagged missionaries."))
 
         if verbose:
-            self.stdout.write('  Per-missionary breakdown:')
-            for m in s5['missionaries']:
-                flag_marker = ' [FLAGGED]' if m['flagged'] else ''
+            self.stdout.write("  Per-missionary breakdown:")
+            for m in s5["missionaries"]:
+                flag_marker = " [FLAGGED]" if m["flagged"] else ""
                 self.stdout.write(
                     f'    - {m["user_name"]} ({m["user_email"]}): '
                     f'{m["contacts"]} contacts, '
@@ -497,9 +466,9 @@ class Command(BaseCommand):
                 )
 
         # Verdict
-        v = report['verdict']
-        self.stdout.write('')
-        if v['status'] == 'HEALTHY':
-            self.stdout.write(self.style.SUCCESS(v['message']))
+        v = report["verdict"]
+        self.stdout.write("")
+        if v["status"] == "HEALTHY":
+            self.stdout.write(self.style.SUCCESS(v["message"]))
         else:
-            self.stdout.write(self.style.ERROR(v['message']))
+            self.stdout.write(self.style.ERROR(v["message"]))

--- a/apps/imports/management/commands/audit_import_health.py
+++ b/apps/imports/management/commands/audit_import_health.py
@@ -334,11 +334,13 @@ class Command(BaseCommand):
                 flag_reasons.append("0 contacts — will see empty dashboard")
             if contacts_count == 0 and credit_count > 0:
                 flag_reasons.append(
-                    "0 contacts but has gift credits via solicitor — suggests contact ownership not reassigned"
+                    "0 contacts but has gift credits via solicitor — "
+                    "suggests contact ownership not reassigned"
                 )
             if gift_sum == 0 and credit_count > 0:
                 flag_reasons.append(
-                    "0 gifts (by ownership) but has gift credits via solicitor — suggests contact ownership not reassigned"
+                    "0 gifts (by ownership) but has gift credits via solicitor — "
+                    "suggests contact ownership not reassigned"
                 )
 
             if flag_reasons:

--- a/apps/imports/management/commands/import_spo_gifts.py
+++ b/apps/imports/management/commands/import_spo_gifts.py
@@ -17,56 +17,54 @@ MAX_UPLOAD_SIZE = 10 * 1024 * 1024
 
 
 class Command(BaseCommand):
-    help = 'Step 2: Import SPO gifts and attribute to missionaries'
+    help = "Step 2: Import SPO gifts and attribute to missionaries"
 
     def add_arguments(self, parser):
-        parser.add_argument('file', type=str, help='Path to CSV file')
+        parser.add_argument("file", type=str, help="Path to CSV file")
         parser.add_argument(
-            '--owner',
+            "--owner",
             type=str,
             required=True,
-            help='Email of the user who runs the import (used as uploaded_by)',
+            help="Email of the user who runs the import (used as uploaded_by)",
         )
         parser.add_argument(
-            '--force',
-            action='store_true',
-            help='Bypass SHA256 dedup (use after adding aliases to MissionaryAlias table)',
+            "--force",
+            action="store_true",
+            help="Bypass SHA256 dedup (use after adding aliases to MissionaryAlias table)",
         )
 
     def handle(self, *args, **options):
-        file_path = options['file']
-        owner_email = options['owner']
+        file_path = options["file"]
+        owner_email = options["owner"]
 
         # Look up owner user by email
         try:
             owner_user = User.objects.get(email=owner_email)
         except User.DoesNotExist:
-            raise CommandError(f'User not found: {owner_email}')
+            raise CommandError(f"User not found: {owner_email}")
 
         # Read file bytes
         try:
-            with open(file_path, 'rb') as f:
+            with open(file_path, "rb") as f:
                 file_bytes = f.read()
         except FileNotFoundError:
-            raise CommandError(f'File not found: {file_path}')
+            raise CommandError(f"File not found: {file_path}")
 
         # Check file size
         if len(file_bytes) > MAX_UPLOAD_SIZE:
-            raise CommandError(
-                f'File too large ({len(file_bytes):,} bytes). Maximum is 10 MB.'
-            )
+            raise CommandError(f"File too large ({len(file_bytes):,} bytes). Maximum is 10 MB.")
 
         # Extract filename from path
-        filename = file_path.rsplit('/', 1)[-1] if '/' in file_path else file_path
+        filename = file_path.rsplit("/", 1)[-1] if "/" in file_path else file_path
 
-        self.stdout.write(f'Processing {filename}...')
+        self.stdout.write(f"Processing {filename}...")
 
         # Call shared service
         batch = import_spo_gifts(
             file_bytes=file_bytes,
             filename=filename,
             uploaded_by=owner_user,
-            force=options['force'],
+            force=options["force"],
         )
 
         self._print_summary(batch, self.stdout)
@@ -75,65 +73,69 @@ class Command(BaseCommand):
         """Print formatted audit table for the SPO gift import result."""
         # Handle duplicate
         if batch.status == ImportBatchStatus.DUPLICATE:
-            stdout.write(self.style.WARNING(
-                f'File already imported (batch {batch.id}). Use --force to re-import.'
-            ))
+            stdout.write(
+                self.style.WARNING(
+                    f"File already imported (batch {batch.id}). Use --force to re-import."
+                )
+            )
             return
 
         # Handle failure
         if batch.status == ImportBatchStatus.FAILED:
-            errors = batch.summary.get('errors', []) or batch.summary.get('error_details', [])
-            stdout.write(self.style.ERROR(f'Import failed: {batch.filename}'))
+            errors = batch.summary.get("errors", []) or batch.summary.get("error_details", [])
+            stdout.write(self.style.ERROR(f"Import failed: {batch.filename}"))
             for err in errors[:10]:
                 stdout.write(self.style.ERROR(f'  Row {err["row"]}: {err["error"]}'))
             return
 
         # Success: aggregate counts
         summary = batch.summary
-        stdout.write(self.style.SUCCESS('\n=== SPO Gift Import Complete ===\n'))
-        stdout.write('Aggregate:')
+        stdout.write(self.style.SUCCESS("\n=== SPO Gift Import Complete ===\n"))
+        stdout.write("Aggregate:")
         stdout.write(f'  Gifts created:          {summary.get("created", batch.created_count)}')
         stdout.write(f'  Skipped:                {summary.get("skipped", batch.skipped_count)}')
         stdout.write(f'  Errors:                 {summary.get("errors", batch.error_count)}')
 
         # Contact not found
-        contact_not_found = summary.get('contact_not_found', [])
+        contact_not_found = summary.get("contact_not_found", [])
         if contact_not_found:
-            stdout.write(self.style.WARNING(
-                f'\n  Contacts not found ({len(contact_not_found)} constituent IDs):'
-            ))
+            stdout.write(
+                self.style.WARNING(
+                    f"\n  Contacts not found ({len(contact_not_found)} constituent IDs):"
+                )
+            )
             for cid in contact_not_found[:20]:
-                stdout.write(f'    - {cid}')
+                stdout.write(f"    - {cid}")
             if len(contact_not_found) > 20:
-                stdout.write(f'    ... and {len(contact_not_found) - 20} more')
+                stdout.write(f"    ... and {len(contact_not_found) - 20} more")
 
         # Unmatched/unresolved solicitor names
-        unmatched_unresolved = summary.get('unmatched_unresolved', [])
+        unmatched_unresolved = summary.get("unmatched_unresolved", [])
         if unmatched_unresolved:
-            stdout.write(self.style.WARNING(
-                f'\n  Unresolved solicitor names ({len(unmatched_unresolved)}):'
-            ))
+            stdout.write(
+                self.style.WARNING(f"\n  Unresolved solicitor names ({len(unmatched_unresolved)}):")
+            )
             seen = set()
             unique = [n for n in unmatched_unresolved if not (n in seen or seen.add(n))]
             for name in unique[:20]:
-                stdout.write(f'    - {name}')
+                stdout.write(f"    - {name}")
             if len(unique) > 20:
-                stdout.write(f'    ... and {len(unique) - 20} more')
+                stdout.write(f"    ... and {len(unique) - 20} more")
 
         # Per-missionary gift table (abbreviated)
-        per_missionary = summary.get('per_missionary', [])
+        per_missionary = summary.get("per_missionary", [])
         if per_missionary:
             # Aggregate per missionary
             agg: dict = {}
             for entry in per_missionary:
-                missionary = entry.get('missionary', 'Unknown')
-                agg.setdefault(missionary, {'count': 0, 'total_cents': 0})
-                agg[missionary]['count'] += 1
-                agg[missionary]['total_cents'] += entry.get('amount_cents', 0)
+                missionary = entry.get("missionary", "Unknown")
+                agg.setdefault(missionary, {"count": 0, "total_cents": 0})
+                agg[missionary]["count"] += 1
+                agg[missionary]["total_cents"] += entry.get("amount_cents", 0)
 
-            stdout.write('\nPer-Missionary Gift Summary:')
+            stdout.write("\nPer-Missionary Gift Summary:")
             stdout.write(f'  {"Missionary":<30} {"Gifts":>6}   Total')
-            stdout.write('  ' + '\u2500' * 50)
+            stdout.write("  " + "\u2500" * 50)
             for name, data in sorted(agg.items()):
-                total_dollars = data['total_cents'] / 100
+                total_dollars = data["total_cents"] / 100
                 stdout.write(f'  {name:<30} {data["count"]:>6}   ${total_dollars:,.2f}')

--- a/apps/imports/management/commands/import_spo_prayers.py
+++ b/apps/imports/management/commands/import_spo_prayers.py
@@ -17,56 +17,54 @@ MAX_UPLOAD_SIZE = 10 * 1024 * 1024
 
 
 class Command(BaseCommand):
-    help = 'Step 3: Extract prayer intentions from SPO gifts CSV (prayer-only rerun)'
+    help = "Step 3: Extract prayer intentions from SPO gifts CSV (prayer-only rerun)"
 
     def add_arguments(self, parser):
-        parser.add_argument('file', type=str, help='Path to CSV file')
+        parser.add_argument("file", type=str, help="Path to CSV file")
         parser.add_argument(
-            '--owner',
+            "--owner",
             type=str,
             required=True,
-            help='Email of the user who runs the import (used as uploaded_by)',
+            help="Email of the user who runs the import (used as uploaded_by)",
         )
         parser.add_argument(
-            '--force',
-            action='store_true',
-            help='Bypass SHA256 dedup (use after adding aliases to MissionaryAlias table)',
+            "--force",
+            action="store_true",
+            help="Bypass SHA256 dedup (use after adding aliases to MissionaryAlias table)",
         )
 
     def handle(self, *args, **options):
-        file_path = options['file']
-        owner_email = options['owner']
+        file_path = options["file"]
+        owner_email = options["owner"]
 
         # Look up owner user by email
         try:
             owner_user = User.objects.get(email=owner_email)
         except User.DoesNotExist:
-            raise CommandError(f'User not found: {owner_email}')
+            raise CommandError(f"User not found: {owner_email}")
 
         # Read file bytes
         try:
-            with open(file_path, 'rb') as f:
+            with open(file_path, "rb") as f:
                 file_bytes = f.read()
         except FileNotFoundError:
-            raise CommandError(f'File not found: {file_path}')
+            raise CommandError(f"File not found: {file_path}")
 
         # Check file size
         if len(file_bytes) > MAX_UPLOAD_SIZE:
-            raise CommandError(
-                f'File too large ({len(file_bytes):,} bytes). Maximum is 10 MB.'
-            )
+            raise CommandError(f"File too large ({len(file_bytes):,} bytes). Maximum is 10 MB.")
 
         # Extract filename from path
-        filename = file_path.rsplit('/', 1)[-1] if '/' in file_path else file_path
+        filename = file_path.rsplit("/", 1)[-1] if "/" in file_path else file_path
 
-        self.stdout.write(f'Processing {filename}...')
+        self.stdout.write(f"Processing {filename}...")
 
         # Call shared service
         batch = import_spo_prayers(
             file_bytes=file_bytes,
             filename=filename,
             uploaded_by=owner_user,
-            force=options['force'],
+            force=options["force"],
         )
 
         self._print_summary(batch, self.stdout)
@@ -75,26 +73,28 @@ class Command(BaseCommand):
         """Print formatted output for the prayer extraction result."""
         # Handle duplicate
         if batch.status == ImportBatchStatus.DUPLICATE:
-            stdout.write(self.style.WARNING(
-                f'File already imported (batch {batch.id}). Use --force to re-import.'
-            ))
+            stdout.write(
+                self.style.WARNING(
+                    f"File already imported (batch {batch.id}). Use --force to re-import."
+                )
+            )
             return
 
         # Handle failure
         if batch.status == ImportBatchStatus.FAILED:
-            errors = batch.summary.get('errors', [])
-            stdout.write(self.style.ERROR(f'Import failed: {batch.filename}'))
+            errors = batch.summary.get("errors", [])
+            stdout.write(self.style.ERROR(f"Import failed: {batch.filename}"))
             for err in errors[:10]:
                 stdout.write(self.style.ERROR(f'  Row {err["row"]}: {err["error"]}'))
             return
 
         # Success: simple aggregate output (prayer-only pass)
         summary = batch.summary
-        prayers_created = summary.get('prayers_created', batch.created_count)
-        skipped = summary.get('skipped', batch.skipped_count)
+        prayers_created = summary.get("prayers_created", batch.created_count)
+        skipped = summary.get("skipped", batch.skipped_count)
 
-        stdout.write(self.style.SUCCESS('\n=== SPO Prayer Extraction Complete ===\n'))
-        stdout.write('Aggregate:')
-        stdout.write(f'  Prayer intentions created: {prayers_created}')
-        stdout.write(f'  Rows skipped:              {skipped}')
-        stdout.write(f'  (Rows without prayer description or unresolvable contacts are skipped)')
+        stdout.write(self.style.SUCCESS("\n=== SPO Prayer Extraction Complete ===\n"))
+        stdout.write("Aggregate:")
+        stdout.write(f"  Prayer intentions created: {prayers_created}")
+        stdout.write(f"  Rows skipped:              {skipped}")
+        stdout.write(f"  (Rows without prayer description or unresolvable contacts are skipped)")

--- a/apps/imports/management/commands/import_spo_prayers.py
+++ b/apps/imports/management/commands/import_spo_prayers.py
@@ -97,4 +97,4 @@ class Command(BaseCommand):
         stdout.write("Aggregate:")
         stdout.write(f"  Prayer intentions created: {prayers_created}")
         stdout.write(f"  Rows skipped:              {skipped}")
-        stdout.write(f"  (Rows without prayer description or unresolvable contacts are skipped)")
+        stdout.write("  (Rows without prayer description or unresolvable contacts are skipped)")

--- a/apps/imports/management/commands/reconcile_missionaries.py
+++ b/apps/imports/management/commands/reconcile_missionaries.py
@@ -17,56 +17,54 @@ MAX_UPLOAD_SIZE = 10 * 1024 * 1024
 
 
 class Command(BaseCommand):
-    help = 'Step 1: Reconcile SPO missionary accounts from Solicitors CSV'
+    help = "Step 1: Reconcile SPO missionary accounts from Solicitors CSV"
 
     def add_arguments(self, parser):
-        parser.add_argument('file', type=str, help='Path to CSV file')
+        parser.add_argument("file", type=str, help="Path to CSV file")
         parser.add_argument(
-            '--owner',
+            "--owner",
             type=str,
             required=True,
-            help='Email of the user who runs the import (used as uploaded_by)',
+            help="Email of the user who runs the import (used as uploaded_by)",
         )
         parser.add_argument(
-            '--force',
-            action='store_true',
-            help='Bypass SHA256 dedup (use after adding aliases to MissionaryAlias table)',
+            "--force",
+            action="store_true",
+            help="Bypass SHA256 dedup (use after adding aliases to MissionaryAlias table)",
         )
 
     def handle(self, *args, **options):
-        file_path = options['file']
-        owner_email = options['owner']
+        file_path = options["file"]
+        owner_email = options["owner"]
 
         # Look up owner user by email
         try:
             owner_user = User.objects.get(email=owner_email)
         except User.DoesNotExist:
-            raise CommandError(f'User not found: {owner_email}')
+            raise CommandError(f"User not found: {owner_email}")
 
         # Read file bytes
         try:
-            with open(file_path, 'rb') as f:
+            with open(file_path, "rb") as f:
                 file_bytes = f.read()
         except FileNotFoundError:
-            raise CommandError(f'File not found: {file_path}')
+            raise CommandError(f"File not found: {file_path}")
 
         # Check file size
         if len(file_bytes) > MAX_UPLOAD_SIZE:
-            raise CommandError(
-                f'File too large ({len(file_bytes):,} bytes). Maximum is 10 MB.'
-            )
+            raise CommandError(f"File too large ({len(file_bytes):,} bytes). Maximum is 10 MB.")
 
         # Extract filename from path
-        filename = file_path.rsplit('/', 1)[-1] if '/' in file_path else file_path
+        filename = file_path.rsplit("/", 1)[-1] if "/" in file_path else file_path
 
-        self.stdout.write(f'Processing {filename}...')
+        self.stdout.write(f"Processing {filename}...")
 
         # Call shared service
         batch = reconcile_missionaries(
             file_bytes=file_bytes,
             filename=filename,
             uploaded_by=owner_user,
-            force=options['force'],
+            force=options["force"],
         )
 
         self._print_summary(batch, self.stdout)
@@ -75,23 +73,25 @@ class Command(BaseCommand):
         """Print formatted audit table for the missionary reconciliation result."""
         # Handle duplicate
         if batch.status == ImportBatchStatus.DUPLICATE:
-            stdout.write(self.style.WARNING(
-                f'File already imported (batch {batch.id}). Use --force to re-import.'
-            ))
+            stdout.write(
+                self.style.WARNING(
+                    f"File already imported (batch {batch.id}). Use --force to re-import."
+                )
+            )
             return
 
         # Handle failure
         if batch.status == ImportBatchStatus.FAILED:
-            errors = batch.summary.get('errors', [])
-            stdout.write(self.style.ERROR(f'Import failed: {batch.filename}'))
+            errors = batch.summary.get("errors", [])
+            stdout.write(self.style.ERROR(f"Import failed: {batch.filename}"))
             for err in errors[:10]:
                 stdout.write(self.style.ERROR(f'  Row {err["row"]}: {err["error"]}'))
             return
 
         # Success: print aggregate section
         summary = batch.summary
-        stdout.write(self.style.SUCCESS('\n=== SPO Missionary Reconciliation Complete ===\n'))
-        stdout.write('Aggregate:')
+        stdout.write(self.style.SUCCESS("\n=== SPO Missionary Reconciliation Complete ===\n"))
+        stdout.write("Aggregate:")
         stdout.write(f'  Missionaries in CSV:    {summary.get("missionaries_expected", 0)}')
         stdout.write(f'  Matched (exact):         {summary.get("matched_exact", 0)}')
         stdout.write(f'  Matched (normalized):    {summary.get("matched_normalized", 0)}')
@@ -100,31 +100,35 @@ class Command(BaseCommand):
         stdout.write(f'  Unresolved:              {summary.get("unresolved", 0)}')
 
         # Per-missionary table
-        per_missionary = summary.get('per_missionary', [])
+        per_missionary = summary.get("per_missionary", [])
         if per_missionary:
-            stdout.write('\nPer-Missionary:')
+            stdout.write("\nPer-Missionary:")
             stdout.write(f'  {"Name":<22} {"Match Type":<12} {"Gifts":>6}   Status')
-            stdout.write('  ' + '\u2500' * 50)
+            stdout.write("  " + "\u2500" * 50)
             for entry in per_missionary:
-                name = entry.get('name', '')
-                match_type = entry.get('match_type', '')
-                gifts_imported = entry.get('gifts_imported', 0)
+                name = entry.get("name", "")
+                match_type = entry.get("match_type", "")
+                gifts_imported = entry.get("gifts_imported", 0)
 
                 if gifts_imported == 0:
-                    status_str = self.style.WARNING('ZERO DONATIONS \u2014 verify import ran correctly')
+                    status_str = self.style.WARNING(
+                        "ZERO DONATIONS \u2014 verify import ran correctly"
+                    )
                 else:
                     status_str = match_type
 
-                stdout.write(f'  {name:<22} {match_type:<12} {gifts_imported:>6}   {status_str}')
+                stdout.write(f"  {name:<22} {match_type:<12} {gifts_imported:>6}   {status_str}")
 
         # Unresolved names
-        unresolved_names = summary.get('unresolved_names', [])
+        unresolved_names = summary.get("unresolved_names", [])
         if unresolved_names:
-            stdout.write(f'\nUnresolved names ({len(unresolved_names)}):')
+            stdout.write(f"\nUnresolved names ({len(unresolved_names)}):")
             for name in unresolved_names:
-                stdout.write(f'  - {name}')
-            stdout.write(self.style.WARNING(
-                '\nRerun with --force after adding aliases to MissionaryAlias table.'
-            ))
+                stdout.write(f"  - {name}")
+            stdout.write(
+                self.style.WARNING(
+                    "\nRerun with --force after adding aliases to MissionaryAlias table."
+                )
+            )
 
-        stdout.write(f'\nUnresolved names saved to ImportBatch #{batch.id} summary.')
+        stdout.write(f"\nUnresolved names saved to ImportBatch #{batch.id} summary.")

--- a/apps/imports/models.py
+++ b/apps/imports/models.py
@@ -11,20 +11,22 @@ from apps.core.models import TimeStampedModel
 
 class ImportType(models.TextChoices):
     """Types of CSV imports supported."""
-    FUNDS = 'funds', 'Funds'
-    ENTITIES = 'entities', 'Entities'
-    TRANSACTIONS = 'transactions', 'Transactions'
-    PLEDGES = 'pledges', 'Pledges'
+
+    FUNDS = "funds", "Funds"
+    ENTITIES = "entities", "Entities"
+    TRANSACTIONS = "transactions", "Transactions"
+    PLEDGES = "pledges", "Pledges"
 
 
 class ImportStatus(models.TextChoices):
     """Import processing status."""
-    PENDING = 'pending', 'Pending'
-    VALIDATING = 'validating', 'Validating'
-    VALIDATED = 'validated', 'Validated'
-    IMPORTING = 'importing', 'Importing'
-    COMPLETED = 'completed', 'Completed'
-    FAILED = 'failed', 'Failed'
+
+    PENDING = "pending", "Pending"
+    VALIDATING = "validating", "Validating"
+    VALIDATED = "validated", "Validated"
+    IMPORTING = "importing", "Importing"
+    COMPLETED = "completed", "Completed"
+    FAILED = "failed", "Failed"
 
 
 class Fund(TimeStampedModel):
@@ -34,41 +36,36 @@ class Fund(TimeStampedModel):
     Funds are imported before transactions and referenced via external_id.
     Used for categorizing donations by account/campaign.
     """
+
     external_id = models.CharField(
-        'external ID',
+        "external ID",
         max_length=100,
         unique=True,
         db_index=True,
-        help_text='Fund ID from SPO system'
+        help_text="Fund ID from SPO system",
     )
-    name = models.CharField(
-        'fund name',
-        max_length=255
-    )
+    name = models.CharField("fund name", max_length=255)
     status = models.CharField(
-        'status',
-        max_length=20,
-        default='active',
-        help_text='active, inactive, or closed'
+        "status", max_length=20, default="active", help_text="active, inactive, or closed"
     )
     owner = models.ForeignKey(
-        'users.User',
+        "users.User",
         on_delete=models.PROTECT,
         null=True,
         blank=True,
-        related_name='funds',
-        verbose_name='owner',
-        help_text='Owner if fund is user-specific, null for org-wide funds'
+        related_name="funds",
+        verbose_name="owner",
+        help_text="Owner if fund is user-specific, null for org-wide funds",
     )
 
     class Meta:
-        db_table = 'funds'
-        verbose_name = 'fund'
-        verbose_name_plural = 'funds'
-        ordering = ['name']
+        db_table = "funds"
+        verbose_name = "fund"
+        verbose_name_plural = "funds"
+        ordering = ["name"]
 
     def __str__(self):
-        return f'{self.name} ({self.external_id})'
+        return f"{self.name} ({self.external_id})"
 
 
 class ImportRun(TimeStampedModel):
@@ -79,75 +76,50 @@ class ImportRun(TimeStampedModel):
     Each import run has a type (funds, entities, etc.) and progresses
     through status states from pending to completed/failed.
     """
-    type = models.CharField(
-        'import type',
-        max_length=20,
-        choices=ImportType.choices,
-        db_index=True
-    )
+
+    type = models.CharField("import type", max_length=20, choices=ImportType.choices, db_index=True)
     status = models.CharField(
-        'status',
-        max_length=20,
-        choices=ImportStatus.choices,
-        default=ImportStatus.PENDING
+        "status", max_length=20, choices=ImportStatus.choices, default=ImportStatus.PENDING
     )
 
     # File metadata
-    filename = models.CharField(
-        'filename',
-        max_length=255
-    )
-    total_rows = models.IntegerField(
-        'total rows',
-        default=0
-    )
+    filename = models.CharField("filename", max_length=255)
+    total_rows = models.IntegerField("total rows", default=0)
 
     # Results
-    created_count = models.IntegerField(
-        'created count',
-        default=0
-    )
-    updated_count = models.IntegerField(
-        'updated count',
-        default=0
-    )
-    skipped_count = models.IntegerField(
-        'skipped count',
-        default=0
-    )
-    error_count = models.IntegerField(
-        'error count',
-        default=0
-    )
+    created_count = models.IntegerField("created count", default=0)
+    updated_count = models.IntegerField("updated count", default=0)
+    skipped_count = models.IntegerField("skipped count", default=0)
+    error_count = models.IntegerField("error count", default=0)
 
     # User tracking
     uploaded_by = models.ForeignKey(
-        'users.User',
+        "users.User",
         on_delete=models.PROTECT,
-        related_name='import_runs',
-        verbose_name='uploaded by'
+        related_name="import_runs",
+        verbose_name="uploaded by",
     )
 
     # Error summary (first 20 errors for quick preview)
     error_summary = models.JSONField(
-        'error summary',
+        "error summary",
         default=dict,
         blank=True,
-        help_text='JSON dict with sample errors for preview'
+        help_text="JSON dict with sample errors for preview",
     )
 
     class Meta:
-        db_table = 'import_runs'
-        verbose_name = 'import run'
-        verbose_name_plural = 'import runs'
-        ordering = ['-created_at']
+        db_table = "import_runs"
+        verbose_name = "import run"
+        verbose_name_plural = "import runs"
+        ordering = ["-created_at"]
         indexes = [
-            models.Index(fields=['uploaded_by', '-created_at']),
-            models.Index(fields=['type', 'status']),
+            models.Index(fields=["uploaded_by", "-created_at"]),
+            models.Index(fields=["type", "status"]),
         ]
 
     def __str__(self):
-        return f'{self.get_type_display()} import by {self.uploaded_by} on {self.created_at.date()}'
+        return f"{self.get_type_display()} import by {self.uploaded_by} on {self.created_at.date()}"
 
 
 class ImportRowError(TimeStampedModel):
@@ -157,58 +129,54 @@ class ImportRowError(TimeStampedModel):
     Stores validation errors with line numbers for error reports.
     Enables "Download Errors CSV" feature for users to fix and re-upload.
     """
+
     import_run = models.ForeignKey(
-        ImportRun,
-        on_delete=models.CASCADE,
-        related_name='row_errors',
-        verbose_name='import run'
+        ImportRun, on_delete=models.CASCADE, related_name="row_errors", verbose_name="import run"
     )
-    row_number = models.IntegerField(
-        'row number'
-    )
+    row_number = models.IntegerField("row number")
     error_messages = models.JSONField(
-        'error messages',
-        help_text='List of error strings for this row'
+        "error messages", help_text="List of error strings for this row"
     )
     row_data = models.JSONField(
-        'row data',
-        help_text='Original CSV row as dict for error CSV download'
+        "row data", help_text="Original CSV row as dict for error CSV download"
     )
 
     class Meta:
-        db_table = 'import_row_errors'
-        verbose_name = 'import row error'
-        verbose_name_plural = 'import row errors'
-        ordering = ['row_number']
+        db_table = "import_row_errors"
+        verbose_name = "import row error"
+        verbose_name_plural = "import row errors"
+        ordering = ["row_number"]
         indexes = [
-            models.Index(fields=['import_run', 'row_number']),
+            models.Index(fields=["import_run", "row_number"]),
         ]
 
     def __str__(self):
-        return f'Row {self.row_number}: {len(self.error_messages)} errors'
+        return f"Row {self.row_number}: {len(self.error_messages)} errors"
 
 
 class ImportBatchType(models.TextChoices):
     """Types of import batches for RE and generic imports."""
-    RE_CONSTITUENT = 're_constituent', 'RE Constituent'
-    RE_SOLICITOR = 're_solicitor', 'RE Solicitor'
-    RE_GIFT = 're_gift', 'RE Gift'
-    RE_RECURRING_GIFT = 're_recurring_gift', 'RE Recurring Gift'
-    GENERIC_CONTACTS = 'generic_contacts', 'Generic Contacts'
-    GENERIC_DONATIONS = 'generic_donations', 'Generic Donations'
-    SMARTSHEET_MPD = 'smartsheet_mpd', 'Smartsheet MPD'
-    SPO_MISSIONARY = 'spo_missionary', 'SPO Missionary Reconciliation'
-    SPO_GIFT = 'spo_gift', 'SPO Gift Import'
-    SPO_PRAYER = 'spo_prayer', 'SPO Prayer Import'
+
+    RE_CONSTITUENT = "re_constituent", "RE Constituent"
+    RE_SOLICITOR = "re_solicitor", "RE Solicitor"
+    RE_GIFT = "re_gift", "RE Gift"
+    RE_RECURRING_GIFT = "re_recurring_gift", "RE Recurring Gift"
+    GENERIC_CONTACTS = "generic_contacts", "Generic Contacts"
+    GENERIC_DONATIONS = "generic_donations", "Generic Donations"
+    SMARTSHEET_MPD = "smartsheet_mpd", "Smartsheet MPD"
+    SPO_MISSIONARY = "spo_missionary", "SPO Missionary Reconciliation"
+    SPO_GIFT = "spo_gift", "SPO Gift Import"
+    SPO_PRAYER = "spo_prayer", "SPO Prayer Import"
 
 
 class ImportBatchStatus(models.TextChoices):
     """Processing status of an import batch."""
-    PENDING = 'pending', 'Pending'
-    PROCESSING = 'processing', 'Processing'
-    COMPLETED = 'completed', 'Completed'
-    FAILED = 'failed', 'Failed'
-    DUPLICATE = 'duplicate', 'Duplicate (already processed)'
+
+    PENDING = "pending", "Pending"
+    PROCESSING = "processing", "Processing"
+    COMPLETED = "completed", "Completed"
+    FAILED = "failed", "Failed"
+    DUPLICATE = "duplicate", "Duplicate (already processed)"
 
 
 class ImportBatch(TimeStampedModel):
@@ -219,75 +187,70 @@ class ImportBatch(TimeStampedModel):
     row counts, and a SHA256 hash unique per import type to prevent
     duplicate file processing.
     """
+
     import_type = models.CharField(
-        'import type',
-        max_length=30,
-        choices=ImportBatchType.choices,
-        db_index=True
+        "import type", max_length=30, choices=ImportBatchType.choices, db_index=True
     )
     status = models.CharField(
-        'status',
+        "status",
         max_length=20,
         choices=ImportBatchStatus.choices,
-        default=ImportBatchStatus.PENDING
+        default=ImportBatchStatus.PENDING,
     )
-    filename = models.CharField('filename', max_length=255)
+    filename = models.CharField("filename", max_length=255)
     sha256_hash = models.CharField(
-        'SHA256 hash',
+        "SHA256 hash",
         max_length=64,
         db_index=True,
-        help_text='SHA256 hex digest for duplicate detection'
+        help_text="SHA256 hex digest for duplicate detection",
     )
 
     # Row counts
-    total_rows = models.PositiveIntegerField('total rows', default=0)
-    created_count = models.PositiveIntegerField('created count', default=0)
-    updated_count = models.PositiveIntegerField('updated count', default=0)
-    skipped_count = models.PositiveIntegerField('skipped count', default=0)
-    error_count = models.PositiveIntegerField('error count', default=0)
+    total_rows = models.PositiveIntegerField("total rows", default=0)
+    created_count = models.PositiveIntegerField("created count", default=0)
+    updated_count = models.PositiveIntegerField("updated count", default=0)
+    skipped_count = models.PositiveIntegerField("skipped count", default=0)
+    error_count = models.PositiveIntegerField("error count", default=0)
 
     # Type-specific metadata
     summary = models.JSONField(
-        'summary',
-        default=dict,
-        blank=True,
-        help_text='Type-specific import metadata and results'
+        "summary", default=dict, blank=True, help_text="Type-specific import metadata and results"
     )
 
     # User tracking
     uploaded_by = models.ForeignKey(
-        'users.User',
+        "users.User",
         on_delete=models.PROTECT,
-        related_name='import_batches',
-        verbose_name='uploaded by'
+        related_name="import_batches",
+        verbose_name="uploaded by",
     )
 
     class Meta:
-        db_table = 'import_batches'
-        verbose_name = 'import batch'
-        verbose_name_plural = 'import batches'
-        ordering = ['-created_at']
+        db_table = "import_batches"
+        verbose_name = "import batch"
+        verbose_name_plural = "import batches"
+        ordering = ["-created_at"]
         indexes = [
-            models.Index(fields=['uploaded_by', '-created_at']),
-            models.Index(fields=['import_type', 'status']),
+            models.Index(fields=["uploaded_by", "-created_at"]),
+            models.Index(fields=["import_type", "status"]),
         ]
         constraints = [
             models.UniqueConstraint(
-                fields=['import_type', 'sha256_hash'],
-                name='unique_import_batch_hash_per_type'
+                fields=["import_type", "sha256_hash"], name="unique_import_batch_hash_per_type"
             )
         ]
 
     def __str__(self):
-        return f'{self.get_import_type_display()} by {self.uploaded_by} ({self.status})'
+        return f"{self.get_import_type_display()} by {self.uploaded_by} ({self.status})"
 
 
 class MPDUpload(TimeStampedModel):
     """Audit trail for each Smartsheet MPD report upload."""
+
     uploaded_by = models.ForeignKey(
-        'users.User',
+        "users.User",
         on_delete=models.PROTECT,
-        related_name='mpd_uploads',
+        related_name="mpd_uploads",
     )
     filename = models.CharField(max_length=255)
     file_format = models.CharField(max_length=10)  # 'csv' or 'xlsx'
@@ -304,50 +267,69 @@ class MPDUpload(TimeStampedModel):
     status = models.CharField(
         max_length=20,
         choices=[
-            ('processing', 'Processing'),
-            ('completed', 'Completed'),
-            ('failed', 'Failed'),
+            ("processing", "Processing"),
+            ("completed", "Completed"),
+            ("failed", "Failed"),
         ],
-        default='processing',
+        default="processing",
     )
-    error_message = models.TextField(blank=True, default='')
+    error_message = models.TextField(blank=True, default="")
 
     class Meta:
-        db_table = 'mpd_uploads'
-        ordering = ['-created_at']
+        db_table = "mpd_uploads"
+        ordering = ["-created_at"]
 
     def __str__(self):
-        return f'MPD Upload by {self.uploaded_by} on {self.created_at.date()}'
+        return f"MPD Upload by {self.uploaded_by} on {self.created_at.date()}"
 
 
 class MPDSnapshot(TimeStampedModel):
     """Monthly MPD financial snapshot for a missionary (User)."""
+
     user = models.ForeignKey(
-        'users.User',
+        "users.User",
         on_delete=models.CASCADE,
-        related_name='mpd_snapshots',
+        related_name="mpd_snapshots",
     )
     upload = models.ForeignKey(
         MPDUpload,
         on_delete=models.CASCADE,
-        related_name='snapshots',
+        related_name="snapshots",
     )
 
     # Financial fields (all nullable for partial data)
-    active_recurring_gifts = models.DecimalField(max_digits=12, decimal_places=2, null=True, blank=True)
+    active_recurring_gifts = models.DecimalField(
+        max_digits=12, decimal_places=2, null=True, blank=True
+    )
     annual_gifts = models.DecimalField(max_digits=12, decimal_places=2, null=True, blank=True)
     monthly_average = models.DecimalField(max_digits=12, decimal_places=2, null=True, blank=True)
-    annual_mpd_estimate = models.DecimalField(max_digits=12, decimal_places=2, null=True, blank=True)
+    annual_mpd_estimate = models.DecimalField(
+        max_digits=12, decimal_places=2, null=True, blank=True
+    )
     mpd_standard = models.DecimalField(max_digits=12, decimal_places=2, null=True, blank=True)
-    amount_below_mpd_standard = models.DecimalField(max_digits=12, decimal_places=2, null=True, blank=True)
+    amount_below_mpd_standard = models.DecimalField(
+        max_digits=12, decimal_places=2, null=True, blank=True
+    )
     mpd_maximum = models.DecimalField(max_digits=12, decimal_places=2, null=True, blank=True)
-    amount_above_below_maximum = models.DecimalField(max_digits=12, decimal_places=2, null=True, blank=True)
-    latest_roll_forward_balance = models.DecimalField(max_digits=12, decimal_places=2, null=True, blank=True)
+    amount_above_below_maximum = models.DecimalField(
+        max_digits=12, decimal_places=2, null=True, blank=True
+    )
+    latest_roll_forward_balance = models.DecimalField(
+        max_digits=12, decimal_places=2, null=True, blank=True
+    )
     current_mpd_cap = models.DecimalField(max_digits=12, decimal_places=2, null=True, blank=True)
-    proj_monthly_deduction_rfb = models.DecimalField(max_digits=12, decimal_places=2, null=True, blank=True)
-    pay_forecast_12_months = models.DecimalField(max_digits=12, decimal_places=2, null=True, blank=True)
-    pay_forecast_over_fy = models.DecimalField(max_digits=12, decimal_places=2, null=True, blank=True)
-    total_one_time_gifts_april = models.DecimalField(max_digits=12, decimal_places=2, null=True, blank=True)
+    proj_monthly_deduction_rfb = models.DecimalField(
+        max_digits=12, decimal_places=2, null=True, blank=True
+    )
+    pay_forecast_12_months = models.DecimalField(
+        max_digits=12, decimal_places=2, null=True, blank=True
+    )
+    pay_forecast_over_fy = models.DecimalField(
+        max_digits=12, decimal_places=2, null=True, blank=True
+    )
+    total_one_time_gifts_april = models.DecimalField(
+        max_digits=12, decimal_places=2, null=True, blank=True
+    )
 
     # Percentage field (stored as integer: 104 for "104%", -16 for "-16%")
     pct_standard_to_max = models.IntegerField(null=True, blank=True)
@@ -359,23 +341,22 @@ class MPDSnapshot(TimeStampedModel):
     match_met_rest_fy = models.BooleanField(null=True)
 
     # Special field: can be numeric string or "infinite"
-    months_remaining_rf = models.CharField(max_length=20, blank=True, default='')
+    months_remaining_rf = models.CharField(max_length=20, blank=True, default="")
 
     class Meta:
-        db_table = 'mpd_snapshots'
-        ordering = ['-upload__created_at']
+        db_table = "mpd_snapshots"
+        ordering = ["-upload__created_at"]
         constraints = [
             models.UniqueConstraint(
-                fields=['user', 'upload'],
-                name='unique_snapshot_per_user_per_upload'
+                fields=["user", "upload"], name="unique_snapshot_per_user_per_upload"
             ),
         ]
         indexes = [
-            models.Index(fields=['user', '-created_at']),
+            models.Index(fields=["user", "-created_at"]),
         ]
 
     def __str__(self):
-        return f'MPD Snapshot for {self.user} ({self.upload.created_at.date()})'
+        return f"MPD Snapshot for {self.user} ({self.upload.created_at.date()})"
 
 
 class MissionaryAlias(TimeStampedModel):
@@ -391,30 +372,28 @@ class MissionaryAlias(TimeStampedModel):
     distinct from "never seen before". This prevents repeated auto-create attempts
     for known-unresolvable names.
     """
+
     source_name = models.CharField(
-        'source name',
+        "source name",
         max_length=255,
         unique=True,
         db_index=True,
-        help_text='Name as it appears in SPO CSV export'
+        help_text="Name as it appears in SPO CSV export",
     )
     user = models.ForeignKey(
-        'users.User',
+        "users.User",
         on_delete=models.CASCADE,
-        related_name='name_aliases',
+        related_name="name_aliases",
         null=True,
         blank=True,
-        help_text='Resolved missionary. Null = unresolved.'
+        help_text="Resolved missionary. Null = unresolved.",
     )
-    notes = models.TextField(
-        blank=True,
-        help_text='Optional admin notes'
-    )
+    notes = models.TextField(blank=True, help_text="Optional admin notes")
 
     class Meta:
-        db_table = 'missionary_aliases'
-        verbose_name = 'missionary alias'
-        verbose_name_plural = 'missionary aliases'
+        db_table = "missionary_aliases"
+        verbose_name = "missionary alias"
+        verbose_name_plural = "missionary aliases"
 
     def __str__(self):
-        return f'{self.source_name} -> {self.user}'
+        return f"{self.source_name} -> {self.user}"

--- a/apps/imports/mpd_services.py
+++ b/apps/imports/mpd_services.py
@@ -20,84 +20,85 @@ logger = logging.getLogger(__name__)
 # Fields prefixed with _ are matching keys, not stored on MPDSnapshot.
 # ---------------------------------------------------------------------------
 SMARTSHEET_COLUMN_MAP = {
-    'full name': None,                  # Skip - derived from First + Last
-    'first name': '_first_name',        # matching key, not stored on snapshot
-    'last name': '_last_name',          # matching key, not stored on snapshot
-    'active recurring gifts': 'active_recurring_gifts',
-    'annual gifts': 'annual_gifts',
-    'monthly average': 'monthly_average',
-    'annual mpd estimate': 'annual_mpd_estimate',
-    'mpd standard': 'mpd_standard',
-    '$ amount below mpd standard': 'amount_below_mpd_standard',
-    '% standard to max': 'pct_standard_to_max',
-    'met mpd standard': 'met_mpd_standard',
-    'mpd maximum': 'mpd_maximum',
-    'met maximum': 'met_maximum',
-    'amount above/below maximum': 'amount_above_below_maximum',
-    'match met': 'match_met',
-    'match met for rest of fiscal year (based on rfb)': 'match_met_rest_fy',
-    'latest roll forward balance': 'latest_roll_forward_balance',
-    'current mpd cap': 'current_mpd_cap',
-    'months remaining in rf': 'months_remaining_rf',
-    'proj. monthly deduction from rfb (cap - rec.gifts)': 'proj_monthly_deduction_rfb',
-    'pay forecast over 12 months': 'pay_forecast_12_months',
-    'pay forecast over fiscal year': 'pay_forecast_over_fy',
-    'total one-time gifts - april': 'total_one_time_gifts_april',
+    "full name": None,  # Skip - derived from First + Last
+    "first name": "_first_name",  # matching key, not stored on snapshot
+    "last name": "_last_name",  # matching key, not stored on snapshot
+    "active recurring gifts": "active_recurring_gifts",
+    "annual gifts": "annual_gifts",
+    "monthly average": "monthly_average",
+    "annual mpd estimate": "annual_mpd_estimate",
+    "mpd standard": "mpd_standard",
+    "$ amount below mpd standard": "amount_below_mpd_standard",
+    "% standard to max": "pct_standard_to_max",
+    "met mpd standard": "met_mpd_standard",
+    "mpd maximum": "mpd_maximum",
+    "met maximum": "met_maximum",
+    "amount above/below maximum": "amount_above_below_maximum",
+    "match met": "match_met",
+    "match met for rest of fiscal year (based on rfb)": "match_met_rest_fy",
+    "latest roll forward balance": "latest_roll_forward_balance",
+    "current mpd cap": "current_mpd_cap",
+    "months remaining in rf": "months_remaining_rf",
+    "proj. monthly deduction from rfb (cap - rec.gifts)": "proj_monthly_deduction_rfb",
+    "pay forecast over 12 months": "pay_forecast_12_months",
+    "pay forecast over fiscal year": "pay_forecast_over_fy",
+    "total one-time gifts - april": "total_one_time_gifts_april",
 }
 
 # Columns to skip entirely (coaching-related, not stored)
 SKIP_COLUMNS = {
-    'will be a coach in 2022 mpd season?',
-    'do you understand the coaching contract?',
-    'have you made these decisions w/ your supervisor?',
+    "will be a coach in 2022 mpd season?",
+    "do you understand the coaching contract?",
+    "have you made these decisions w/ your supervisor?",
 }
 
 # Field classification for type-specific parsing
 CURRENCY_FIELDS = {
-    'active_recurring_gifts',
-    'annual_gifts',
-    'monthly_average',
-    'annual_mpd_estimate',
-    'mpd_standard',
-    'amount_below_mpd_standard',
-    'mpd_maximum',
-    'amount_above_below_maximum',
-    'latest_roll_forward_balance',
-    'current_mpd_cap',
-    'proj_monthly_deduction_rfb',
-    'pay_forecast_12_months',
-    'pay_forecast_over_fy',
-    'total_one_time_gifts_april',
+    "active_recurring_gifts",
+    "annual_gifts",
+    "monthly_average",
+    "annual_mpd_estimate",
+    "mpd_standard",
+    "amount_below_mpd_standard",
+    "mpd_maximum",
+    "amount_above_below_maximum",
+    "latest_roll_forward_balance",
+    "current_mpd_cap",
+    "proj_monthly_deduction_rfb",
+    "pay_forecast_12_months",
+    "pay_forecast_over_fy",
+    "total_one_time_gifts_april",
 }
 
 BOOLEAN_FIELDS = {
-    'met_mpd_standard',
-    'met_maximum',
-    'match_met',
-    'match_met_rest_fy',
+    "met_mpd_standard",
+    "met_maximum",
+    "match_met",
+    "match_met_rest_fy",
 }
 
-PERCENTAGE_FIELDS = {'pct_standard_to_max'}
+PERCENTAGE_FIELDS = {"pct_standard_to_max"}
 
-MONTHS_REMAINING_FIELD = 'months_remaining_rf'
+MONTHS_REMAINING_FIELD = "months_remaining_rf"
 
 # Formula injection characters to strip from start of cell values.
 # Note: '-' is intentionally NOT stripped (negative currency like -$468.33).
-FORMULA_INJECTION_CHARS = {'=', '+', '@', '\t', '\r'}
+FORMULA_INJECTION_CHARS = {"=", "+", "@", "\t", "\r"}
 
 
 # ---------------------------------------------------------------------------
 # Parsing helpers
 # ---------------------------------------------------------------------------
 
+
 def detect_file_format(file_bytes: bytes) -> str:
     """Detect whether file is XLSX or CSV from magic bytes.
 
     XLSX/ZIP files start with PK\\x03\\x04. Everything else treated as CSV.
     """
-    if file_bytes[:4] == b'PK\x03\x04':
-        return 'xlsx'
-    return 'csv'
+    if file_bytes[:4] == b"PK\x03\x04":
+        return "xlsx"
+    return "csv"
 
 
 def sanitize_cell_value(value):
@@ -136,20 +137,20 @@ def parse_currency(value) -> Decimal | None:
 
     # Handle parenthetical negatives: ($468.33) -> -468.33
     negative = False
-    if value.startswith('(') and value.endswith(')'):
+    if value.startswith("(") and value.endswith(")"):
         negative = True
         value = value[1:-1]
 
     # Handle leading negative sign before or after dollar sign
-    if value.startswith('-'):
+    if value.startswith("-"):
         negative = True
         value = value[1:]
 
     # Strip dollar sign, commas, spaces
-    value = value.replace('$', '').replace(',', '').replace(' ', '')
+    value = value.replace("$", "").replace(",", "").replace(" ", "")
 
     # Handle negative after dollar sign: $-468.33
-    if value.startswith('-'):
+    if value.startswith("-"):
         negative = True
         value = value[1:]
 
@@ -184,9 +185,9 @@ def parse_yes_no(value) -> bool | None:
     if not value:
         return None
 
-    if value in ('yes', 'true', '1'):
+    if value in ("yes", "true", "1"):
         return True
-    if value in ('no', 'false', '0'):
+    if value in ("no", "false", "0"):
         return False
 
     return None
@@ -219,7 +220,7 @@ def parse_percentage(value) -> int | None:
         return None
 
     # Strip % sign
-    value = value.replace('%', '').strip()
+    value = value.replace("%", "").strip()
 
     try:
         num = float(value)
@@ -239,31 +240,31 @@ def parse_months_remaining(value) -> str:
     Returns empty string for None/empty.
     """
     if value is None:
-        return ''
+        return ""
 
     if isinstance(value, (int, float)):
         if isinstance(value, int):
             return str(value)
         # Format float with up to 6 decimal places, strip trailing zeros
-        formatted = f'{value:.6f}'.rstrip('0').rstrip('.')
+        formatted = f"{value:.6f}".rstrip("0").rstrip(".")
         return formatted
 
     if not isinstance(value, str):
-        return ''
+        return ""
 
     value = value.strip()
     if not value:
-        return ''
+        return ""
 
-    if value.lower() == 'infinite':
-        return 'infinite'
+    if value.lower() == "infinite":
+        return "infinite"
 
     # Try to parse as numeric
     try:
         num = float(value)
         if num == int(num):
             return str(int(num))
-        formatted = f'{num:.6f}'.rstrip('0').rstrip('.')
+        formatted = f"{num:.6f}".rstrip("0").rstrip(".")
         return formatted
     except (ValueError, TypeError):
         return value
@@ -272,6 +273,7 @@ def parse_months_remaining(value) -> str:
 # ---------------------------------------------------------------------------
 # Column mapping and row parsing
 # ---------------------------------------------------------------------------
+
 
 def build_column_index(headers: list[str]) -> tuple[dict, list[str]]:
     """Map header positions to field names using SMARTSHEET_COLUMN_MAP.
@@ -328,12 +330,12 @@ def parse_row(row_values: list, column_index: dict) -> dict:
             value = sanitize_cell_value(value)
 
         # Type-specific parsing
-        if field_name.startswith('_'):
+        if field_name.startswith("_"):
             # Matching keys: just sanitize and strip as string
             if isinstance(value, str):
                 result[field_name] = value.strip()
             else:
-                result[field_name] = str(value).strip() if value is not None else ''
+                result[field_name] = str(value).strip() if value is not None else ""
         elif field_name in CURRENCY_FIELDS:
             result[field_name] = parse_currency(value)
         elif field_name in BOOLEAN_FIELDS:
@@ -351,6 +353,7 @@ def parse_row(row_values: list, column_index: dict) -> dict:
 # ---------------------------------------------------------------------------
 # File parsing (XLSX and CSV)
 # ---------------------------------------------------------------------------
+
 
 def parse_xlsx(file_bytes: bytes) -> tuple[list[str], list[list]]:
     """Parse XLSX file into headers and data rows.
@@ -370,7 +373,7 @@ def parse_xlsx(file_bytes: bytes) -> tuple[list[str], list[list]]:
         return [], []
 
     # First row is headers
-    headers = [str(cell) if cell is not None else '' for cell in rows[0]]
+    headers = [str(cell) if cell is not None else "" for cell in rows[0]]
     data_rows = [list(row) for row in rows[1:]]
 
     return headers, data_rows
@@ -382,7 +385,7 @@ def parse_csv(file_bytes: bytes) -> tuple[list[str], list[list]]:
     Decodes with utf-8-sig to handle BOM.
     Returns (headers, data_rows).
     """
-    text = file_bytes.decode('utf-8-sig')
+    text = file_bytes.decode("utf-8-sig")
     reader = csv.reader(StringIO(text))
 
     rows = list(reader)
@@ -398,6 +401,7 @@ def parse_csv(file_bytes: bytes) -> tuple[list[str], list[list]]:
 # ---------------------------------------------------------------------------
 # User matching
 # ---------------------------------------------------------------------------
+
 
 def match_users(parsed_rows: list[dict]) -> tuple[list[tuple], list[dict]]:
     """Match parsed rows to DonorCRM users by first + last name.
@@ -424,14 +428,17 @@ def match_users(parsed_rows: list[dict]) -> tuple[list[tuple], list[dict]]:
         if key in user_lookup:
             duplicates.add(key)
             logger.warning(
-                'Duplicate user name key: %s %s (IDs: %s, %s)',
-                key[0], key[1], user_lookup[key].id, user.id
+                "Duplicate user name key: %s %s (IDs: %s, %s)",
+                key[0],
+                key[1],
+                user_lookup[key].id,
+                user.id,
             )
         else:
             user_lookup[key] = user
 
     if duplicates:
-        logger.warning('Found %d duplicate name keys in users', len(duplicates))
+        logger.warning("Found %d duplicate name keys in users", len(duplicates))
 
     matched = []
     unmatched = []
@@ -439,45 +446,60 @@ def match_users(parsed_rows: list[dict]) -> tuple[list[tuple], list[dict]]:
     for i, row_data in enumerate(parsed_rows):
         row_num = i + 2  # Header is row 1
 
-        first_name = row_data.get('_first_name', '').lower().strip()
-        last_name = row_data.get('_last_name', '').lower().strip()
+        first_name = row_data.get("_first_name", "").lower().strip()
+        last_name = row_data.get("_last_name", "").lower().strip()
         key = (first_name, last_name)
 
         # Skip rows with ambiguous (duplicate) name keys
         if key in duplicates:
             logger.warning(
-                'Row %d: ambiguous name match for %s %s (multiple users)',
-                row_num, first_name, last_name
+                "Row %d: ambiguous name match for %s %s (multiple users)",
+                row_num,
+                first_name,
+                last_name,
             )
-            unmatched.append({
-                'row': row_num,
-                'first_name': row_data.get('_first_name', ''),
-                'last_name': row_data.get('_last_name', ''),
-                # Financial fields for admin visibility in results dialog
-                'current_mpd_cap': str(row_data.get('current_mpd_cap', '')) if row_data.get('current_mpd_cap') is not None else None,
-                'latest_roll_forward_balance': str(row_data.get('latest_roll_forward_balance', '')) if row_data.get('latest_roll_forward_balance') is not None else None,
-                'months_remaining_rf': row_data.get('months_remaining_rf', ''),
-            })
+            unmatched.append(
+                {
+                    "row": row_num,
+                    "first_name": row_data.get("_first_name", ""),
+                    "last_name": row_data.get("_last_name", ""),
+                    # Financial fields for admin visibility in results dialog
+                    "current_mpd_cap": str(row_data.get("current_mpd_cap", ""))
+                    if row_data.get("current_mpd_cap") is not None
+                    else None,
+                    "latest_roll_forward_balance": str(
+                        row_data.get("latest_roll_forward_balance", "")
+                    )
+                    if row_data.get("latest_roll_forward_balance") is not None
+                    else None,
+                    "months_remaining_rf": row_data.get("months_remaining_rf", ""),
+                }
+            )
             continue
 
         user = user_lookup.get(key)
         if user:
             # Build snapshot kwargs (exclude keys starting with _)
-            snapshot_data = {
-                k: v for k, v in row_data.items()
-                if not k.startswith('_')
-            }
+            snapshot_data = {k: v for k, v in row_data.items() if not k.startswith("_")}
             matched.append((user, snapshot_data))
         else:
-            unmatched.append({
-                'row': row_num,
-                'first_name': row_data.get('_first_name', ''),
-                'last_name': row_data.get('_last_name', ''),
-                # Financial fields for admin visibility in results dialog
-                'current_mpd_cap': str(row_data.get('current_mpd_cap', '')) if row_data.get('current_mpd_cap') is not None else None,
-                'latest_roll_forward_balance': str(row_data.get('latest_roll_forward_balance', '')) if row_data.get('latest_roll_forward_balance') is not None else None,
-                'months_remaining_rf': row_data.get('months_remaining_rf', ''),
-            })
+            unmatched.append(
+                {
+                    "row": row_num,
+                    "first_name": row_data.get("_first_name", ""),
+                    "last_name": row_data.get("_last_name", ""),
+                    # Financial fields for admin visibility in results dialog
+                    "current_mpd_cap": str(row_data.get("current_mpd_cap", ""))
+                    if row_data.get("current_mpd_cap") is not None
+                    else None,
+                    "latest_roll_forward_balance": str(
+                        row_data.get("latest_roll_forward_balance", "")
+                    )
+                    if row_data.get("latest_roll_forward_balance") is not None
+                    else None,
+                    "months_remaining_rf": row_data.get("months_remaining_rf", ""),
+                }
+            )
 
     return matched, unmatched
 
@@ -485,6 +507,7 @@ def match_users(parsed_rows: list[dict]) -> tuple[list[tuple], list[dict]]:
 # ---------------------------------------------------------------------------
 # Main orchestrator
 # ---------------------------------------------------------------------------
+
 
 def process_mpd_upload(file_bytes: bytes, filename: str, uploaded_by) -> MPDUpload:
     """Process an MPD Smartsheet report upload end-to-end.
@@ -504,49 +527,46 @@ def process_mpd_upload(file_bytes: bytes, filename: str, uploaded_by) -> MPDUplo
     """
     # Step 1: Detect format
     file_format = detect_file_format(file_bytes)
-    logger.info('MPD upload started: %s (format: %s)', filename, file_format)
+    logger.info("MPD upload started: %s (format: %s)", filename, file_format)
 
     # Step 2: Create upload record
     upload = MPDUpload.objects.create(
         uploaded_by=uploaded_by,
         filename=filename,
         file_format=file_format,
-        status='processing',
+        status="processing",
     )
 
     try:
         # Step 3: Parse file
-        if file_format == 'xlsx':
+        if file_format == "xlsx":
             headers, data_rows = parse_xlsx(file_bytes)
         else:
             headers, data_rows = parse_csv(file_bytes)
 
-        logger.info('Parsed %d data rows from %s', len(data_rows), filename)
+        logger.info("Parsed %d data rows from %s", len(data_rows), filename)
 
         # Step 4: Build column index
         column_index, unrecognized = build_column_index(headers)
 
         if unrecognized:
-            logger.warning('Unrecognized columns in %s: %s', filename, unrecognized)
+            logger.warning("Unrecognized columns in %s: %s", filename, unrecognized)
 
         if not column_index:
-            upload.status = 'failed'
-            upload.error_message = 'No recognized columns found in file headers.'
+            upload.status = "failed"
+            upload.error_message = "No recognized columns found in file headers."
             upload.save()
             return upload
 
-        logger.info('Mapped %d columns from headers', len(column_index))
+        logger.info("Mapped %d columns from headers", len(column_index))
 
         # Step 5: Parse all data rows
         parsed_rows = [parse_row(row, column_index) for row in data_rows]
-        logger.info('Parsed %d rows', len(parsed_rows))
+        logger.info("Parsed %d rows", len(parsed_rows))
 
         # Step 6: Match users
         matched, unmatched = match_users(parsed_rows)
-        logger.info(
-            'User matching: %d matched, %d unmatched',
-            len(matched), len(unmatched)
-        )
+        logger.info("User matching: %d matched, %d unmatched", len(matched), len(unmatched))
 
         # Step 7: Bulk create MPDSnapshot records
         snapshots = [
@@ -567,8 +587,7 @@ def process_mpd_upload(file_bytes: bytes, filename: str, uploaded_by) -> MPDUplo
                 # Fall back to one-by-one creation if bulk fails
                 # (e.g., same user appears twice in file)
                 logger.warning(
-                    'Bulk create failed for %s, falling back to individual creates',
-                    filename
+                    "Bulk create failed for %s, falling back to individual creates", filename
                 )
                 for snapshot in snapshots:
                     try:
@@ -576,25 +595,26 @@ def process_mpd_upload(file_bytes: bytes, filename: str, uploaded_by) -> MPDUplo
                         snapshot_count += 1
                     except IntegrityError:
                         logger.warning(
-                            'Duplicate snapshot skipped: user=%s upload=%s',
-                            snapshot.user_id, upload.id
+                            "Duplicate snapshot skipped: user=%s upload=%s",
+                            snapshot.user_id,
+                            upload.id,
                         )
 
-        logger.info('Created %d MPDSnapshot records', snapshot_count)
+        logger.info("Created %d MPDSnapshot records", snapshot_count)
 
         # Step 8: Update upload with counts
         upload.total_rows = len(data_rows)
         upload.matched_count = len(matched)
         upload.unmatched_count = len(unmatched)
         upload.unmatched_rows = unmatched
-        upload.status = 'completed'
+        upload.status = "completed"
         upload.save()
 
         return upload
 
     except Exception as e:
-        logger.error('MPD upload failed for %s: %s', filename, e)
-        upload.status = 'failed'
+        logger.error("MPD upload failed for %s: %s", filename, e)
+        upload.status = "failed"
         upload.error_message = str(e)
         upload.save()
         raise

--- a/apps/imports/re_services.py
+++ b/apps/imports/re_services.py
@@ -944,8 +944,7 @@ def import_re_constituents(
                         {
                             "row": row_number,
                             "error": (
-                                f"Row {row_number}: Unexpected error: "
-                                f"{type(e).__name__}"
+                                f"Row {row_number}: Unexpected error: " f"{type(e).__name__}"
                             ),
                         }
                     )
@@ -1565,9 +1564,7 @@ def import_re_gifts(
                 except Exception as e:
                     transaction.savepoint_rollback(sp)
                     row_nums = ", ".join(r.get("_row_number", "?") for r in rows)
-                    logger.exception(
-                        "Gift group %s failed in import_re_gifts", gift_id
-                    )
+                    logger.exception("Gift group %s failed in import_re_gifts", gift_id)
                     errors.append(
                         {
                             "row": int(rows[0].get("_row_number", 0)),
@@ -2161,8 +2158,7 @@ def import_re_recurring_gifts(
                     transaction.savepoint_rollback(sp)
                     row_nums = ", ".join(r.get("_row_number", "?") for r in rows)
                     logger.exception(
-                        "Recurring gift group %s failed in "
-                        "import_re_recurring_gifts",
+                        "Recurring gift group %s failed in " "import_re_recurring_gifts",
                         gift_id,
                     )
                     errors.append(

--- a/apps/imports/re_services.py
+++ b/apps/imports/re_services.py
@@ -856,12 +856,13 @@ def import_re_constituents(
                             updated_count += 1
                         else:
                             skipped_count += 1
+                            contact_name = f"{contact.first_name} {contact.last_name}".strip()
                             skipped_details.append(
                                 {
                                     "row": row_number,
                                     "reason": "all_fields_populated",
                                     "match_type": match_type,
-                                    "contact_name": f"{contact.first_name} {contact.last_name}".strip(),
+                                    "contact_name": contact_name,
                                     "constituent_id": ext_id,
                                 }
                             )

--- a/apps/imports/services.py
+++ b/apps/imports/services.py
@@ -69,7 +69,7 @@ def _parse_amount(amount_str: str) -> Tuple[Decimal, str]:
     except InvalidOperation:
         return (
             None,
-            f'Invalid amount format: "{amount_str}". Expected a number like "100.00" or "$1,234.56"',
+            f'Invalid amount format: "{amount_str}". Expected a number like "100.00" or "$1,234.56"',  # noqa: E501
         )
 
 
@@ -202,8 +202,8 @@ def import_contacts(records: List[dict], user) -> Tuple[int, List[Contact]]:
     return len(created_contacts), created_contacts
 
 
-## Old SPO donation import functions (parse_donations_csv, import_donations) removed.
-## Superseded by Phase 28-29 RE import pipeline in apps/imports/re_services.py.
+# Old SPO donation import functions (parse_donations_csv, import_donations) removed.
+# Superseded by Phase 28-29 RE import pipeline in apps/imports/re_services.py.
 
 
 def export_contacts_csv(queryset) -> str:
@@ -310,7 +310,7 @@ def get_contacts_template() -> str:
     return "first_name,last_name,email,phone,street_address,city,state,postal_code,country,notes\n"
 
 
-## Old get_donations_template removed. Superseded by RE import pipeline.
+# Old get_donations_template removed. Superseded by RE import pipeline.
 
 
 def get_funds_template() -> str:
@@ -618,14 +618,6 @@ def import_entities(records: List[dict], user, import_run) -> Tuple[int, int]:
         import_run.save()
         return 0, 0
 
-    # Get existing external_ids for this user to calculate created vs updated
-    external_ids = [record["entity_id"] for record in records]
-    existing_external_ids = set(
-        Contact.objects.filter(owner=user, external_id__in=external_ids).values_list(
-            "external_id", flat=True
-        )
-    )
-
     # Upsert contacts individually
     # Note: Using update_or_create instead of bulk_create with update_conflicts
     # because the Contact model has a conditional unique constraint which
@@ -660,7 +652,7 @@ def import_entities(records: List[dict], user, import_run) -> Tuple[int, int]:
     return created_count, updated_count
 
 
-## Old SPO transaction/pledge import functions removed.
-## (get_transactions_template, parse_transactions_csv, import_transactions,
-##  update_contact_stats_for_import, get_pledges_template, parse_pledges_csv, import_pledges)
-## Superseded by Phase 28-29 RE import pipeline in apps/imports/re_services.py.
+# Old SPO transaction/pledge import functions removed.
+# (get_transactions_template, parse_transactions_csv, import_transactions,
+#  update_contact_stats_for_import, get_pledges_template, parse_pledges_csv, import_pledges)
+# Superseded by Phase 28-29 RE import pipeline in apps/imports/re_services.py.

--- a/apps/imports/tasks.py
+++ b/apps/imports/tasks.py
@@ -4,30 +4,28 @@ Celery tasks for asynchronous CSV imports.
 import logging
 import uuid
 
-from celery import shared_task
 from django.core.cache import cache
+
+from celery import shared_task
 
 logger = logging.getLogger(__name__)
 
 # Cache key prefix for import progress
-IMPORT_PROGRESS_PREFIX = 'import_progress_'
+IMPORT_PROGRESS_PREFIX = "import_progress_"
 IMPORT_PROGRESS_TTL = 3600  # 1 hour
 
 
 def get_import_progress(import_id: str) -> dict:
     """Get progress for an import task."""
-    return cache.get(f'{IMPORT_PROGRESS_PREFIX}{import_id}', {
-        'status': 'unknown',
-        'progress': 0,
-        'total': 0,
-        'imported': 0,
-        'errors': []
-    })
+    return cache.get(
+        f"{IMPORT_PROGRESS_PREFIX}{import_id}",
+        {"status": "unknown", "progress": 0, "total": 0, "imported": 0, "errors": []},
+    )
 
 
 def set_import_progress(import_id: str, data: dict):
     """Update progress for an import task."""
-    cache.set(f'{IMPORT_PROGRESS_PREFIX}{import_id}', data, IMPORT_PROGRESS_TTL)
+    cache.set(f"{IMPORT_PROGRESS_PREFIX}{import_id}", data, IMPORT_PROGRESS_TTL)
 
 
 @shared_task(bind=True)
@@ -47,45 +45,37 @@ def import_contacts_async(self, file_content: str, user_id: int, import_id: str 
     if not import_id:
         import_id = uuid.uuid4().hex[:12]
 
-    logger.info(f'Starting async contact import {import_id} for user {user_id}')
+    logger.info(f"Starting async contact import {import_id} for user {user_id}")
 
     try:
         user = User.objects.get(pk=user_id)
     except User.DoesNotExist:
-        logger.error(f'Import {import_id} failed: User {user_id} not found')
-        set_import_progress(import_id, {
-            'status': 'failed',
-            'error': 'User not found'
-        })
-        return {'status': 'failed', 'error': 'User not found'}
+        logger.error(f"Import {import_id} failed: User {user_id} not found")
+        set_import_progress(import_id, {"status": "failed", "error": "User not found"})
+        return {"status": "failed", "error": "User not found"}
 
     # Parse CSV
-    set_import_progress(import_id, {
-        'status': 'parsing',
-        'progress': 0,
-        'total': 0,
-        'imported': 0,
-        'errors': []
-    })
+    set_import_progress(
+        import_id, {"status": "parsing", "progress": 0, "total": 0, "imported": 0, "errors": []}
+    )
 
     valid_records, errors = parse_contacts_csv(file_content, user)
     total = len(valid_records)
 
-    logger.info(f'Import {import_id}: {total} valid records, {len(errors)} errors')
+    logger.info(f"Import {import_id}: {total} valid records, {len(errors)} errors")
 
     if not valid_records:
-        set_import_progress(import_id, {
-            'status': 'completed',
-            'progress': 100,
-            'total': 0,
-            'imported': 0,
-            'errors': errors[:50]  # Limit stored errors
-        })
-        return {
-            'status': 'completed',
-            'imported': 0,
-            'errors': errors
-        }
+        set_import_progress(
+            import_id,
+            {
+                "status": "completed",
+                "progress": 100,
+                "total": 0,
+                "imported": 0,
+                "errors": errors[:50],  # Limit stored errors
+            },
+        )
+        return {"status": "completed", "imported": 0, "errors": errors}
 
     # Import in batches
     batch_size = 100
@@ -103,33 +93,39 @@ def import_contacts_async(self, file_content: str, user_id: int, import_id: str 
 
             # Update progress
             progress = int((i + 1) / total * 100)
-            set_import_progress(import_id, {
-                'status': 'importing',
-                'progress': progress,
-                'total': total,
-                'imported': imported,
-                'errors': errors[:50]
-            })
+            set_import_progress(
+                import_id,
+                {
+                    "status": "importing",
+                    "progress": progress,
+                    "total": total,
+                    "imported": imported,
+                    "errors": errors[:50],
+                },
+            )
 
-            logger.debug(f'Import {import_id}: {imported}/{total} contacts created')
+            logger.debug(f"Import {import_id}: {imported}/{total} contacts created")
 
     # Final progress update
-    set_import_progress(import_id, {
-        'status': 'completed',
-        'progress': 100,
-        'total': total,
-        'imported': imported,
-        'errors': errors[:50]
-    })
+    set_import_progress(
+        import_id,
+        {
+            "status": "completed",
+            "progress": 100,
+            "total": total,
+            "imported": imported,
+            "errors": errors[:50],
+        },
+    )
 
-    logger.info(f'Import {import_id} completed: {imported} contacts imported')
+    logger.info(f"Import {import_id} completed: {imported} contacts imported")
 
     return {
-        'status': 'completed',
-        'import_id': import_id,
-        'imported': imported,
-        'error_count': len(errors),
-        'errors': errors[:50]
+        "status": "completed",
+        "import_id": import_id,
+        "imported": imported,
+        "error_count": len(errors),
+        "errors": errors[:50],
     }
 
 

--- a/apps/imports/tasks.py
+++ b/apps/imports/tasks.py
@@ -129,5 +129,5 @@ def import_contacts_async(self, file_content: str, user_id: int, import_id: str 
     }
 
 
-## Old import_donations_async task removed.
-## Superseded by Phase 28-29 RE import pipeline.
+# Old import_donations_async task removed.
+# Superseded by Phase 28-29 RE import pipeline.

--- a/apps/imports/tests/test_audit_import_health.py
+++ b/apps/imports/tests/test_audit_import_health.py
@@ -5,7 +5,6 @@ Covers all 5 sections, --verbose/--json flags, zero-solicitors edge case,
 and HEALTHY vs NEEDS ATTENTION verdict logic.
 """
 import json
-from decimal import Decimal
 from io import StringIO
 
 from django.core.management import call_command
@@ -78,7 +77,8 @@ class AuditImportHealthSolicitorsTest(TestCase):
         self.assertIn("John Smith", output)
 
     def test_section1_near_miss_alias(self):
-        """Detects near-misses by comparing unlinked solicitor names to MissionaryAlias source_names."""
+        """Detects near-misses by comparing unlinked solicitor names to
+        MissionaryAlias source_names."""
         MissionaryAlias.objects.create(source_name="Johnny Smith", user=self.missionary)
         Solicitor.objects.create(normalized_name="Johny Smith", user=None)
 

--- a/apps/imports/tests/test_audit_import_health.py
+++ b/apps/imports/tests/test_audit_import_health.py
@@ -31,15 +31,15 @@ class AuditImportHealthZeroSolicitorsTest(TestCase):
     def test_zero_solicitors_exits_cleanly(self):
         """When no solicitors exist, print message and exit without sections."""
         out = StringIO()
-        call_command('audit_import_health', stdout=out)
+        call_command("audit_import_health", stdout=out)
         output = out.getvalue()
-        self.assertIn('No solicitors found', output)
+        self.assertIn("No solicitors found", output)
         # Should not print any section headers
-        self.assertNotIn('Section 1', output)
-        self.assertNotIn('Section 2', output)
-        self.assertNotIn('Section 3', output)
-        self.assertNotIn('Section 4', output)
-        self.assertNotIn('Section 5', output)
+        self.assertNotIn("Section 1", output)
+        self.assertNotIn("Section 2", output)
+        self.assertNotIn("Section 3", output)
+        self.assertNotIn("Section 4", output)
+        self.assertNotIn("Section 5", output)
 
 
 class AuditImportHealthSolicitorsTest(TestCase):
@@ -48,44 +48,44 @@ class AuditImportHealthSolicitorsTest(TestCase):
     def setUp(self):
         self.missionary = UserFactory(
             role=UserRole.MISSIONARY,
-            first_name='John',
-            last_name='Smith',
+            first_name="John",
+            last_name="Smith",
         )
 
     def test_section1_counts_linked_and_unlinked(self):
         """Counts total solicitors, linked and unlinked with percentages."""
-        Solicitor.objects.create(normalized_name='Smith, John', user=self.missionary)
-        Solicitor.objects.create(normalized_name='Doe, Jane', user=None)
+        Solicitor.objects.create(normalized_name="Smith, John", user=self.missionary)
+        Solicitor.objects.create(normalized_name="Doe, Jane", user=None)
 
         out = StringIO()
-        call_command('audit_import_health', stdout=out)
+        call_command("audit_import_health", stdout=out)
         output = out.getvalue()
-        self.assertIn('Solicitor Linking', output)
-        self.assertIn('Total: 2', output)
-        self.assertIn('Linked: 1 (50.0%)', output)
-        self.assertIn('Unlinked: 1 (50.0%)', output)
+        self.assertIn("Solicitor Linking", output)
+        self.assertIn("Total: 2", output)
+        self.assertIn("Linked: 1 (50.0%)", output)
+        self.assertIn("Unlinked: 1 (50.0%)", output)
 
     def test_section1_near_miss_user_fullname(self):
         """Detects near-misses by comparing unlinked solicitor names to User full names."""
         # Unlinked solicitor with name very close to a User's full name
         # Use "First Last" format so SequenceMatcher ratio >= 0.8
-        Solicitor.objects.create(normalized_name='Jon Smith', user=None)
+        Solicitor.objects.create(normalized_name="Jon Smith", user=None)
 
         out = StringIO()
-        call_command('audit_import_health', '--verbose', stdout=out)
+        call_command("audit_import_health", "--verbose", stdout=out)
         output = out.getvalue()
-        self.assertIn('near-miss', output.lower())
-        self.assertIn('John Smith', output)
+        self.assertIn("near-miss", output.lower())
+        self.assertIn("John Smith", output)
 
     def test_section1_near_miss_alias(self):
         """Detects near-misses by comparing unlinked solicitor names to MissionaryAlias source_names."""
-        MissionaryAlias.objects.create(source_name='Johnny Smith', user=self.missionary)
-        Solicitor.objects.create(normalized_name='Johny Smith', user=None)
+        MissionaryAlias.objects.create(source_name="Johnny Smith", user=self.missionary)
+        Solicitor.objects.create(normalized_name="Johny Smith", user=None)
 
         out = StringIO()
-        call_command('audit_import_health', '--verbose', stdout=out)
+        call_command("audit_import_health", "--verbose", stdout=out)
         output = out.getvalue()
-        self.assertIn('near-miss', output.lower())
+        self.assertIn("near-miss", output.lower())
 
 
 class AuditImportHealthContactOwnershipTest(TestCase):
@@ -94,13 +94,13 @@ class AuditImportHealthContactOwnershipTest(TestCase):
     def setUp(self):
         self.missionary = UserFactory(
             role=UserRole.MISSIONARY,
-            first_name='Alice',
-            last_name='Missionary',
+            first_name="Alice",
+            last_name="Missionary",
         )
-        self.admin = UserFactory(role=UserRole.ADMIN, first_name='Bob', last_name='Admin')
+        self.admin = UserFactory(role=UserRole.ADMIN, first_name="Bob", last_name="Admin")
         # Need at least one solicitor so sections run
         self.solicitor = Solicitor.objects.create(
-            normalized_name='Missionary, Alice',
+            normalized_name="Missionary, Alice",
             user=self.missionary,
         )
 
@@ -108,34 +108,34 @@ class AuditImportHealthContactOwnershipTest(TestCase):
         """Groups contacts by owner role."""
         Contact.objects.create(
             owner=self.missionary,
-            first_name='Donor',
-            last_name='One',
+            first_name="Donor",
+            last_name="One",
         )
         Contact.objects.create(
             owner=self.admin,
-            first_name='Donor',
-            last_name='Two',
+            first_name="Donor",
+            last_name="Two",
         )
 
         out = StringIO()
-        call_command('audit_import_health', stdout=out)
+        call_command("audit_import_health", stdout=out)
         output = out.getvalue()
-        self.assertIn('Contact Ownership', output)
-        self.assertIn('missionary', output.lower())
+        self.assertIn("Contact Ownership", output)
+        self.assertIn("missionary", output.lower())
 
     def test_section2_detects_misattributions(self):
         """Detects contacts owned by admin/supervisor with gift credits to missionary solicitor."""
         # Contact owned by admin
         contact = Contact.objects.create(
             owner=self.admin,
-            first_name='Misattributed',
-            last_name='Donor',
+            first_name="Misattributed",
+            last_name="Donor",
         )
         # Gift on that contact with a credit pointing to missionary solicitor
         gift = Gift.objects.create(
             donor_contact=contact,
             amount_cents=10000,
-            gift_date='2026-01-01',
+            gift_date="2026-01-01",
         )
         GiftCredit.objects.create(
             gift=gift,
@@ -144,9 +144,9 @@ class AuditImportHealthContactOwnershipTest(TestCase):
         )
 
         out = StringIO()
-        call_command('audit_import_health', stdout=out)
+        call_command("audit_import_health", stdout=out)
         output = out.getvalue()
-        self.assertIn('misattribut', output.lower())
+        self.assertIn("misattribut", output.lower())
 
 
 class AuditImportHealthGiftCreditTest(TestCase):
@@ -155,13 +155,13 @@ class AuditImportHealthGiftCreditTest(TestCase):
     def setUp(self):
         self.missionary = UserFactory(role=UserRole.MISSIONARY)
         self.solicitor = Solicitor.objects.create(
-            normalized_name='Test, Sol',
+            normalized_name="Test, Sol",
             user=self.missionary,
         )
         self.contact = Contact.objects.create(
             owner=self.missionary,
-            first_name='Donor',
-            last_name='One',
+            first_name="Donor",
+            last_name="One",
         )
 
     def test_section3_counts_gifts_and_credits(self):
@@ -169,7 +169,7 @@ class AuditImportHealthGiftCreditTest(TestCase):
         gift = Gift.objects.create(
             donor_contact=self.contact,
             amount_cents=5000,
-            gift_date='2026-01-01',
+            gift_date="2026-01-01",
         )
         GiftCredit.objects.create(
             gift=gift,
@@ -178,25 +178,25 @@ class AuditImportHealthGiftCreditTest(TestCase):
         )
 
         out = StringIO()
-        call_command('audit_import_health', stdout=out)
+        call_command("audit_import_health", stdout=out)
         output = out.getvalue()
-        self.assertIn('Gift Credit Integrity', output)
-        self.assertIn('Total gifts: 1', output)
-        self.assertIn('Total credits: 1', output)
+        self.assertIn("Gift Credit Integrity", output)
+        self.assertIn("Total gifts: 1", output)
+        self.assertIn("Total credits: 1", output)
 
     def test_section3_orphaned_gifts(self):
         """Detects orphaned gifts (no credits) and unlinked dollar value."""
         Gift.objects.create(
             donor_contact=self.contact,
             amount_cents=25000,
-            gift_date='2026-01-15',
+            gift_date="2026-01-15",
         )
 
         out = StringIO()
-        call_command('audit_import_health', stdout=out)
+        call_command("audit_import_health", stdout=out)
         output = out.getvalue()
-        self.assertIn('Orphaned gifts (no credits): 1', output)
-        self.assertIn('250.00', output)
+        self.assertIn("Orphaned gifts (no credits): 1", output)
+        self.assertIn("250.00", output)
 
 
 class AuditImportHealthRecurringTest(TestCase):
@@ -205,13 +205,13 @@ class AuditImportHealthRecurringTest(TestCase):
     def setUp(self):
         self.missionary = UserFactory(role=UserRole.MISSIONARY)
         self.solicitor = Solicitor.objects.create(
-            normalized_name='Test, Sol',
+            normalized_name="Test, Sol",
             user=self.missionary,
         )
         self.contact = Contact.objects.create(
             owner=self.missionary,
-            first_name='Donor',
-            last_name='Rec',
+            first_name="Donor",
+            last_name="Rec",
         )
 
     def test_section4_counts_active_recurring(self):
@@ -219,8 +219,8 @@ class AuditImportHealthRecurringTest(TestCase):
         rg = RecurringGift.objects.create(
             donor_contact=self.contact,
             amount_cents=10000,
-            frequency='monthly',
-            start_date='2026-01-01',
+            frequency="monthly",
+            start_date="2026-01-01",
             status=RecurringGiftStatus.ACTIVE,
         )
         RecurringGiftCredit.objects.create(
@@ -230,41 +230,41 @@ class AuditImportHealthRecurringTest(TestCase):
         )
 
         out = StringIO()
-        call_command('audit_import_health', stdout=out)
+        call_command("audit_import_health", stdout=out)
         output = out.getvalue()
-        self.assertIn('Recurring Gift Credit Integrity', output)
-        self.assertIn('Active recurring gifts: 1', output)
+        self.assertIn("Recurring Gift Credit Integrity", output)
+        self.assertIn("Active recurring gifts: 1", output)
 
     def test_section4_orphaned_recurring(self):
         """Detects orphaned active recurring gifts (no credits)."""
         RecurringGift.objects.create(
             donor_contact=self.contact,
             amount_cents=15000,
-            frequency='monthly',
-            start_date='2026-01-01',
+            frequency="monthly",
+            start_date="2026-01-01",
             status=RecurringGiftStatus.ACTIVE,
         )
 
         out = StringIO()
-        call_command('audit_import_health', stdout=out)
+        call_command("audit_import_health", stdout=out)
         output = out.getvalue()
-        self.assertIn('Orphaned active recurring gifts: 1', output)
-        self.assertIn('150.00', output)
+        self.assertIn("Orphaned active recurring gifts: 1", output)
+        self.assertIn("150.00", output)
 
     def test_section4_ignores_non_active(self):
         """Non-active recurring gifts are not counted."""
         RecurringGift.objects.create(
             donor_contact=self.contact,
             amount_cents=10000,
-            frequency='monthly',
-            start_date='2026-01-01',
+            frequency="monthly",
+            start_date="2026-01-01",
             status=RecurringGiftStatus.CANCELLED,
         )
 
         out = StringIO()
-        call_command('audit_import_health', stdout=out)
+        call_command("audit_import_health", stdout=out)
         output = out.getvalue()
-        self.assertIn('Active recurring gifts: 0', output)
+        self.assertIn("Active recurring gifts: 0", output)
 
 
 class AuditImportHealthDashboardImpactTest(TestCase):
@@ -273,11 +273,11 @@ class AuditImportHealthDashboardImpactTest(TestCase):
     def setUp(self):
         self.missionary = UserFactory(
             role=UserRole.MISSIONARY,
-            first_name='Test',
-            last_name='Missionary',
+            first_name="Test",
+            last_name="Missionary",
         )
         self.solicitor = Solicitor.objects.create(
-            normalized_name='Missionary, Test',
+            normalized_name="Missionary, Test",
             user=self.missionary,
         )
 
@@ -285,19 +285,19 @@ class AuditImportHealthDashboardImpactTest(TestCase):
         """Lists missionaries with their contact/gift counts."""
         contact = Contact.objects.create(
             owner=self.missionary,
-            first_name='Donor',
-            last_name='A',
+            first_name="Donor",
+            last_name="A",
         )
         Gift.objects.create(
             donor_contact=contact,
             amount_cents=10000,
-            gift_date='2026-01-01',
+            gift_date="2026-01-01",
         )
 
         out = StringIO()
-        call_command('audit_import_health', stdout=out)
+        call_command("audit_import_health", stdout=out)
         output = out.getvalue()
-        self.assertIn('Dashboard Impact', output)
+        self.assertIn("Dashboard Impact", output)
 
     def test_section5_flags_missionary_with_credits_but_no_contacts(self):
         """Flags missionary with 0 contacts but gift credits via solicitor."""
@@ -305,13 +305,13 @@ class AuditImportHealthDashboardImpactTest(TestCase):
         other_user = UserFactory(role=UserRole.ADMIN)
         contact = Contact.objects.create(
             owner=other_user,
-            first_name='Donor',
-            last_name='B',
+            first_name="Donor",
+            last_name="B",
         )
         gift = Gift.objects.create(
             donor_contact=contact,
             amount_cents=10000,
-            gift_date='2026-01-01',
+            gift_date="2026-01-01",
         )
         GiftCredit.objects.create(
             gift=gift,
@@ -320,10 +320,10 @@ class AuditImportHealthDashboardImpactTest(TestCase):
         )
 
         out = StringIO()
-        call_command('audit_import_health', stdout=out)
+        call_command("audit_import_health", stdout=out)
         output = out.getvalue()
         # Should have a flag/warning for this missionary
-        self.assertIn('flag', output.lower())
+        self.assertIn("flag", output.lower())
 
 
 class AuditImportHealthVerdictTest(TestCase):
@@ -333,18 +333,18 @@ class AuditImportHealthVerdictTest(TestCase):
         """HEALTHY when all sections clean."""
         missionary = UserFactory(role=UserRole.MISSIONARY)
         solicitor = Solicitor.objects.create(
-            normalized_name='Test, Sol',
+            normalized_name="Test, Sol",
             user=missionary,
         )
         contact = Contact.objects.create(
             owner=missionary,
-            first_name='Donor',
-            last_name='A',
+            first_name="Donor",
+            last_name="A",
         )
         gift = Gift.objects.create(
             donor_contact=contact,
             amount_cents=10000,
-            gift_date='2026-01-01',
+            gift_date="2026-01-01",
         )
         GiftCredit.objects.create(
             gift=gift,
@@ -353,20 +353,20 @@ class AuditImportHealthVerdictTest(TestCase):
         )
 
         out = StringIO()
-        call_command('audit_import_health', stdout=out)
+        call_command("audit_import_health", stdout=out)
         output = out.getvalue()
-        self.assertIn('HEALTHY', output)
+        self.assertIn("HEALTHY", output)
 
     def test_needs_attention_verdict(self):
         """NEEDS ATTENTION with issue count when problems exist."""
         UserFactory(role=UserRole.MISSIONARY)
-        Solicitor.objects.create(normalized_name='Unlinked, Sol', user=None)
+        Solicitor.objects.create(normalized_name="Unlinked, Sol", user=None)
 
         out = StringIO()
-        call_command('audit_import_health', stdout=out)
+        call_command("audit_import_health", stdout=out)
         output = out.getvalue()
-        self.assertIn('NEEDS ATTENTION', output)
-        self.assertIn('issue', output.lower())
+        self.assertIn("NEEDS ATTENTION", output)
+        self.assertIn("issue", output.lower())
 
 
 class AuditImportHealthVerboseTest(TestCase):
@@ -375,30 +375,30 @@ class AuditImportHealthVerboseTest(TestCase):
     def test_verbose_shows_unlinked_solicitor_names(self):
         """--verbose lists each unlinked solicitor by name."""
         UserFactory(role=UserRole.MISSIONARY)
-        Solicitor.objects.create(normalized_name='Doe, Jane', user=None)
+        Solicitor.objects.create(normalized_name="Doe, Jane", user=None)
 
         out = StringIO()
-        call_command('audit_import_health', '--verbose', stdout=out)
+        call_command("audit_import_health", "--verbose", stdout=out)
         output = out.getvalue()
-        self.assertIn('Doe, Jane', output)
+        self.assertIn("Doe, Jane", output)
 
     def test_verbose_shows_misattributed_contacts(self):
         """--verbose lists each misattributed contact."""
         missionary = UserFactory(role=UserRole.MISSIONARY)
         admin = UserFactory(role=UserRole.ADMIN)
         solicitor = Solicitor.objects.create(
-            normalized_name='M, Test',
+            normalized_name="M, Test",
             user=missionary,
         )
         contact = Contact.objects.create(
             owner=admin,
-            first_name='Donor',
-            last_name='Misattr',
+            first_name="Donor",
+            last_name="Misattr",
         )
         gift = Gift.objects.create(
             donor_contact=contact,
             amount_cents=5000,
-            gift_date='2026-01-01',
+            gift_date="2026-01-01",
         )
         GiftCredit.objects.create(
             gift=gift,
@@ -407,9 +407,9 @@ class AuditImportHealthVerboseTest(TestCase):
         )
 
         out = StringIO()
-        call_command('audit_import_health', '--verbose', stdout=out)
+        call_command("audit_import_health", "--verbose", stdout=out)
         output = out.getvalue()
-        self.assertIn('Donor Misattr', output)
+        self.assertIn("Donor Misattr", output)
 
 
 class AuditImportHealthJsonTest(TestCase):
@@ -419,31 +419,31 @@ class AuditImportHealthJsonTest(TestCase):
         """--json outputs valid JSON with all 5 sections."""
         missionary = UserFactory(role=UserRole.MISSIONARY)
         Solicitor.objects.create(
-            normalized_name='Test, Sol',
+            normalized_name="Test, Sol",
             user=missionary,
         )
 
         out = StringIO()
-        call_command('audit_import_health', '--json', stdout=out)
+        call_command("audit_import_health", "--json", stdout=out)
         output = out.getvalue()
         data = json.loads(output)
-        self.assertIn('solicitor_linking', data)
-        self.assertIn('contact_ownership', data)
-        self.assertIn('gift_credit_integrity', data)
-        self.assertIn('recurring_gift_credit_integrity', data)
-        self.assertIn('dashboard_impact', data)
-        self.assertIn('verdict', data)
+        self.assertIn("solicitor_linking", data)
+        self.assertIn("contact_ownership", data)
+        self.assertIn("gift_credit_integrity", data)
+        self.assertIn("recurring_gift_credit_integrity", data)
+        self.assertIn("dashboard_impact", data)
+        self.assertIn("verdict", data)
 
     def test_json_no_styled_text(self):
         """--json does not include styled text output (section headers)."""
         missionary = UserFactory(role=UserRole.MISSIONARY)
         Solicitor.objects.create(
-            normalized_name='Test, Sol',
+            normalized_name="Test, Sol",
             user=missionary,
         )
 
         out = StringIO()
-        call_command('audit_import_health', '--json', stdout=out)
+        call_command("audit_import_health", "--json", stdout=out)
         output = out.getvalue()
         # Should not contain section header markers
-        self.assertNotIn('===', output)
+        self.assertNotIn("===", output)

--- a/apps/imports/tests/test_entity_import.py
+++ b/apps/imports/tests/test_entity_import.py
@@ -2,15 +2,18 @@
 Tests for Entity CSV import functionality.
 """
 import io
-import pytest
+
 from django.contrib.auth import get_user_model
 from django.urls import reverse
+
 from rest_framework import status
 from rest_framework.test import APIClient
 
+import pytest
+
 from apps.contacts.models import Contact
-from apps.imports.models import ImportRun, ImportType, ImportStatus
-from apps.imports.services import parse_entities_csv, import_entities
+from apps.imports.models import ImportRun, ImportStatus, ImportType
+from apps.imports.services import import_entities, parse_entities_csv
 
 User = get_user_model()
 
@@ -19,10 +22,7 @@ User = get_user_model()
 def test_user(db):
     """Create a test user."""
     return User.objects.create_user(
-        email='test@example.com',
-        password='testpass123',
-        first_name='Test',
-        last_name='User'
+        email="test@example.com", password="testpass123", first_name="Test", last_name="User"
     )
 
 
@@ -30,11 +30,11 @@ def test_user(db):
 def admin_user(db):
     """Create an admin user."""
     return User.objects.create_user(
-        email='admin@example.com',
-        password='adminpass123',
-        first_name='Admin',
-        last_name='User',
-        role='admin'
+        email="admin@example.com",
+        password="adminpass123",
+        first_name="Admin",
+        last_name="User",
+        role="admin",
     )
 
 
@@ -50,8 +50,8 @@ def import_run(test_user):
     return ImportRun.objects.create(
         type=ImportType.ENTITIES,
         status=ImportStatus.PENDING,
-        filename='test_entities.csv',
-        uploaded_by=test_user
+        filename="test_entities.csv",
+        uploaded_by=test_user,
     )
 
 
@@ -68,15 +68,15 @@ ENT002,Mary Jane Smith,mary@example.com,555-5678,456 Oak Ave,person"""
 
         assert len(records) == 2
         assert len(errors) == 0
-        assert records[0]['entity_id'] == 'ENT001'
-        assert records[0]['first_name'] == 'John'
-        assert records[0]['last_name'] == 'Smith'
-        assert records[0]['email'] == 'john@example.com'
-        assert records[0]['phone'] == '555-1234'
-        assert records[0]['street_address'] == '123 Main St'
-        assert records[1]['entity_id'] == 'ENT002'
-        assert records[1]['first_name'] == 'Mary Jane'
-        assert records[1]['last_name'] == 'Smith'
+        assert records[0]["entity_id"] == "ENT001"
+        assert records[0]["first_name"] == "John"
+        assert records[0]["last_name"] == "Smith"
+        assert records[0]["email"] == "john@example.com"
+        assert records[0]["phone"] == "555-1234"
+        assert records[0]["street_address"] == "123 Main St"
+        assert records[1]["entity_id"] == "ENT002"
+        assert records[1]["first_name"] == "Mary Jane"
+        assert records[1]["last_name"] == "Smith"
 
     def test_missing_entity_id_column_returns_error(self, test_user):
         """Missing entity_id column should return error at row 1."""
@@ -87,9 +87,9 @@ John Smith,john@example.com"""
 
         assert len(records) == 0
         assert len(errors) == 1
-        assert errors[0]['row'] == 1
-        assert 'Missing required column' in errors[0]['errors'][0]
-        assert 'entity_id' in errors[0]['errors'][0]
+        assert errors[0]["row"] == 1
+        assert "Missing required column" in errors[0]["errors"][0]
+        assert "entity_id" in errors[0]["errors"][0]
 
     def test_missing_name_column_returns_error(self, test_user):
         """Missing name column should return error at row 1."""
@@ -100,9 +100,9 @@ ENT001,john@example.com"""
 
         assert len(records) == 0
         assert len(errors) == 1
-        assert errors[0]['row'] == 1
-        assert 'Missing required column' in errors[0]['errors'][0]
-        assert 'name' in errors[0]['errors'][0]
+        assert errors[0]["row"] == 1
+        assert "Missing required column" in errors[0]["errors"][0]
+        assert "name" in errors[0]["errors"][0]
 
     def test_empty_entity_id_returns_error(self, test_user):
         """Empty entity_id should return row-level error."""
@@ -113,8 +113,8 @@ ENT001,john@example.com"""
 
         assert len(records) == 0
         assert len(errors) == 1
-        assert errors[0]['row'] == 2
-        assert 'entity_id is required' in errors[0]['errors'][0]
+        assert errors[0]["row"] == 2
+        assert "entity_id is required" in errors[0]["errors"][0]
 
     def test_empty_name_returns_error(self, test_user):
         """Empty name should return row-level error."""
@@ -125,8 +125,8 @@ ENT001,,john@example.com"""
 
         assert len(records) == 0
         assert len(errors) == 1
-        assert errors[0]['row'] == 2
-        assert 'name is required' in errors[0]['errors'][0]
+        assert errors[0]["row"] == 2
+        assert "name is required" in errors[0]["errors"][0]
 
     def test_duplicate_entity_id_in_file_returns_error(self, test_user):
         """Duplicate entity_id in file should return error."""
@@ -138,13 +138,13 @@ ENT001,Jane Doe,jane@example.com"""
 
         assert len(records) == 1  # First one is valid
         assert len(errors) == 1  # Second one errors
-        assert errors[0]['row'] == 3
-        assert 'Duplicate entity_id' in errors[0]['errors'][0]
-        assert 'ENT001' in errors[0]['errors'][0]
+        assert errors[0]["row"] == 3
+        assert "Duplicate entity_id" in errors[0]["errors"][0]
+        assert "ENT001" in errors[0]["errors"][0]
 
     def test_entity_id_exceeds_max_length_returns_error(self, test_user):
         """entity_id exceeding 100 characters should return error."""
-        long_entity_id = 'E' * 101
+        long_entity_id = "E" * 101
         csv_content = f"""entity_id,name,email
 {long_entity_id},John Smith,john@example.com"""
 
@@ -152,12 +152,12 @@ ENT001,Jane Doe,jane@example.com"""
 
         assert len(records) == 0
         assert len(errors) == 1
-        assert errors[0]['row'] == 2
-        assert 'entity_id exceeds maximum length' in errors[0]['errors'][0]
+        assert errors[0]["row"] == 2
+        assert "entity_id exceeds maximum length" in errors[0]["errors"][0]
 
     def test_name_exceeds_max_length_returns_error(self, test_user):
         """name exceeding 300 characters should return error."""
-        long_name = 'N' * 301
+        long_name = "N" * 301
         csv_content = f"""entity_id,name,email
 ENT001,{long_name},john@example.com"""
 
@@ -165,8 +165,8 @@ ENT001,{long_name},john@example.com"""
 
         assert len(records) == 0
         assert len(errors) == 1
-        assert errors[0]['row'] == 2
-        assert 'name exceeds maximum length' in errors[0]['errors'][0]
+        assert errors[0]["row"] == 2
+        assert "name exceeds maximum length" in errors[0]["errors"][0]
 
     def test_invalid_email_format_returns_error(self, test_user):
         """Invalid email format should return error."""
@@ -177,12 +177,12 @@ ENT001,John Smith,not-an-email"""
 
         assert len(records) == 0
         assert len(errors) == 1
-        assert errors[0]['row'] == 2
-        assert 'Invalid email format' in errors[0]['errors'][0]
+        assert errors[0]["row"] == 2
+        assert "Invalid email format" in errors[0]["errors"][0]
 
     def test_email_exceeds_max_length_returns_error(self, test_user):
         """email exceeding 254 characters should return error."""
-        long_email = 'a' * 246 + '@test.com'  # 246 + 9 = 255 characters
+        long_email = "a" * 246 + "@test.com"  # 246 + 9 = 255 characters
         csv_content = f"""entity_id,name,email
 ENT001,John Smith,{long_email}"""
 
@@ -190,12 +190,12 @@ ENT001,John Smith,{long_email}"""
 
         assert len(records) == 0
         assert len(errors) == 1
-        assert errors[0]['row'] == 2
-        assert 'email exceeds maximum length' in errors[0]['errors'][0]
+        assert errors[0]["row"] == 2
+        assert "email exceeds maximum length" in errors[0]["errors"][0]
 
     def test_phone_exceeds_max_length_returns_error(self, test_user):
         """phone exceeding 20 characters should return error."""
-        long_phone = '1' * 21
+        long_phone = "1" * 21
         csv_content = f"""entity_id,name,email,phone
 ENT001,John Smith,john@example.com,{long_phone}"""
 
@@ -203,12 +203,12 @@ ENT001,John Smith,john@example.com,{long_phone}"""
 
         assert len(records) == 0
         assert len(errors) == 1
-        assert errors[0]['row'] == 2
-        assert 'phone exceeds maximum length' in errors[0]['errors'][0]
+        assert errors[0]["row"] == 2
+        assert "phone exceeds maximum length" in errors[0]["errors"][0]
 
     def test_address_exceeds_max_length_returns_error(self, test_user):
         """address exceeding 255 characters should return error."""
-        long_address = 'A' * 256
+        long_address = "A" * 256
         csv_content = f"""entity_id,name,email,phone,address
 ENT001,John Smith,john@example.com,555-1234,{long_address}"""
 
@@ -216,8 +216,8 @@ ENT001,John Smith,john@example.com,555-1234,{long_address}"""
 
         assert len(records) == 0
         assert len(errors) == 1
-        assert errors[0]['row'] == 2
-        assert 'address exceeds maximum length' in errors[0]['errors'][0]
+        assert errors[0]["row"] == 2
+        assert "address exceeds maximum length" in errors[0]["errors"][0]
 
     def test_formula_character_in_entity_id_returns_error(self, test_user):
         """Formula character in entity_id should return error."""
@@ -232,7 +232,7 @@ ENT001,John Smith,john@example.com,555-1234,{long_address}"""
         assert len(records) == 0
         assert len(errors) == 4
         for error in errors:
-            assert 'formula character' in error['errors'][0].lower()
+            assert "formula character" in error["errors"][0].lower()
 
     def test_formula_character_in_name_returns_error(self, test_user):
         """Formula character in name should return error."""
@@ -247,7 +247,7 @@ ENT004,@Alice Brown,alice@example.com"""
         assert len(records) == 0
         assert len(errors) == 4
         for error in errors:
-            assert 'formula character' in error['errors'][0].lower()
+            assert "formula character" in error["errors"][0].lower()
 
     def test_name_split_two_words(self, test_user):
         """Name 'John Smith' should split to first_name='John', last_name='Smith'."""
@@ -258,8 +258,8 @@ ENT001,John Smith"""
 
         assert len(records) == 1
         assert len(errors) == 0
-        assert records[0]['first_name'] == 'John'
-        assert records[0]['last_name'] == 'Smith'
+        assert records[0]["first_name"] == "John"
+        assert records[0]["last_name"] == "Smith"
 
     def test_name_split_three_words(self, test_user):
         """Name 'Mary Jane Smith' should split to first_name='Mary Jane', last_name='Smith'."""
@@ -270,8 +270,8 @@ ENT001,Mary Jane Smith"""
 
         assert len(records) == 1
         assert len(errors) == 0
-        assert records[0]['first_name'] == 'Mary Jane'
-        assert records[0]['last_name'] == 'Smith'
+        assert records[0]["first_name"] == "Mary Jane"
+        assert records[0]["last_name"] == "Smith"
 
     def test_name_split_single_word(self, test_user):
         """Name 'Madonna' should split to first_name='Madonna', last_name=''."""
@@ -282,8 +282,8 @@ ENT001,Madonna"""
 
         assert len(records) == 1
         assert len(errors) == 0
-        assert records[0]['first_name'] == 'Madonna'
-        assert records[0]['last_name'] == ''
+        assert records[0]["first_name"] == "Madonna"
+        assert records[0]["last_name"] == ""
 
     def test_entity_type_column_is_ignored(self, test_user):
         """entity_type column should be ignored (no error, not in output)."""
@@ -296,8 +296,8 @@ ENT002,Jane Doe,organization"""
         assert len(records) == 2
         assert len(errors) == 0
         # entity_type should NOT be in the output
-        assert 'entity_type' not in records[0]
-        assert 'entity_type' not in records[1]
+        assert "entity_type" not in records[0]
+        assert "entity_type" not in records[1]
 
     def test_address_maps_to_street_address(self, test_user):
         """address should map to street_address in output."""
@@ -308,8 +308,8 @@ ENT001,John Smith,123 Main St"""
 
         assert len(records) == 1
         assert len(errors) == 0
-        assert records[0]['street_address'] == '123 Main St'
-        assert 'address' not in records[0]
+        assert records[0]["street_address"] == "123 Main St"
+        assert "address" not in records[0]
 
     def test_optional_fields_can_be_empty(self, test_user):
         """Optional fields (email, phone, address) can be empty."""
@@ -320,9 +320,9 @@ ENT001,John Smith,,,"""
 
         assert len(records) == 1
         assert len(errors) == 0
-        assert records[0]['email'] == ''
-        assert records[0]['phone'] == ''
-        assert records[0]['street_address'] == ''
+        assert records[0]["email"] == ""
+        assert records[0]["phone"] == ""
+        assert records[0]["street_address"] == ""
 
     def test_whitespace_is_trimmed(self, test_user):
         """Whitespace in values should be trimmed."""
@@ -333,10 +333,10 @@ ENT001,John Smith,,,"""
 
         assert len(records) == 1
         assert len(errors) == 0
-        assert records[0]['entity_id'] == 'ENT001'
-        assert records[0]['first_name'] == 'John'
-        assert records[0]['last_name'] == 'Smith'
-        assert records[0]['email'] == 'john@example.com'
+        assert records[0]["entity_id"] == "ENT001"
+        assert records[0]["first_name"] == "John"
+        assert records[0]["last_name"] == "Smith"
+        assert records[0]["email"] == "john@example.com"
 
     def test_empty_csv_returns_empty_lists(self, test_user):
         """Empty CSV should return empty lists."""
@@ -368,10 +368,22 @@ class TestImportEntities:
     def test_creates_contacts_with_owner_and_external_id(self, test_user, import_run):
         """Should create contacts with owner=user and external_id."""
         records = [
-            {'entity_id': 'ENT001', 'first_name': 'John', 'last_name': 'Smith',
-             'email': 'john@example.com', 'phone': '555-1234', 'street_address': '123 Main St'},
-            {'entity_id': 'ENT002', 'first_name': 'Jane', 'last_name': 'Doe',
-             'email': 'jane@example.com', 'phone': '555-5678', 'street_address': '456 Oak Ave'},
+            {
+                "entity_id": "ENT001",
+                "first_name": "John",
+                "last_name": "Smith",
+                "email": "john@example.com",
+                "phone": "555-1234",
+                "street_address": "123 Main St",
+            },
+            {
+                "entity_id": "ENT002",
+                "first_name": "Jane",
+                "last_name": "Doe",
+                "email": "jane@example.com",
+                "phone": "555-5678",
+                "street_address": "456 Oak Ave",
+            },
         ]
 
         created, updated = import_entities(records, test_user, import_run)
@@ -380,13 +392,13 @@ class TestImportEntities:
         assert updated == 0
         assert Contact.objects.count() == 2
 
-        contact1 = Contact.objects.get(external_id='ENT001')
+        contact1 = Contact.objects.get(external_id="ENT001")
         assert contact1.owner == test_user
-        assert contact1.first_name == 'John'
-        assert contact1.last_name == 'Smith'
-        assert contact1.email == 'john@example.com'
-        assert contact1.phone == '555-1234'
-        assert contact1.street_address == '123 Main St'
+        assert contact1.first_name == "John"
+        assert contact1.last_name == "Smith"
+        assert contact1.email == "john@example.com"
+        assert contact1.phone == "555-1234"
+        assert contact1.street_address == "123 Main St"
 
         import_run.refresh_from_db()
         assert import_run.created_count == 2
@@ -398,15 +410,21 @@ class TestImportEntities:
         # Create existing contact
         Contact.objects.create(
             owner=test_user,
-            external_id='ENT001',
-            first_name='Old',
-            last_name='Name',
-            email='old@example.com'
+            external_id="ENT001",
+            first_name="Old",
+            last_name="Name",
+            email="old@example.com",
         )
 
         records = [
-            {'entity_id': 'ENT001', 'first_name': 'John', 'last_name': 'Smith',
-             'email': 'john@example.com', 'phone': '555-1234', 'street_address': '123 Main St'},
+            {
+                "entity_id": "ENT001",
+                "first_name": "John",
+                "last_name": "Smith",
+                "email": "john@example.com",
+                "phone": "555-1234",
+                "street_address": "123 Main St",
+            },
         ]
 
         created, updated = import_entities(records, test_user, import_run)
@@ -415,11 +433,11 @@ class TestImportEntities:
         assert updated == 1
         assert Contact.objects.count() == 1
 
-        contact = Contact.objects.get(external_id='ENT001')
+        contact = Contact.objects.get(external_id="ENT001")
         assert contact.owner == test_user
-        assert contact.first_name == 'John'
-        assert contact.last_name == 'Smith'
-        assert contact.email == 'john@example.com'
+        assert contact.first_name == "John"
+        assert contact.last_name == "Smith"
+        assert contact.email == "john@example.com"
 
         import_run.refresh_from_db()
         assert import_run.created_count == 0
@@ -431,17 +449,29 @@ class TestImportEntities:
         # Create existing contact
         Contact.objects.create(
             owner=test_user,
-            external_id='ENT001',
-            first_name='Old',
-            last_name='Name',
-            email='old@example.com'
+            external_id="ENT001",
+            first_name="Old",
+            last_name="Name",
+            email="old@example.com",
         )
 
         records = [
-            {'entity_id': 'ENT001', 'first_name': 'John', 'last_name': 'Smith',
-             'email': 'john@example.com', 'phone': '', 'street_address': ''},
-            {'entity_id': 'ENT002', 'first_name': 'Jane', 'last_name': 'Doe',
-             'email': 'jane@example.com', 'phone': '', 'street_address': ''},
+            {
+                "entity_id": "ENT001",
+                "first_name": "John",
+                "last_name": "Smith",
+                "email": "john@example.com",
+                "phone": "",
+                "street_address": "",
+            },
+            {
+                "entity_id": "ENT002",
+                "first_name": "Jane",
+                "last_name": "Doe",
+                "email": "jane@example.com",
+                "phone": "",
+                "street_address": "",
+            },
         ]
 
         created, updated = import_entities(records, test_user, import_run)
@@ -454,21 +484,29 @@ class TestImportEntities:
         assert import_run.created_count == 1
         assert import_run.updated_count == 1
 
-    def test_does_not_update_owner_field_on_existing_contacts(self, test_user, admin_user, import_run):
+    def test_does_not_update_owner_field_on_existing_contacts(
+        self, test_user, admin_user, import_run
+    ):
         """Should NOT update owner field on existing contacts."""
         # Create existing contact owned by test_user
         existing = Contact.objects.create(
             owner=test_user,
-            external_id='ENT001',
-            first_name='Old',
-            last_name='Name',
-            email='old@example.com'
+            external_id="ENT001",
+            first_name="Old",
+            last_name="Name",
+            email="old@example.com",
         )
 
         # Try to import with different user (should still match on owner+external_id)
         records = [
-            {'entity_id': 'ENT001', 'first_name': 'Updated', 'last_name': 'Name',
-             'email': 'updated@example.com', 'phone': '', 'street_address': ''},
+            {
+                "entity_id": "ENT001",
+                "first_name": "Updated",
+                "last_name": "Name",
+                "email": "updated@example.com",
+                "phone": "",
+                "street_address": "",
+            },
         ]
 
         created, updated = import_entities(records, test_user, import_run)
@@ -476,13 +514,19 @@ class TestImportEntities:
         assert updated == 1
         existing.refresh_from_db()
         assert existing.owner == test_user  # Owner should NOT change
-        assert existing.first_name == 'Updated'  # But other fields should update
+        assert existing.first_name == "Updated"  # But other fields should update
 
     def test_sets_import_run_status_to_completed(self, test_user, import_run):
         """Should set ImportRun status to COMPLETED after import."""
         records = [
-            {'entity_id': 'ENT001', 'first_name': 'John', 'last_name': 'Smith',
-             'email': '', 'phone': '', 'street_address': ''},
+            {
+                "entity_id": "ENT001",
+                "first_name": "John",
+                "last_name": "Smith",
+                "email": "",
+                "phone": "",
+                "street_address": "",
+            },
         ]
 
         import_entities(records, test_user, import_run)
@@ -494,27 +538,45 @@ class TestImportEntities:
         """Should handle mixed create/update batch correctly."""
         # Create existing contacts
         Contact.objects.create(
-            owner=test_user,
-            external_id='ENT001',
-            first_name='Old1',
-            last_name='Name1'
+            owner=test_user, external_id="ENT001", first_name="Old1", last_name="Name1"
         )
         Contact.objects.create(
-            owner=test_user,
-            external_id='ENT003',
-            first_name='Old3',
-            last_name='Name3'
+            owner=test_user, external_id="ENT003", first_name="Old3", last_name="Name3"
         )
 
         records = [
-            {'entity_id': 'ENT001', 'first_name': 'Updated1', 'last_name': 'Name1',
-             'email': '', 'phone': '', 'street_address': ''},
-            {'entity_id': 'ENT002', 'first_name': 'New2', 'last_name': 'Name2',
-             'email': '', 'phone': '', 'street_address': ''},
-            {'entity_id': 'ENT003', 'first_name': 'Updated3', 'last_name': 'Name3',
-             'email': '', 'phone': '', 'street_address': ''},
-            {'entity_id': 'ENT004', 'first_name': 'New4', 'last_name': 'Name4',
-             'email': '', 'phone': '', 'street_address': ''},
+            {
+                "entity_id": "ENT001",
+                "first_name": "Updated1",
+                "last_name": "Name1",
+                "email": "",
+                "phone": "",
+                "street_address": "",
+            },
+            {
+                "entity_id": "ENT002",
+                "first_name": "New2",
+                "last_name": "Name2",
+                "email": "",
+                "phone": "",
+                "street_address": "",
+            },
+            {
+                "entity_id": "ENT003",
+                "first_name": "Updated3",
+                "last_name": "Name3",
+                "email": "",
+                "phone": "",
+                "street_address": "",
+            },
+            {
+                "entity_id": "ENT004",
+                "first_name": "New4",
+                "last_name": "Name4",
+                "email": "",
+                "phone": "",
+                "street_address": "",
+            },
         ]
 
         created, updated = import_entities(records, test_user, import_run)
@@ -526,8 +588,14 @@ class TestImportEntities:
     def test_multiple_imports_same_entity_id_updates_not_duplicates(self, test_user, import_run):
         """Multiple imports of same entity_id should update, not create duplicates."""
         records1 = [
-            {'entity_id': 'ENT001', 'first_name': 'John', 'last_name': 'Smith',
-             'email': 'john@example.com', 'phone': '', 'street_address': ''},
+            {
+                "entity_id": "ENT001",
+                "first_name": "John",
+                "last_name": "Smith",
+                "email": "john@example.com",
+                "phone": "",
+                "street_address": "",
+            },
         ]
 
         # First import
@@ -539,13 +607,19 @@ class TestImportEntities:
         import_run2 = ImportRun.objects.create(
             type=ImportType.ENTITIES,
             status=ImportStatus.PENDING,
-            filename='test2.csv',
-            uploaded_by=test_user
+            filename="test2.csv",
+            uploaded_by=test_user,
         )
 
         records2 = [
-            {'entity_id': 'ENT001', 'first_name': 'John', 'last_name': 'Updated',
-             'email': 'updated@example.com', 'phone': '', 'street_address': ''},
+            {
+                "entity_id": "ENT001",
+                "first_name": "John",
+                "last_name": "Updated",
+                "email": "updated@example.com",
+                "phone": "",
+                "street_address": "",
+            },
         ]
 
         created2, updated2 = import_entities(records2, test_user, import_run2)
@@ -554,9 +628,9 @@ class TestImportEntities:
 
         # Should only have one contact
         assert Contact.objects.filter(owner=test_user).count() == 1
-        contact = Contact.objects.get(owner=test_user, external_id='ENT001')
-        assert contact.last_name == 'Updated'
-        assert contact.email == 'updated@example.com'
+        contact = Contact.objects.get(owner=test_user, external_id="ENT001")
+        assert contact.last_name == "Updated"
+        assert contact.email == "updated@example.com"
 
 
 @pytest.mark.django_db
@@ -571,16 +645,16 @@ ENT001,John Smith,john@example.com
 ENT002,Jane Doe,jane@example.com"""
 
         csv_file = io.BytesIO(csv_content)
-        csv_file.name = 'entities.csv'
+        csv_file.name = "entities.csv"
 
-        url = reverse('imports:import-entities')
-        response = api_client.post(url, {'file': csv_file}, format='multipart')
+        url = reverse("imports:import-entities")
+        response = api_client.post(url, {"file": csv_file}, format="multipart")
 
         assert response.status_code == status.HTTP_200_OK
-        assert response.data['created_count'] == 2
-        assert response.data['updated_count'] == 0
-        assert response.data['error_count'] == 0
-        assert 'import_run_id' in response.data
+        assert response.data["created_count"] == 2
+        assert response.data["updated_count"] == 0
+        assert response.data["error_count"] == 0
+        assert "import_run_id" in response.data
         assert Contact.objects.count() == 2
 
     def test_non_admin_receives_403(self, api_client, test_user):
@@ -590,10 +664,10 @@ ENT002,Jane Doe,jane@example.com"""
 ENT001,John Smith"""
 
         csv_file = io.BytesIO(csv_content)
-        csv_file.name = 'entities.csv'
+        csv_file.name = "entities.csv"
 
-        url = reverse('imports:import-entities')
-        response = api_client.post(url, {'file': csv_file}, format='multipart')
+        url = reverse("imports:import-entities")
+        response = api_client.post(url, {"file": csv_file}, format="multipart")
 
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
@@ -601,11 +675,11 @@ ENT001,John Smith"""
         """POST without file should return 400 with detail message."""
         api_client.force_authenticate(user=admin_user)
 
-        url = reverse('imports:import-entities')
-        response = api_client.post(url, {}, format='multipart')
+        url = reverse("imports:import-entities")
+        response = api_client.post(url, {}, format="multipart")
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert response.data['detail'] == 'No file provided.'
+        assert response.data["detail"] == "No file provided."
 
     def test_non_csv_file_returns_400(self, api_client, admin_user):
         """POST with non-CSV file should return 400."""
@@ -613,13 +687,13 @@ ENT001,John Smith"""
         txt_content = b"This is a text file"
 
         txt_file = io.BytesIO(txt_content)
-        txt_file.name = 'entities.txt'
+        txt_file.name = "entities.txt"
 
-        url = reverse('imports:import-entities')
-        response = api_client.post(url, {'file': txt_file}, format='multipart')
+        url = reverse("imports:import-entities")
+        response = api_client.post(url, {"file": txt_file}, format="multipart")
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert response.data['detail'] == 'File must be a CSV.'
+        assert response.data["detail"] == "File must be a CSV."
 
     def test_validation_errors_return_error_details(self, api_client, admin_user):
         """POST CSV with invalid rows should return error details."""
@@ -629,17 +703,17 @@ ENT001,John Smith"""
 ENT002,Jane Doe,not-an-email"""
 
         csv_file = io.BytesIO(csv_content)
-        csv_file.name = 'entities.csv'
+        csv_file.name = "entities.csv"
 
-        url = reverse('imports:import-entities')
-        response = api_client.post(url, {'file': csv_file}, format='multipart')
+        url = reverse("imports:import-entities")
+        response = api_client.post(url, {"file": csv_file}, format="multipart")
 
         assert response.status_code == status.HTTP_200_OK
-        assert response.data['created_count'] == 0
-        assert response.data['error_count'] == 2
-        assert len(response.data['errors']) == 2
-        assert any('entity_id is required' in str(err['errors']) for err in response.data['errors'])
-        assert any('Invalid email format' in str(err['errors']) for err in response.data['errors'])
+        assert response.data["created_count"] == 0
+        assert response.data["error_count"] == 2
+        assert len(response.data["errors"]) == 2
+        assert any("entity_id is required" in str(err["errors"]) for err in response.data["errors"])
+        assert any("Invalid email format" in str(err["errors"]) for err in response.data["errors"])
 
     def test_validate_only_dry_run(self, api_client, admin_user):
         """POST with ?validate_only=true should not create DB records."""
@@ -649,27 +723,24 @@ ENT001,John Smith,john@example.com
 ENT002,Jane Doe,jane@example.com"""
 
         csv_file = io.BytesIO(csv_content)
-        csv_file.name = 'entities.csv'
+        csv_file.name = "entities.csv"
 
-        url = reverse('imports:import-entities') + '?validate_only=true'
-        response = api_client.post(url, {'file': csv_file}, format='multipart')
+        url = reverse("imports:import-entities") + "?validate_only=true"
+        response = api_client.post(url, {"file": csv_file}, format="multipart")
 
         assert response.status_code == status.HTTP_200_OK
-        assert response.data['valid_count'] == 2
-        assert response.data['error_count'] == 0
+        assert response.data["valid_count"] == 2
+        assert response.data["error_count"] == 0
         # No DB records created
         assert Contact.objects.count() == 0
         # No import_run_id in response for validate_only
-        assert 'import_run_id' not in response.data
+        assert "import_run_id" not in response.data
 
     def test_successful_import_returns_counts(self, api_client, admin_user):
         """Successful import should return created_count and updated_count."""
         # Create existing contact
         Contact.objects.create(
-            owner=admin_user,
-            external_id='ENT001',
-            first_name='Old',
-            last_name='Name'
+            owner=admin_user, external_id="ENT001", first_name="Old", last_name="Name"
         )
 
         api_client.force_authenticate(user=admin_user)
@@ -678,15 +749,15 @@ ENT001,John Smith Updated,john@example.com
 ENT002,Jane Doe,jane@example.com"""
 
         csv_file = io.BytesIO(csv_content)
-        csv_file.name = 'entities.csv'
+        csv_file.name = "entities.csv"
 
-        url = reverse('imports:import-entities')
-        response = api_client.post(url, {'file': csv_file}, format='multipart')
+        url = reverse("imports:import-entities")
+        response = api_client.post(url, {"file": csv_file}, format="multipart")
 
         assert response.status_code == status.HTTP_200_OK
-        assert response.data['created_count'] == 1
-        assert response.data['updated_count'] == 1
-        assert response.data['error_count'] == 0
+        assert response.data["created_count"] == 1
+        assert response.data["updated_count"] == 1
+        assert response.data["error_count"] == 0
         assert Contact.objects.count() == 2
 
     def test_import_creates_import_run_record(self, api_client, admin_user):
@@ -696,18 +767,18 @@ ENT002,Jane Doe,jane@example.com"""
 ENT001,John Smith"""
 
         csv_file = io.BytesIO(csv_content)
-        csv_file.name = 'entities.csv'
+        csv_file.name = "entities.csv"
 
-        url = reverse('imports:import-entities')
-        response = api_client.post(url, {'file': csv_file}, format='multipart')
+        url = reverse("imports:import-entities")
+        response = api_client.post(url, {"file": csv_file}, format="multipart")
 
         assert response.status_code == status.HTTP_200_OK
 
         # Verify ImportRun exists
-        import_run = ImportRun.objects.get(id=response.data['import_run_id'])
+        import_run = ImportRun.objects.get(id=response.data["import_run_id"])
         assert import_run.type == ImportType.ENTITIES
         assert import_run.status == ImportStatus.COMPLETED
-        assert import_run.filename == 'entities.csv'
+        assert import_run.filename == "entities.csv"
         assert import_run.uploaded_by == admin_user
         assert import_run.created_count == 1
         assert import_run.updated_count == 0
@@ -716,21 +787,21 @@ ENT001,John Smith"""
         """CSV with UTF-8 BOM should parse correctly."""
         api_client.force_authenticate(user=admin_user)
         # UTF-8 BOM followed by CSV content
-        csv_content = b'\xef\xbb\xbfentity_id,name,email\nENT001,John Smith,john@example.com'
+        csv_content = b"\xef\xbb\xbfentity_id,name,email\nENT001,John Smith,john@example.com"
 
         csv_file = io.BytesIO(csv_content)
-        csv_file.name = 'entities.csv'
+        csv_file.name = "entities.csv"
 
-        url = reverse('imports:import-entities')
-        response = api_client.post(url, {'file': csv_file}, format='multipart')
+        url = reverse("imports:import-entities")
+        response = api_client.post(url, {"file": csv_file}, format="multipart")
 
         assert response.status_code == status.HTTP_200_OK
-        assert response.data['created_count'] == 1
-        assert response.data['error_count'] == 0
+        assert response.data["created_count"] == 1
+        assert response.data["error_count"] == 0
         # Verify contact was created correctly
-        contact = Contact.objects.get(external_id='ENT001')
-        assert contact.first_name == 'John'
-        assert contact.last_name == 'Smith'
+        contact = Contact.objects.get(external_id="ENT001")
+        assert contact.first_name == "John"
+        assert contact.last_name == "Smith"
 
     def test_import_run_id_in_response(self, api_client, admin_user):
         """Response should include import_run_id."""
@@ -739,36 +810,36 @@ ENT001,John Smith"""
 ENT001,John Smith"""
 
         csv_file = io.BytesIO(csv_content)
-        csv_file.name = 'entities.csv'
+        csv_file.name = "entities.csv"
 
-        url = reverse('imports:import-entities')
-        response = api_client.post(url, {'file': csv_file}, format='multipart')
+        url = reverse("imports:import-entities")
+        response = api_client.post(url, {"file": csv_file}, format="multipart")
 
         assert response.status_code == status.HTTP_200_OK
-        assert 'import_run_id' in response.data
-        assert response.data['import_run_id'] is not None
+        assert "import_run_id" in response.data
+        assert response.data["import_run_id"] is not None
 
     def test_template_download(self, api_client, admin_user):
         """GET /templates/entities/ should return CSV template."""
         api_client.force_authenticate(user=admin_user)
 
-        url = reverse('imports:template-entities')
+        url = reverse("imports:template-entities")
         response = api_client.get(url)
 
         assert response.status_code == status.HTTP_200_OK
-        assert response['Content-Type'] == 'text/csv'
-        assert response['Content-Disposition'] == 'attachment; filename="entities_template.csv"'
+        assert response["Content-Type"] == "text/csv"
+        assert response["Content-Disposition"] == 'attachment; filename="entities_template.csv"'
         # Verify template content
-        content = response.content.decode('utf-8')
-        assert 'entity_id' in content
-        assert 'name' in content
-        assert 'email' in content
+        content = response.content.decode("utf-8")
+        assert "entity_id" in content
+        assert "name" in content
+        assert "email" in content
 
     def test_template_requires_admin(self, api_client, test_user):
         """Non-admin should get 403 on template download."""
         api_client.force_authenticate(user=test_user)
 
-        url = reverse('imports:template-entities')
+        url = reverse("imports:template-entities")
         response = api_client.get(url)
 
         assert response.status_code == status.HTTP_403_FORBIDDEN

--- a/apps/imports/tests/test_fund_import.py
+++ b/apps/imports/tests/test_fund_import.py
@@ -2,14 +2,17 @@
 Tests for Fund CSV import functionality.
 """
 import io
-import pytest
+
 from django.contrib.auth import get_user_model
 from django.urls import reverse
+
 from rest_framework import status
 from rest_framework.test import APIClient
 
-from apps.imports.models import Fund, ImportRun, ImportType, ImportStatus
-from apps.imports.services import parse_funds_csv, import_funds
+import pytest
+
+from apps.imports.models import Fund, ImportRun, ImportStatus, ImportType
+from apps.imports.services import import_funds, parse_funds_csv
 
 User = get_user_model()
 
@@ -18,10 +21,7 @@ User = get_user_model()
 def test_user(db):
     """Create a test user."""
     return User.objects.create_user(
-        email='test@example.com',
-        password='testpass123',
-        first_name='Test',
-        last_name='User'
+        email="test@example.com", password="testpass123", first_name="Test", last_name="User"
     )
 
 
@@ -29,11 +29,11 @@ def test_user(db):
 def admin_user(db):
     """Create an admin user."""
     return User.objects.create_user(
-        email='admin@example.com',
-        password='adminpass123',
-        first_name='Admin',
-        last_name='User',
-        role='admin'
+        email="admin@example.com",
+        password="adminpass123",
+        first_name="Admin",
+        last_name="User",
+        role="admin",
     )
 
 
@@ -49,8 +49,8 @@ def import_run(test_user):
     return ImportRun.objects.create(
         type=ImportType.FUNDS,
         status=ImportStatus.PENDING,
-        filename='test_funds.csv',
-        uploaded_by=test_user
+        filename="test_funds.csv",
+        uploaded_by=test_user,
     )
 
 
@@ -67,12 +67,12 @@ FUND002,Special Projects,inactive"""
 
         assert len(records) == 2
         assert len(errors) == 0
-        assert records[0]['fund_id'] == 'FUND001'
-        assert records[0]['name'] == 'General Ministry'
-        assert records[0]['status'] == 'active'
-        assert records[1]['fund_id'] == 'FUND002'
-        assert records[1]['name'] == 'Special Projects'
-        assert records[1]['status'] == 'inactive'
+        assert records[0]["fund_id"] == "FUND001"
+        assert records[0]["name"] == "General Ministry"
+        assert records[0]["status"] == "active"
+        assert records[1]["fund_id"] == "FUND002"
+        assert records[1]["name"] == "Special Projects"
+        assert records[1]["status"] == "inactive"
 
     def test_missing_fund_id_returns_error(self):
         """Missing fund_id should return error."""
@@ -83,8 +83,8 @@ FUND002,Special Projects,inactive"""
 
         assert len(records) == 0
         assert len(errors) == 1
-        assert errors[0]['row'] == 2
-        assert 'fund_id is required' in errors[0]['errors'][0]
+        assert errors[0]["row"] == 2
+        assert "fund_id is required" in errors[0]["errors"][0]
 
     def test_missing_name_returns_error(self):
         """Missing name should return error."""
@@ -95,8 +95,8 @@ FUND001,,active"""
 
         assert len(records) == 0
         assert len(errors) == 1
-        assert errors[0]['row'] == 2
-        assert 'name is required' in errors[0]['errors'][0]
+        assert errors[0]["row"] == 2
+        assert "name is required" in errors[0]["errors"][0]
 
     def test_missing_status_defaults_to_active(self):
         """Missing status should default to 'active'."""
@@ -107,7 +107,7 @@ FUND001,General Ministry,"""
 
         assert len(records) == 1
         assert len(errors) == 0
-        assert records[0]['status'] == 'active'
+        assert records[0]["status"] == "active"
 
     def test_invalid_status_returns_error(self):
         """Invalid status should return error."""
@@ -118,8 +118,8 @@ FUND001,General Ministry,invalid_status"""
 
         assert len(records) == 0
         assert len(errors) == 1
-        assert errors[0]['row'] == 2
-        assert 'Invalid status' in errors[0]['errors'][0]
+        assert errors[0]["row"] == 2
+        assert "Invalid status" in errors[0]["errors"][0]
 
     def test_status_is_case_insensitive(self):
         """Status validation should be case-insensitive."""
@@ -132,9 +132,9 @@ FUND003,Old Fund,CLOSED"""
 
         assert len(records) == 3
         assert len(errors) == 0
-        assert records[0]['status'] == 'active'
-        assert records[1]['status'] == 'inactive'
-        assert records[2]['status'] == 'closed'
+        assert records[0]["status"] == "active"
+        assert records[1]["status"] == "inactive"
+        assert records[2]["status"] == "closed"
 
     def test_duplicate_fund_id_in_file_returns_error(self):
         """Duplicate fund_id in same file should return error."""
@@ -146,12 +146,12 @@ FUND001,Duplicate Fund,active"""
 
         assert len(records) == 1  # First one is valid
         assert len(errors) == 1  # Second one errors
-        assert errors[0]['row'] == 3
-        assert 'Duplicate fund_id' in errors[0]['errors'][0]
+        assert errors[0]["row"] == 3
+        assert "Duplicate fund_id" in errors[0]["errors"][0]
 
     def test_fund_id_exceeds_max_length_returns_error(self):
         """fund_id exceeding 100 characters should return error."""
-        long_fund_id = 'F' * 101
+        long_fund_id = "F" * 101
         csv_content = f"""fund_id,name,status
 {long_fund_id},General Ministry,active"""
 
@@ -159,12 +159,12 @@ FUND001,Duplicate Fund,active"""
 
         assert len(records) == 0
         assert len(errors) == 1
-        assert errors[0]['row'] == 2
-        assert 'fund_id exceeds maximum length' in errors[0]['errors'][0]
+        assert errors[0]["row"] == 2
+        assert "fund_id exceeds maximum length" in errors[0]["errors"][0]
 
     def test_name_exceeds_max_length_returns_error(self):
         """name exceeding 255 characters should return error."""
-        long_name = 'N' * 256
+        long_name = "N" * 256
         csv_content = f"""fund_id,name,status
 FUND001,{long_name},active"""
 
@@ -172,8 +172,8 @@ FUND001,{long_name},active"""
 
         assert len(records) == 0
         assert len(errors) == 1
-        assert errors[0]['row'] == 2
-        assert 'name exceeds maximum length' in errors[0]['errors'][0]
+        assert errors[0]["row"] == 2
+        assert "name exceeds maximum length" in errors[0]["errors"][0]
 
     def test_missing_required_column_header_returns_error(self):
         """Missing required column header should return error."""
@@ -184,8 +184,8 @@ FUND001,active"""
 
         assert len(records) == 0
         assert len(errors) == 1
-        assert 'Missing required column' in errors[0]['errors'][0]
-        assert 'name' in errors[0]['errors'][0]
+        assert "Missing required column" in errors[0]["errors"][0]
+        assert "name" in errors[0]["errors"][0]
 
     def test_empty_csv_returns_empty_lists(self):
         """Empty CSV should return empty lists."""
@@ -205,9 +205,9 @@ FUND001,active"""
 
         assert len(records) == 1
         assert len(errors) == 0
-        assert records[0]['fund_id'] == 'FUND001'
-        assert records[0]['name'] == 'General Ministry'
-        assert records[0]['status'] == 'active'
+        assert records[0]["fund_id"] == "FUND001"
+        assert records[0]["name"] == "General Ministry"
+        assert records[0]["status"] == "active"
 
     def test_fund_id_starting_with_formula_characters_rejected(self):
         """fund_id starting with formula characters should be rejected."""
@@ -222,7 +222,7 @@ FUND001,active"""
         assert len(records) == 0
         assert len(errors) == 4
         for error in errors:
-            assert 'formula character' in error['errors'][0].lower()
+            assert "formula character" in error["errors"][0].lower()
 
     def test_name_starting_with_formula_characters_rejected(self):
         """name starting with formula characters should be rejected."""
@@ -237,7 +237,7 @@ FUND004,@Also Bad,active"""
         assert len(records) == 0
         assert len(errors) == 4
         for error in errors:
-            assert 'formula character' in error['errors'][0].lower()
+            assert "formula character" in error["errors"][0].lower()
 
 
 class TestImportFunds:
@@ -246,8 +246,8 @@ class TestImportFunds:
     def test_creates_new_funds(self, import_run):
         """Should create new funds from records."""
         records = [
-            {'fund_id': 'FUND001', 'name': 'General Ministry', 'status': 'active'},
-            {'fund_id': 'FUND002', 'name': 'Special Projects', 'status': 'inactive'},
+            {"fund_id": "FUND001", "name": "General Ministry", "status": "active"},
+            {"fund_id": "FUND002", "name": "Special Projects", "status": "inactive"},
         ]
 
         created, updated = import_funds(records, import_run)
@@ -256,9 +256,9 @@ class TestImportFunds:
         assert updated == 0
         assert Fund.objects.count() == 2
 
-        fund1 = Fund.objects.get(external_id='FUND001')
-        assert fund1.name == 'General Ministry'
-        assert fund1.status == 'active'
+        fund1 = Fund.objects.get(external_id="FUND001")
+        assert fund1.name == "General Ministry"
+        assert fund1.status == "active"
         assert fund1.owner is None
 
         # Check ImportRun was updated
@@ -270,14 +270,10 @@ class TestImportFunds:
     def test_updates_existing_funds_matching_external_id(self, import_run):
         """Should update existing funds based on external_id."""
         # Create existing fund
-        Fund.objects.create(
-            external_id='FUND001',
-            name='Old Name',
-            status='inactive'
-        )
+        Fund.objects.create(external_id="FUND001", name="Old Name", status="inactive")
 
         records = [
-            {'fund_id': 'FUND001', 'name': 'Updated Name', 'status': 'active'},
+            {"fund_id": "FUND001", "name": "Updated Name", "status": "active"},
         ]
 
         created, updated = import_funds(records, import_run)
@@ -286,9 +282,9 @@ class TestImportFunds:
         assert updated == 1
         assert Fund.objects.count() == 1
 
-        fund = Fund.objects.get(external_id='FUND001')
-        assert fund.name == 'Updated Name'
-        assert fund.status == 'active'
+        fund = Fund.objects.get(external_id="FUND001")
+        assert fund.name == "Updated Name"
+        assert fund.status == "active"
 
         # Check ImportRun was updated
         import_run.refresh_from_db()
@@ -299,15 +295,11 @@ class TestImportFunds:
     def test_mixed_create_update_works_correctly(self, import_run):
         """Should handle mix of creates and updates correctly."""
         # Create existing fund
-        Fund.objects.create(
-            external_id='FUND001',
-            name='Old Name',
-            status='inactive'
-        )
+        Fund.objects.create(external_id="FUND001", name="Old Name", status="inactive")
 
         records = [
-            {'fund_id': 'FUND001', 'name': 'Updated Name', 'status': 'active'},
-            {'fund_id': 'FUND002', 'name': 'New Fund', 'status': 'active'},
+            {"fund_id": "FUND001", "name": "Updated Name", "status": "active"},
+            {"fund_id": "FUND002", "name": "New Fund", "status": "active"},
         ]
 
         created, updated = import_funds(records, import_run)
@@ -325,7 +317,7 @@ class TestImportFunds:
     def test_updates_import_run_counts(self, import_run):
         """Should update ImportRun counts accurately."""
         records = [
-            {'fund_id': 'FUND001', 'name': 'General Ministry', 'status': 'active'},
+            {"fund_id": "FUND001", "name": "General Ministry", "status": "active"},
         ]
 
         created, updated = import_funds(records, import_run)
@@ -352,12 +344,12 @@ class TestImportFunds:
     def test_fund_owner_is_null(self, import_run):
         """Funds should be created with null owner (org-wide)."""
         records = [
-            {'fund_id': 'FUND001', 'name': 'General Ministry', 'status': 'active'},
+            {"fund_id": "FUND001", "name": "General Ministry", "status": "active"},
         ]
 
         created, updated = import_funds(records, import_run)
 
-        fund = Fund.objects.get(external_id='FUND001')
+        fund = Fund.objects.get(external_id="FUND001")
         assert fund.owner is None
 
 
@@ -373,21 +365,21 @@ FUND001,General Ministry,active
 FUND002,Special Projects,inactive"""
 
         csv_file = io.BytesIO(csv_content)
-        csv_file.name = 'funds.csv'
+        csv_file.name = "funds.csv"
 
-        url = reverse('imports:import-funds')
-        response = api_client.post(url, {'file': csv_file}, format='multipart')
+        url = reverse("imports:import-funds")
+        response = api_client.post(url, {"file": csv_file}, format="multipart")
 
         assert response.status_code == status.HTTP_200_OK
-        assert response.data['created_count'] == 2
-        assert response.data['updated_count'] == 0
-        assert response.data['error_count'] == 0
-        assert 'import_run_id' in response.data
+        assert response.data["created_count"] == 2
+        assert response.data["updated_count"] == 0
+        assert response.data["error_count"] == 0
+        assert "import_run_id" in response.data
 
         # Verify funds were created
         assert Fund.objects.count() == 2
-        assert Fund.objects.filter(external_id='FUND001').exists()
-        assert Fund.objects.filter(external_id='FUND002').exists()
+        assert Fund.objects.filter(external_id="FUND001").exists()
+        assert Fund.objects.filter(external_id="FUND002").exists()
 
         # Verify ImportRun was created
         assert ImportRun.objects.count() == 1
@@ -404,10 +396,10 @@ FUND002,Special Projects,inactive"""
 FUND001,General Ministry,active"""
 
         csv_file = io.BytesIO(csv_content)
-        csv_file.name = 'funds.csv'
+        csv_file.name = "funds.csv"
 
-        url = reverse('imports:import-funds')
-        response = api_client.post(url, {'file': csv_file}, format='multipart')
+        url = reverse("imports:import-funds")
+        response = api_client.post(url, {"file": csv_file}, format="multipart")
 
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
@@ -415,24 +407,24 @@ FUND001,General Ministry,active"""
         """Missing file returns 400 with 'No file provided' message."""
         api_client.force_authenticate(user=admin_user)
 
-        url = reverse('imports:import-funds')
-        response = api_client.post(url, {}, format='multipart')
+        url = reverse("imports:import-funds")
+        response = api_client.post(url, {}, format="multipart")
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert 'No file provided' in response.data['detail']
+        assert "No file provided" in response.data["detail"]
 
     def test_non_csv_file_returns_400(self, api_client, admin_user):
         """Non-CSV file returns 400 with 'File must be a CSV' message."""
         api_client.force_authenticate(user=admin_user)
 
         txt_file = io.BytesIO(b"not a csv")
-        txt_file.name = 'funds.txt'
+        txt_file.name = "funds.txt"
 
-        url = reverse('imports:import-funds')
-        response = api_client.post(url, {'file': txt_file}, format='multipart')
+        url = reverse("imports:import-funds")
+        response = api_client.post(url, {"file": txt_file}, format="multipart")
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert 'File must be a CSV' in response.data['detail']
+        assert "File must be a CSV" in response.data["detail"]
 
     def test_validation_errors_return_400_with_details(self, api_client, admin_user):
         """Validation errors return 400 with error details and row numbers."""
@@ -444,19 +436,19 @@ FUND002,,active
 FUND003,Special Projects,invalid_status"""
 
         csv_file = io.BytesIO(csv_content)
-        csv_file.name = 'funds.csv'
+        csv_file.name = "funds.csv"
 
-        url = reverse('imports:import-funds')
-        response = api_client.post(url, {'file': csv_file}, format='multipart')
+        url = reverse("imports:import-funds")
+        response = api_client.post(url, {"file": csv_file}, format="multipart")
 
         assert response.status_code == status.HTTP_200_OK
-        assert response.data['created_count'] == 0
-        assert response.data['error_count'] == 3
-        assert len(response.data['errors']) == 3
+        assert response.data["created_count"] == 0
+        assert response.data["error_count"] == 3
+        assert len(response.data["errors"]) == 3
 
         # Check error structure includes row numbers
-        assert response.data['errors'][0]['row'] == 2
-        assert 'fund_id is required' in response.data['errors'][0]['errors'][0]
+        assert response.data["errors"][0]["row"] == 2
+        assert "fund_id is required" in response.data["errors"][0]["errors"][0]
 
     def test_validate_only_dry_run(self, api_client, admin_user):
         """validate_only=true performs dry-run validation without importing."""
@@ -467,15 +459,16 @@ FUND001,General Ministry,active
 FUND002,Special Projects,inactive"""
 
         csv_file = io.BytesIO(csv_content)
-        csv_file.name = 'funds.csv'
+        csv_file.name = "funds.csv"
 
-        url = reverse('imports:import-funds')
-        response = api_client.post(url, {'file': csv_file}, format='multipart',
-                                   QUERY_STRING='validate_only=true')
+        url = reverse("imports:import-funds")
+        response = api_client.post(
+            url, {"file": csv_file}, format="multipart", QUERY_STRING="validate_only=true"
+        )
 
         assert response.status_code == status.HTTP_200_OK
-        assert response.data['valid_count'] == 2
-        assert response.data['error_count'] == 0
+        assert response.data["valid_count"] == 2
+        assert response.data["error_count"] == 0
 
         # Verify no funds were created
         assert Fund.objects.count() == 0
@@ -488,27 +481,23 @@ FUND002,Special Projects,inactive"""
         api_client.force_authenticate(user=admin_user)
 
         # Create existing fund
-        Fund.objects.create(
-            external_id='FUND001',
-            name='Old Name',
-            status='inactive'
-        )
+        Fund.objects.create(external_id="FUND001", name="Old Name", status="inactive")
 
         csv_content = b"""fund_id,name,status
 FUND001,Updated Name,active
 FUND002,New Fund,active"""
 
         csv_file = io.BytesIO(csv_content)
-        csv_file.name = 'funds.csv'
+        csv_file.name = "funds.csv"
 
-        url = reverse('imports:import-funds')
-        response = api_client.post(url, {'file': csv_file}, format='multipart')
+        url = reverse("imports:import-funds")
+        response = api_client.post(url, {"file": csv_file}, format="multipart")
 
         assert response.status_code == status.HTTP_200_OK
-        assert response.data['created_count'] == 1
-        assert response.data['updated_count'] == 1
-        assert response.data['error_count'] == 0
-        assert 'import_run_id' in response.data
+        assert response.data["created_count"] == 1
+        assert response.data["updated_count"] == 1
+        assert response.data["error_count"] == 0
+        assert "import_run_id" in response.data
 
     def test_import_creates_audit_record(self, api_client, admin_user):
         """Import creates ImportRun audit record."""
@@ -518,10 +507,10 @@ FUND002,New Fund,active"""
 FUND001,General Ministry,active"""
 
         csv_file = io.BytesIO(csv_content)
-        csv_file.name = 'test_funds.csv'
+        csv_file.name = "test_funds.csv"
 
-        url = reverse('imports:import-funds')
-        response = api_client.post(url, {'file': csv_file}, format='multipart')
+        url = reverse("imports:import-funds")
+        response = api_client.post(url, {"file": csv_file}, format="multipart")
 
         assert response.status_code == status.HTTP_200_OK
 
@@ -530,7 +519,7 @@ FUND001,General Ministry,active"""
         import_run = ImportRun.objects.first()
         assert import_run.type == ImportType.FUNDS
         assert import_run.status == ImportStatus.COMPLETED
-        assert import_run.filename == 'test_funds.csv'
+        assert import_run.filename == "test_funds.csv"
         assert import_run.uploaded_by == admin_user
         assert import_run.created_count == 1
         assert import_run.updated_count == 0
@@ -544,18 +533,18 @@ FUND001,General Ministry,active"""
 FUND001,General Ministry,active"""
 
         csv_file = io.BytesIO(csv_content)
-        csv_file.name = 'funds.csv'
+        csv_file.name = "funds.csv"
 
-        url = reverse('imports:import-funds')
-        response = api_client.post(url, {'file': csv_file}, format='multipart')
+        url = reverse("imports:import-funds")
+        response = api_client.post(url, {"file": csv_file}, format="multipart")
 
         assert response.status_code == status.HTTP_200_OK
-        assert response.data['created_count'] == 1
-        assert response.data['error_count'] == 0
+        assert response.data["created_count"] == 1
+        assert response.data["error_count"] == 0
 
         # Verify fund was created with correct data
-        fund = Fund.objects.get(external_id='FUND001')
-        assert fund.name == 'General Ministry'
+        fund = Fund.objects.get(external_id="FUND001")
+        assert fund.name == "General Ministry"
 
     def test_import_run_id_in_response(self, api_client, admin_user):
         """Import response includes import_run_id."""
@@ -565,15 +554,15 @@ FUND001,General Ministry,active"""
 FUND001,General Ministry,active"""
 
         csv_file = io.BytesIO(csv_content)
-        csv_file.name = 'funds.csv'
+        csv_file.name = "funds.csv"
 
-        url = reverse('imports:import-funds')
-        response = api_client.post(url, {'file': csv_file}, format='multipart')
+        url = reverse("imports:import-funds")
+        response = api_client.post(url, {"file": csv_file}, format="multipart")
 
         assert response.status_code == status.HTTP_200_OK
-        assert 'import_run_id' in response.data
+        assert "import_run_id" in response.data
 
-        import_run_id = response.data['import_run_id']
+        import_run_id = response.data["import_run_id"]
         assert ImportRun.objects.filter(id=import_run_id).exists()
 
 
@@ -584,19 +573,19 @@ class TestFundTemplateView:
         """Admin user can download funds CSV template."""
         api_client.force_authenticate(user=admin_user)
 
-        url = reverse('imports:template-funds')
+        url = reverse("imports:template-funds")
         response = api_client.get(url)
 
         assert response.status_code == status.HTTP_200_OK
-        assert response['Content-Type'] == 'text/csv'
-        assert 'attachment; filename="funds_template.csv"' in response['Content-Disposition']
-        assert response.content == b'fund_id,name,status\n'
+        assert response["Content-Type"] == "text/csv"
+        assert 'attachment; filename="funds_template.csv"' in response["Content-Disposition"]
+        assert response.content == b"fund_id,name,status\n"
 
     def test_non_admin_cannot_download_template(self, api_client, test_user):
         """Non-admin user receives 403 Forbidden."""
         api_client.force_authenticate(user=test_user)
 
-        url = reverse('imports:template-funds')
+        url = reverse("imports:template-funds")
         response = api_client.get(url)
 
         assert response.status_code == status.HTTP_403_FORBIDDEN

--- a/apps/imports/tests/test_generic_imports.py
+++ b/apps/imports/tests/test_generic_imports.py
@@ -15,7 +15,7 @@ from rest_framework.test import APIClient
 from apps.contacts.models import Contact
 from apps.gifts.models import Gift
 from apps.imports.generic_services import import_generic_contacts, import_generic_donations
-from apps.imports.models import ImportBatch, ImportBatchStatus
+from apps.imports.models import ImportBatchStatus
 from apps.users.models import User, UserRole
 
 

--- a/apps/imports/tests/test_generic_imports.py
+++ b/apps/imports/tests/test_generic_imports.py
@@ -8,15 +8,13 @@ Covers:
 """
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import TestCase
+
 from rest_framework import status
 from rest_framework.test import APIClient
 
 from apps.contacts.models import Contact
 from apps.gifts.models import Gift
-from apps.imports.generic_services import (
-    import_generic_contacts,
-    import_generic_donations,
-)
+from apps.imports.generic_services import import_generic_contacts, import_generic_donations
 from apps.imports.models import ImportBatch, ImportBatchStatus
 from apps.users.models import User, UserRole
 

--- a/apps/imports/tests/test_missionary_alias.py
+++ b/apps/imports/tests/test_missionary_alias.py
@@ -1,8 +1,6 @@
 from django.db import IntegrityError
 from django.test import TestCase
 
-import pytest
-
 from apps.imports.models import MissionaryAlias
 from apps.users.models import User
 

--- a/apps/imports/tests/test_missionary_alias.py
+++ b/apps/imports/tests/test_missionary_alias.py
@@ -1,6 +1,7 @@
-import pytest
 from django.db import IntegrityError
 from django.test import TestCase
+
+import pytest
 
 from apps.imports.models import MissionaryAlias
 from apps.users.models import User
@@ -9,41 +10,41 @@ from apps.users.models import User
 class TestMissionaryAliasModel(TestCase):
     """Tests for MissionaryAlias model."""
 
-    def _make_user(self, email='test@example.com', first='Test', last='User'):
+    def _make_user(self, email="test@example.com", first="Test", last="User"):
         return User.objects.create_user(
             email=email,
-            password='testpass123',
+            password="testpass123",
             first_name=first,
             last_name=last,
-            role='missionary',
+            role="missionary",
         )
 
     def test_source_name_unique(self):
         """source_name has unique constraint."""
         user = self._make_user()
-        MissionaryAlias.objects.create(source_name='John Smith', user=user)
+        MissionaryAlias.objects.create(source_name="John Smith", user=user)
         with self.assertRaises(IntegrityError):
-            MissionaryAlias.objects.create(source_name='John Smith', user=user)
+            MissionaryAlias.objects.create(source_name="John Smith", user=user)
 
     def test_null_user_means_unresolved(self):
         """user=None is distinct from 'never seen' — represents admin-flagged unresolved."""
-        alias = MissionaryAlias.objects.create(source_name='Unknown Name', user=None)
+        alias = MissionaryAlias.objects.create(source_name="Unknown Name", user=None)
         alias.refresh_from_db()
         self.assertIsNone(alias.user)
         # Verify it's stored intentionally with notes
-        alias.notes = 'Admin-flagged as unresolvable'
+        alias.notes = "Admin-flagged as unresolvable"
         alias.save()
         alias.refresh_from_db()
-        self.assertEqual(alias.notes, 'Admin-flagged as unresolvable')
+        self.assertEqual(alias.notes, "Admin-flagged as unresolvable")
 
     def test_str_representation(self):
         """__str__ shows source_name -> user."""
-        user = self._make_user(email='john.smith@test.com', first='John', last='Smith')
-        alias = MissionaryAlias.objects.create(source_name='J. Smith', user=user)
-        self.assertIn('J. Smith', str(alias))
-        self.assertIn('->', str(alias))
+        user = self._make_user(email="john.smith@test.com", first="John", last="Smith")
+        alias = MissionaryAlias.objects.create(source_name="J. Smith", user=user)
+        self.assertIn("J. Smith", str(alias))
+        self.assertIn("->", str(alias))
 
         # Also test with null user
-        alias_null = MissionaryAlias.objects.create(source_name='Mystery Person', user=None)
-        self.assertIn('Mystery Person', str(alias_null))
-        self.assertIn('->', str(alias_null))
+        alias_null = MissionaryAlias.objects.create(source_name="Mystery Person", user=None)
+        self.assertIn("Mystery Person", str(alias_null))
+        self.assertIn("->", str(alias_null))

--- a/apps/imports/tests/test_mpd_views.py
+++ b/apps/imports/tests/test_mpd_views.py
@@ -3,15 +3,17 @@ Tests for MPD API views: MPDMyDataView and MPDOverviewView.
 
 Covers monthly_average_snapshot field in both endpoints (MPD-01, MPD-02).
 """
-import pytest
 from decimal import Decimal
 
 from django.contrib.auth import get_user_model
 from django.urls import reverse
+
 from rest_framework import status
 from rest_framework.test import APIClient
 
-from apps.imports.models import MPDUpload, MPDSnapshot
+import pytest
+
+from apps.imports.models import MPDSnapshot, MPDUpload
 
 User = get_user_model()
 
@@ -24,22 +26,22 @@ def api_client():
 @pytest.fixture
 def missionary_user(db):
     return User.objects.create_user(
-        email='missionary@example.com',
-        password='testpass123',
-        first_name='John',
-        last_name='Doe',
-        role='missionary',
+        email="missionary@example.com",
+        password="testpass123",
+        first_name="John",
+        last_name="Doe",
+        role="missionary",
     )
 
 
 @pytest.fixture
 def admin_user(db):
     return User.objects.create_user(
-        email='admin@example.com',
-        password='adminpass123',
-        first_name='Admin',
-        last_name='User',
-        role='admin',
+        email="admin@example.com",
+        password="adminpass123",
+        first_name="Admin",
+        last_name="User",
+        role="admin",
     )
 
 
@@ -47,9 +49,9 @@ def admin_user(db):
 def mpd_upload(db, admin_user):
     return MPDUpload.objects.create(
         uploaded_by=admin_user,
-        filename='mpd_report.csv',
-        file_format='csv',
-        status='completed',
+        filename="mpd_report.csv",
+        file_format="csv",
+        status="completed",
     )
 
 
@@ -62,15 +64,15 @@ class TestMPDMyDataView:
         MPDSnapshot.objects.create(
             user=missionary_user,
             upload=mpd_upload,
-            monthly_average=Decimal('1234.56'),
+            monthly_average=Decimal("1234.56"),
         )
 
         api_client.force_authenticate(user=missionary_user)
-        url = reverse('imports:mpd-my-data')
+        url = reverse("imports:mpd-my-data")
         response = api_client.get(url)
 
         assert response.status_code == status.HTTP_200_OK
-        assert response.data['monthly_average_snapshot'] == '1234.56'
+        assert response.data["monthly_average_snapshot"] == "1234.56"
 
     def test_mpd_my_data_monthly_average_null(self, api_client, missionary_user, mpd_upload):
         """Snapshot monthly average is returned as null when not set."""
@@ -81,38 +83,40 @@ class TestMPDMyDataView:
         )
 
         api_client.force_authenticate(user=missionary_user)
-        url = reverse('imports:mpd-my-data')
+        url = reverse("imports:mpd-my-data")
         response = api_client.get(url)
 
         assert response.status_code == status.HTTP_200_OK
-        assert response.data['monthly_average_snapshot'] is None
+        assert response.data["monthly_average_snapshot"] is None
 
 
 @pytest.mark.django_db
 class TestMPDOverviewView:
     """Tests for MPDOverviewView GET /api/v1/imports/mpd/overview/."""
 
-    def test_mpd_overview_includes_monthly_average(self, api_client, missionary_user, admin_user, mpd_upload):
+    def test_mpd_overview_includes_monthly_average(
+        self, api_client, missionary_user, admin_user, mpd_upload
+    ):
         """Snapshot monthly average is returned under monthly_average_snapshot key."""
         MPDSnapshot.objects.create(
             user=missionary_user,
             upload=mpd_upload,
-            monthly_average=Decimal('5678.00'),
+            monthly_average=Decimal("5678.00"),
         )
 
         api_client.force_authenticate(user=admin_user)
-        url = reverse('imports:mpd-overview')
+        url = reverse("imports:mpd-overview")
         response = api_client.get(url)
 
         assert response.status_code == status.HTTP_200_OK
-        missionaries = response.data['missionaries']
+        missionaries = response.data["missionaries"]
         assert len(missionaries) == 1
-        assert missionaries[0]['monthly_average_snapshot'] == '5678.00'
+        assert missionaries[0]["monthly_average_snapshot"] == "5678.00"
 
     def test_mpd_overview_admin_only(self, api_client, missionary_user):
         """Non-admin users receive 403 Forbidden."""
         api_client.force_authenticate(user=missionary_user)
-        url = reverse('imports:mpd-overview')
+        url = reverse("imports:mpd-overview")
         response = api_client.get(url)
 
         assert response.status_code == status.HTTP_403_FORBIDDEN

--- a/apps/imports/tests/test_pledge_import.py
+++ b/apps/imports/tests/test_pledge_import.py
@@ -6,11 +6,12 @@ get_pledges_template) were removed in Phase 30-02 and replaced by the RE
 Recurring Gift import pipeline. This test file verifies the legacy endpoint
 returns 410 Gone.
 """
-import pytest
+from django.contrib.auth import get_user_model
 from django.urls import reverse
+
 from rest_framework.test import APIClient
 
-from django.contrib.auth import get_user_model
+import pytest
 
 User = get_user_model()
 
@@ -18,11 +19,7 @@ User = get_user_model()
 @pytest.fixture
 def admin_user(db):
     """Create admin user for testing."""
-    return User.objects.create_user(
-        email='admin@example.com',
-        password='testpass',
-        role='admin'
-    )
+    return User.objects.create_user(email="admin@example.com", password="testpass", role="admin")
 
 
 @pytest.fixture
@@ -40,16 +37,14 @@ class TestLegacyPledgeImportView:
         api_client.force_authenticate(user=admin_user)
         from django.core.files.uploadedfile import SimpleUploadedFile
 
-        file = SimpleUploadedFile('test.csv', b'header\n', content_type='text/csv')
+        file = SimpleUploadedFile("test.csv", b"header\n", content_type="text/csv")
         response = api_client.post(
-            reverse('imports:import-pledges'),
-            {'file': file},
-            format='multipart'
+            reverse("imports:import-pledges"), {"file": file}, format="multipart"
         )
         assert response.status_code == 410
 
     def test_legacy_template_returns_410(self, api_client, admin_user):
         """Legacy pledge template GET returns 410 Gone."""
         api_client.force_authenticate(user=admin_user)
-        response = api_client.get(reverse('imports:template-pledges'))
+        response = api_client.get(reverse("imports:template-pledges"))
         assert response.status_code == 410

--- a/apps/imports/tests/test_re_services.py
+++ b/apps/imports/tests/test_re_services.py
@@ -27,22 +27,23 @@ from apps.users.tests.factories import AdminUserFactory, UserFactory
 
 def _to_bytes(csv_str: str) -> bytes:
     """Convert a CSV string to bytes for import functions."""
-    return csv_str.encode('utf-8')
+    return csv_str.encode("utf-8")
 
 
 @pytest.fixture
 def admin_user():
-    return AdminUserFactory(email='import-admin@test.com')
+    return AdminUserFactory(email="import-admin@test.com")
 
 
 @pytest.fixture
 def staff_user():
-    return UserFactory(email='import-staff@test.com')
+    return UserFactory(email="import-staff@test.com")
 
 
 # ---------------------------------------------------------------------------
 # import_re_solicitors tests
 # ---------------------------------------------------------------------------
+
 
 @pytest.mark.django_db
 class TestImportRESolicitors:
@@ -50,43 +51,32 @@ class TestImportRESolicitors:
 
     def test_import_solicitors_basic(self, admin_user):
         csv_data = _to_bytes(
-            'Solicitor_Name,Solicitor_ID\n'
-            '"Doe, John",SOL001\n'
-            '"Smith, Jane",SOL002\n'
+            "Solicitor_Name,Solicitor_ID\n" '"Doe, John",SOL001\n' '"Smith, Jane",SOL002\n'
         )
-        batch = import_re_solicitors(csv_data, 'solicitors.csv', admin_user)
+        batch = import_re_solicitors(csv_data, "solicitors.csv", admin_user)
         assert batch.status == ImportBatchStatus.COMPLETED
         assert batch.created_count == 2
-        assert Solicitor.objects.filter(external_solicitor_id='SOL001').exists()
-        assert Solicitor.objects.filter(external_solicitor_id='SOL002').exists()
+        assert Solicitor.objects.filter(external_solicitor_id="SOL001").exists()
+        assert Solicitor.objects.filter(external_solicitor_id="SOL002").exists()
 
     def test_import_solicitors_dedup_within_file(self, admin_user):
         csv_data = _to_bytes(
-            'Solicitor_Name,Solicitor_ID\n'
-            '"Doe, John",SOL001\n'
-            '"Doe, John",SOL001\n'
+            "Solicitor_Name,Solicitor_ID\n" '"Doe, John",SOL001\n' '"Doe, John",SOL001\n'
         )
-        batch = import_re_solicitors(csv_data, 'solicitors.csv', admin_user)
+        batch = import_re_solicitors(csv_data, "solicitors.csv", admin_user)
         assert batch.status == ImportBatchStatus.COMPLETED
         assert batch.created_count == 1
         assert batch.skipped_count == 1
 
     def test_import_solicitors_missing_name_header(self, admin_user):
-        csv_data = _to_bytes(
-            'Some_Column,Another_Column\n'
-            'foo,bar\n'
-        )
-        batch = import_re_solicitors(csv_data, 'bad.csv', admin_user)
+        csv_data = _to_bytes("Some_Column,Another_Column\n" "foo,bar\n")
+        batch = import_re_solicitors(csv_data, "bad.csv", admin_user)
         assert batch.status == ImportBatchStatus.FAILED
 
     def test_import_solicitors_empty_name_row(self, admin_user):
         """Rows with empty solicitor name are recorded as errors."""
-        csv_data = _to_bytes(
-            'Solicitor_Name\n'
-            '  \n'
-            '"Smith, Jane"\n'
-        )
-        batch = import_re_solicitors(csv_data, 'solicitors.csv', admin_user)
+        csv_data = _to_bytes("Solicitor_Name\n" "  \n" '"Smith, Jane"\n')
+        batch = import_re_solicitors(csv_data, "solicitors.csv", admin_user)
         assert batch.status == ImportBatchStatus.COMPLETED
         assert batch.created_count == 1
         # The whitespace-only row is counted as a row with missing name
@@ -98,57 +88,53 @@ class TestImportRESolicitors:
 # import_re_constituents tests
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.django_db
 class TestImportREConstituents:
     """Test RE constituent CSV import."""
 
     def test_import_constituents_basic(self, admin_user, staff_user):
         csv_data = _to_bytes(
-            'CnBio_ID,CnBio_First_Name,CnBio_Last_Name,CnAdrPrf_Email\n'
-            'C001,Alice,Johnson,alice@example.com\n'
-            'C002,Bob,Williams,bob@example.com\n'
+            "CnBio_ID,CnBio_First_Name,CnBio_Last_Name,CnAdrPrf_Email\n"
+            "C001,Alice,Johnson,alice@example.com\n"
+            "C002,Bob,Williams,bob@example.com\n"
         )
-        batch = import_re_constituents(csv_data, 'constituents.csv', admin_user, staff_user)
+        batch = import_re_constituents(csv_data, "constituents.csv", admin_user, staff_user)
         assert batch.status == ImportBatchStatus.COMPLETED
         assert batch.created_count == 2
-        assert Contact.objects.filter(external_constituent_id='C001', owner=staff_user).exists()
-        assert Contact.objects.filter(external_constituent_id='C002', owner=staff_user).exists()
+        assert Contact.objects.filter(external_constituent_id="C001", owner=staff_user).exists()
+        assert Contact.objects.filter(external_constituent_id="C002", owner=staff_user).exists()
 
     def test_import_constituents_merge_existing(self, admin_user, staff_user):
         # Create existing contact with constituent ID
         Contact.objects.create(
             owner=staff_user,
-            external_constituent_id='C001',
-            first_name='Alice',
-            last_name='Johnson',
-            email='',  # blank -- will be filled
+            external_constituent_id="C001",
+            first_name="Alice",
+            last_name="Johnson",
+            email="",  # blank -- will be filled
         )
         csv_data = _to_bytes(
-            'CnBio_ID,CnBio_First_Name,CnBio_Last_Name,CnAdrPrf_Email\n'
-            'C001,Alice,Johnson,alice@example.com\n'
+            "CnBio_ID,CnBio_First_Name,CnBio_Last_Name,CnAdrPrf_Email\n"
+            "C001,Alice,Johnson,alice@example.com\n"
         )
-        batch = import_re_constituents(csv_data, 'constituents.csv', admin_user, staff_user)
+        batch = import_re_constituents(csv_data, "constituents.csv", admin_user, staff_user)
         assert batch.status == ImportBatchStatus.COMPLETED
         assert batch.updated_count == 1
         assert batch.created_count == 0
-        contact = Contact.objects.get(external_constituent_id='C001')
-        assert contact.email == 'alice@example.com'
+        contact = Contact.objects.get(external_constituent_id="C001")
+        assert contact.email == "alice@example.com"
 
     def test_import_constituents_missing_name_headers(self, admin_user, staff_user):
-        csv_data = _to_bytes(
-            'Random_Column\n'
-            'value\n'
-        )
-        batch = import_re_constituents(csv_data, 'bad.csv', admin_user, staff_user)
+        csv_data = _to_bytes("Random_Column\n" "value\n")
+        batch = import_re_constituents(csv_data, "bad.csv", admin_user, staff_user)
         assert batch.status == ImportBatchStatus.FAILED
 
     def test_import_constituents_row_with_no_name(self, admin_user, staff_user):
         csv_data = _to_bytes(
-            'CnBio_ID,CnBio_First_Name,CnBio_Last_Name\n'
-            'C001,,\n'
-            'C002,Alice,Johnson\n'
+            "CnBio_ID,CnBio_First_Name,CnBio_Last_Name\n" "C001,,\n" "C002,Alice,Johnson\n"
         )
-        batch = import_re_constituents(csv_data, 'constituents.csv', admin_user, staff_user)
+        batch = import_re_constituents(csv_data, "constituents.csv", admin_user, staff_user)
         assert batch.status == ImportBatchStatus.COMPLETED
         assert batch.created_count == 1
         assert batch.error_count == 1
@@ -158,6 +144,7 @@ class TestImportREConstituents:
 # import_re_gifts tests
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.django_db
 class TestImportREGifts:
     """Test RE gift CSV import with multi-row grouping."""
@@ -166,72 +153,67 @@ class TestImportREGifts:
     def setup_contact(self, staff_user):
         return Contact.objects.create(
             owner=staff_user,
-            external_constituent_id='C001',
-            first_name='Alice',
-            last_name='Donor',
+            external_constituent_id="C001",
+            first_name="Alice",
+            last_name="Donor",
         )
 
     def test_import_gifts_basic(self, admin_user, staff_user, setup_contact):
         csv_data = _to_bytes(
-            'Gift_ID,Constituent_ID,GF_Amount,GF_Date\n'
-            'G001,C001,100.00,2025-06-15\n'
-            'G002,C001,250.00,2025-07-20\n'
+            "Gift_ID,Constituent_ID,GF_Amount,GF_Date\n"
+            "G001,C001,100.00,2025-06-15\n"
+            "G002,C001,250.00,2025-07-20\n"
         )
-        batch = import_re_gifts(csv_data, 'gifts.csv', admin_user, staff_user)
+        batch = import_re_gifts(csv_data, "gifts.csv", admin_user, staff_user)
         assert batch.status == ImportBatchStatus.COMPLETED
         assert batch.created_count == 2
-        assert Gift.objects.filter(external_gift_id='G001').exists()
-        assert Gift.objects.filter(external_gift_id='G002').exists()
+        assert Gift.objects.filter(external_gift_id="G001").exists()
+        assert Gift.objects.filter(external_gift_id="G002").exists()
 
     def test_import_gifts_multi_row_grouping(self, admin_user, staff_user, setup_contact):
         # Create two solicitors for split-credit rows
         # normalize_solicitor_name("Doe, John") -> "doe, john"
         # normalize_solicitor_name("Smith, Jane") -> "smith, jane"
         Solicitor.objects.create(
-            normalized_name='doe, john',
-            external_solicitor_id='SOL001',
+            normalized_name="doe, john",
+            external_solicitor_id="SOL001",
         )
         Solicitor.objects.create(
-            normalized_name='smith, jane',
-            external_solicitor_id='SOL002',
+            normalized_name="smith, jane",
+            external_solicitor_id="SOL002",
         )
         csv_data = _to_bytes(
-            'Gift_ID,Constituent_ID,GF_Amount,GF_Date,Solicitor_Name,Credit_Amount\n'
+            "Gift_ID,Constituent_ID,GF_Amount,GF_Date,Solicitor_Name,Credit_Amount\n"
             'G001,C001,500.00,2025-06-15,"Doe, John",250.00\n'
             'G001,C001,500.00,2025-06-15,"Smith, Jane",250.00\n'
         )
-        batch = import_re_gifts(csv_data, 'gifts.csv', admin_user, staff_user)
+        batch = import_re_gifts(csv_data, "gifts.csv", admin_user, staff_user)
         assert batch.status == ImportBatchStatus.COMPLETED
         assert batch.created_count == 1
-        gift = Gift.objects.get(external_gift_id='G001')
+        gift = Gift.objects.get(external_gift_id="G001")
         assert gift.amount_cents == 50000
         # Two different solicitors = two GiftCredit rows
         assert gift.credits.count() == 2
 
     def test_import_gifts_missing_constituent(self, admin_user, staff_user, setup_contact):
         csv_data = _to_bytes(
-            'Gift_ID,Constituent_ID,GF_Amount,GF_Date\n'
-            'G001,C999,100.00,2025-06-15\n'
+            "Gift_ID,Constituent_ID,GF_Amount,GF_Date\n" "G001,C999,100.00,2025-06-15\n"
         )
-        batch = import_re_gifts(csv_data, 'gifts.csv', admin_user, staff_user)
+        batch = import_re_gifts(csv_data, "gifts.csv", admin_user, staff_user)
         assert batch.status == ImportBatchStatus.COMPLETED
         assert batch.created_count == 0
         assert batch.error_count >= 1
 
     def test_import_gifts_missing_required_headers(self, admin_user, staff_user):
-        csv_data = _to_bytes(
-            'Random_Header\n'
-            'value\n'
-        )
-        batch = import_re_gifts(csv_data, 'bad.csv', admin_user, staff_user)
+        csv_data = _to_bytes("Random_Header\n" "value\n")
+        batch = import_re_gifts(csv_data, "bad.csv", admin_user, staff_user)
         assert batch.status == ImportBatchStatus.FAILED
 
     def test_import_gifts_invalid_amount(self, admin_user, staff_user, setup_contact):
         csv_data = _to_bytes(
-            'Gift_ID,Constituent_ID,GF_Amount,GF_Date\n'
-            'G001,C001,not_a_number,2025-06-15\n'
+            "Gift_ID,Constituent_ID,GF_Amount,GF_Date\n" "G001,C001,not_a_number,2025-06-15\n"
         )
-        batch = import_re_gifts(csv_data, 'gifts.csv', admin_user, staff_user)
+        batch = import_re_gifts(csv_data, "gifts.csv", admin_user, staff_user)
         assert batch.status == ImportBatchStatus.COMPLETED
         assert batch.created_count == 0
         assert batch.error_count >= 1
@@ -241,6 +223,7 @@ class TestImportREGifts:
 # import_re_recurring_gifts tests
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.django_db
 class TestImportRERecurringGifts:
     """Test RE recurring gift CSV import."""
@@ -249,70 +232,76 @@ class TestImportRERecurringGifts:
     def setup_contact(self, staff_user):
         return Contact.objects.create(
             owner=staff_user,
-            external_constituent_id='C001',
-            first_name='Alice',
-            last_name='Donor',
+            external_constituent_id="C001",
+            first_name="Alice",
+            last_name="Donor",
         )
 
     def test_import_recurring_gifts_basic(self, admin_user, staff_user, setup_contact):
         csv_data = _to_bytes(
-            'Gift_ID,Constituent_ID,Amount,Frequency,Start_Date,Status\n'
-            'RG001,C001,200.00,Monthly,2025-01-01,Active\n'
-            'RG002,C001,300.00,Quarterly,2025-03-01,Active\n'
+            "Gift_ID,Constituent_ID,Amount,Frequency,Start_Date,Status\n"
+            "RG001,C001,200.00,Monthly,2025-01-01,Active\n"
+            "RG002,C001,300.00,Quarterly,2025-03-01,Active\n"
         )
-        batch = import_re_recurring_gifts(csv_data, 'recurring.csv', admin_user, staff_user)
+        batch = import_re_recurring_gifts(csv_data, "recurring.csv", admin_user, staff_user)
         assert batch.status == ImportBatchStatus.COMPLETED
         assert batch.created_count == 2
-        rg1 = RecurringGift.objects.get(external_gift_id='RG001')
+        rg1 = RecurringGift.objects.get(external_gift_id="RG001")
         assert rg1.amount_cents == 20000
-        assert rg1.frequency == 'monthly'
-        rg2 = RecurringGift.objects.get(external_gift_id='RG002')
-        assert rg2.frequency == 'quarterly'
+        assert rg1.frequency == "monthly"
+        rg2 = RecurringGift.objects.get(external_gift_id="RG002")
+        assert rg2.frequency == "quarterly"
 
     def test_import_recurring_gifts_empty_frequency_defaults_monthly(
-        self, admin_user, staff_user, setup_contact,
+        self,
+        admin_user,
+        staff_user,
+        setup_contact,
     ):
         csv_data = _to_bytes(
-            'Gift_ID,Constituent_ID,Amount,Frequency,Start_Date,Status\n'
-            'RG001,C001,100.00,,2025-01-01,Active\n'
+            "Gift_ID,Constituent_ID,Amount,Frequency,Start_Date,Status\n"
+            "RG001,C001,100.00,,2025-01-01,Active\n"
         )
-        batch = import_re_recurring_gifts(csv_data, 'recurring.csv', admin_user, staff_user)
+        batch = import_re_recurring_gifts(csv_data, "recurring.csv", admin_user, staff_user)
         assert batch.status == ImportBatchStatus.COMPLETED
         assert batch.created_count == 1
-        rg = RecurringGift.objects.get(external_gift_id='RG001')
-        assert rg.frequency == 'monthly'
+        rg = RecurringGift.objects.get(external_gift_id="RG001")
+        assert rg.frequency == "monthly"
 
     def test_import_recurring_gifts_empty_status_defaults_active(
-        self, admin_user, staff_user, setup_contact,
+        self,
+        admin_user,
+        staff_user,
+        setup_contact,
     ):
         csv_data = _to_bytes(
-            'Gift_ID,Constituent_ID,Amount,Frequency,Start_Date,Status\n'
-            'RG001,C001,100.00,Monthly,2025-01-01,\n'
+            "Gift_ID,Constituent_ID,Amount,Frequency,Start_Date,Status\n"
+            "RG001,C001,100.00,Monthly,2025-01-01,\n"
         )
-        batch = import_re_recurring_gifts(csv_data, 'recurring.csv', admin_user, staff_user)
+        batch = import_re_recurring_gifts(csv_data, "recurring.csv", admin_user, staff_user)
         assert batch.status == ImportBatchStatus.COMPLETED
         assert batch.created_count == 1
-        rg = RecurringGift.objects.get(external_gift_id='RG001')
-        assert rg.status == 'active'
+        rg = RecurringGift.objects.get(external_gift_id="RG001")
+        assert rg.status == "active"
 
     def test_import_recurring_gifts_unknown_frequency_skips(
-        self, admin_user, staff_user, setup_contact,
+        self,
+        admin_user,
+        staff_user,
+        setup_contact,
     ):
         csv_data = _to_bytes(
-            'Gift_ID,Constituent_ID,Amount,Frequency,Start_Date,Status\n'
-            'RG001,C001,100.00,FortnightlyWeird,2025-01-01,Active\n'
+            "Gift_ID,Constituent_ID,Amount,Frequency,Start_Date,Status\n"
+            "RG001,C001,100.00,FortnightlyWeird,2025-01-01,Active\n"
         )
-        batch = import_re_recurring_gifts(csv_data, 'recurring.csv', admin_user, staff_user)
+        batch = import_re_recurring_gifts(csv_data, "recurring.csv", admin_user, staff_user)
         assert batch.status == ImportBatchStatus.COMPLETED
         assert batch.created_count == 0
         assert batch.error_count >= 1
 
     def test_import_recurring_gifts_missing_headers(self, admin_user, staff_user):
-        csv_data = _to_bytes(
-            'Bad_Header\n'
-            'value\n'
-        )
-        batch = import_re_recurring_gifts(csv_data, 'bad.csv', admin_user, staff_user)
+        csv_data = _to_bytes("Bad_Header\n" "value\n")
+        batch = import_re_recurring_gifts(csv_data, "bad.csv", admin_user, staff_user)
         assert batch.status == ImportBatchStatus.FAILED
 
 
@@ -320,51 +309,45 @@ class TestImportRERecurringGifts:
 # SHA256 dedup tests
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.django_db
 class TestSHA256Dedup:
     """Test SHA256 dedup prevents reprocessing same file."""
 
     def test_solicitor_dedup_second_import_returns_duplicate(self, admin_user):
-        csv_data = _to_bytes(
-            'Solicitor_Name\n'
-            '"Doe, John"\n'
-        )
-        batch1 = import_re_solicitors(csv_data, 'solicitors.csv', admin_user)
+        csv_data = _to_bytes("Solicitor_Name\n" '"Doe, John"\n')
+        batch1 = import_re_solicitors(csv_data, "solicitors.csv", admin_user)
         assert batch1.status == ImportBatchStatus.COMPLETED
         assert batch1.created_count == 1
 
-        batch2 = import_re_solicitors(csv_data, 'solicitors.csv', admin_user)
+        batch2 = import_re_solicitors(csv_data, "solicitors.csv", admin_user)
         assert batch2.status == ImportBatchStatus.DUPLICATE
         assert batch2.id == batch1.id  # Same batch returned
 
     def test_constituent_dedup_second_import_returns_duplicate(self, admin_user):
-        staff_user = UserFactory(email='dedup-staff@test.com')
-        csv_data = _to_bytes(
-            'CnBio_First_Name,CnBio_Last_Name\n'
-            'Alice,Johnson\n'
-        )
-        batch1 = import_re_constituents(csv_data, 'constituents.csv', admin_user, staff_user)
+        staff_user = UserFactory(email="dedup-staff@test.com")
+        csv_data = _to_bytes("CnBio_First_Name,CnBio_Last_Name\n" "Alice,Johnson\n")
+        batch1 = import_re_constituents(csv_data, "constituents.csv", admin_user, staff_user)
         assert batch1.status == ImportBatchStatus.COMPLETED
 
-        batch2 = import_re_constituents(csv_data, 'constituents.csv', admin_user, staff_user)
+        batch2 = import_re_constituents(csv_data, "constituents.csv", admin_user, staff_user)
         assert batch2.status == ImportBatchStatus.DUPLICATE
         assert batch2.id == batch1.id
 
     def test_gift_dedup_second_import_returns_duplicate(self, admin_user, staff_user):
         Contact.objects.create(
             owner=staff_user,
-            external_constituent_id='C001',
-            first_name='Test',
-            last_name='Donor',
+            external_constituent_id="C001",
+            first_name="Test",
+            last_name="Donor",
         )
         csv_data = _to_bytes(
-            'Gift_ID,Constituent_ID,GF_Amount,GF_Date\n'
-            'G001,C001,100.00,2025-01-01\n'
+            "Gift_ID,Constituent_ID,GF_Amount,GF_Date\n" "G001,C001,100.00,2025-01-01\n"
         )
-        batch1 = import_re_gifts(csv_data, 'gifts.csv', admin_user, staff_user)
+        batch1 = import_re_gifts(csv_data, "gifts.csv", admin_user, staff_user)
         assert batch1.status == ImportBatchStatus.COMPLETED
 
-        batch2 = import_re_gifts(csv_data, 'gifts.csv', admin_user, staff_user)
+        batch2 = import_re_gifts(csv_data, "gifts.csv", admin_user, staff_user)
         assert batch2.status == ImportBatchStatus.DUPLICATE
         assert batch2.id == batch1.id
 
@@ -373,30 +356,31 @@ class TestSHA256Dedup:
 # Malformed CSV handling tests
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.django_db
 class TestMalformedCSVHandling:
     """Test graceful error handling for bad CSV input."""
 
     def test_empty_csv_solicitors(self, admin_user):
-        csv_data = _to_bytes('')
-        batch = import_re_solicitors(csv_data, 'empty.csv', admin_user)
+        csv_data = _to_bytes("")
+        batch = import_re_solicitors(csv_data, "empty.csv", admin_user)
         assert batch.status == ImportBatchStatus.FAILED
 
     def test_empty_csv_constituents(self, admin_user, staff_user):
-        csv_data = _to_bytes('')
-        batch = import_re_constituents(csv_data, 'empty.csv', admin_user, staff_user)
+        csv_data = _to_bytes("")
+        batch = import_re_constituents(csv_data, "empty.csv", admin_user, staff_user)
         assert batch.status == ImportBatchStatus.FAILED
 
     def test_binary_garbage_solicitors(self, admin_user):
         csv_data = bytes(range(256))
-        batch = import_re_solicitors(csv_data, 'garbage.csv', admin_user)
+        batch = import_re_solicitors(csv_data, "garbage.csv", admin_user)
         # Should not raise -- returns a batch with FAILED status or misparse
         assert batch is not None
         assert isinstance(batch, ImportBatch)
 
     def test_csv_with_null_bytes(self, admin_user):
         csv_data = b'Solicitor_Name\x00\n"Doe, John"\x00\n'
-        batch = import_re_solicitors(csv_data, 'nulls.csv', admin_user)
+        batch = import_re_solicitors(csv_data, "nulls.csv", admin_user)
         # Null bytes are stripped by decode_csv_bytes, import should succeed
         assert batch.status == ImportBatchStatus.COMPLETED
         assert batch.created_count == 1
@@ -406,6 +390,7 @@ class TestMalformedCSVHandling:
 # Recurring gift prayer extraction tests
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.django_db
 class TestImportRERecurringGiftsPrayers:
     """Test prayer extraction from recurring gift import."""
@@ -414,25 +399,26 @@ class TestImportRERecurringGiftsPrayers:
     def setup_contact(self, staff_user):
         return Contact.objects.create(
             owner=staff_user,
-            external_constituent_id='C-PRAY-01',
-            first_name='Prayer',
-            last_name='Donor',
+            external_constituent_id="C-PRAY-01",
+            first_name="Prayer",
+            last_name="Donor",
         )
 
     def test_prayer_extracted_from_recurring_gift(self, admin_user, staff_user, setup_contact):
         """Recurring gift with prayer_description creates PrayerIntention."""
         from apps.prayers.models import PrayerIntention
+
         csv_data = _to_bytes(
-            'Recurring Gift\n'
-            'Gift ID,Constituent ID,Amount,Frequency,Gift Date,Status,'
-            'Gift Specific Attributes Prayer Requests Description\n'
-            'RG-PRAY-01,C-PRAY-01,100.00,Monthly,2025-01-01,Active,Healing for family\n'
+            "Recurring Gift\n"
+            "Gift ID,Constituent ID,Amount,Frequency,Gift Date,Status,"
+            "Gift Specific Attributes Prayer Requests Description\n"
+            "RG-PRAY-01,C-PRAY-01,100.00,Monthly,2025-01-01,Active,Healing for family\n"
         )
-        batch = import_re_recurring_gifts(csv_data, 'recurring.csv', admin_user, staff_user)
+        batch = import_re_recurring_gifts(csv_data, "recurring.csv", admin_user, staff_user)
         assert batch.status == ImportBatchStatus.COMPLETED
         assert PrayerIntention.objects.count() == 1
         prayer = PrayerIntention.objects.first()
-        assert 'Healing' in prayer.description
+        assert "Healing" in prayer.description
         assert prayer.contact == setup_contact
         # No gift M2M link — recurring gifts have no associated Gift record
         assert prayer.gifts.count() == 0
@@ -440,27 +426,29 @@ class TestImportRERecurringGiftsPrayers:
     def test_no_prayer_when_description_empty(self, admin_user, staff_user, setup_contact):
         """Recurring gift with empty prayer description creates no PrayerIntention."""
         from apps.prayers.models import PrayerIntention
+
         csv_data = _to_bytes(
-            'Recurring Gift\n'
-            'Gift ID,Constituent ID,Amount,Frequency,Gift Date,Status,'
-            'Gift Specific Attributes Prayer Requests Description\n'
-            'RG-NOPRAY-01,C-PRAY-01,100.00,Monthly,2025-01-01,Active,\n'
+            "Recurring Gift\n"
+            "Gift ID,Constituent ID,Amount,Frequency,Gift Date,Status,"
+            "Gift Specific Attributes Prayer Requests Description\n"
+            "RG-NOPRAY-01,C-PRAY-01,100.00,Monthly,2025-01-01,Active,\n"
         )
-        batch = import_re_recurring_gifts(csv_data, 'recurring.csv', admin_user, staff_user)
+        batch = import_re_recurring_gifts(csv_data, "recurring.csv", admin_user, staff_user)
         assert batch.status == ImportBatchStatus.COMPLETED
         assert PrayerIntention.objects.count() == 0
 
     def test_prayer_dedup_across_recurring_gifts(self, admin_user, staff_user, setup_contact):
         """Two recurring gifts with identical prayer text create one PrayerIntention."""
         from apps.prayers.models import PrayerIntention
+
         csv_data = _to_bytes(
-            'Recurring Gift\n'
-            'Gift ID,Constituent ID,Amount,Frequency,Gift Date,Status,'
-            'Gift Specific Attributes Prayer Requests Description\n'
-            'RG-DEDUP-01,C-PRAY-01,100.00,Monthly,2025-01-01,Active,Same prayer text\n'
-            'RG-DEDUP-02,C-PRAY-01,200.00,Monthly,2025-02-01,Active,Same prayer text\n'
+            "Recurring Gift\n"
+            "Gift ID,Constituent ID,Amount,Frequency,Gift Date,Status,"
+            "Gift Specific Attributes Prayer Requests Description\n"
+            "RG-DEDUP-01,C-PRAY-01,100.00,Monthly,2025-01-01,Active,Same prayer text\n"
+            "RG-DEDUP-02,C-PRAY-01,200.00,Monthly,2025-02-01,Active,Same prayer text\n"
         )
-        batch = import_re_recurring_gifts(csv_data, 'recurring.csv', admin_user, staff_user)
+        batch = import_re_recurring_gifts(csv_data, "recurring.csv", admin_user, staff_user)
         assert batch.status == ImportBatchStatus.COMPLETED
         assert PrayerIntention.objects.count() == 1
 
@@ -469,108 +457,110 @@ class TestImportRERecurringGiftsPrayers:
 # Owner reassignment tests
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.django_db
 class TestImportREGiftsOwnerReassignment:
     """Test that import_re_gifts reassigns contact owner to the matched solicitor's user."""
 
     @pytest.fixture
     def admin1(self):
-        return AdminUserFactory(email='admin1@test.com')
+        return AdminUserFactory(email="admin1@test.com")
 
     @pytest.fixture
     def admin2(self):
-        return AdminUserFactory(email='admin2@test.com')
+        return AdminUserFactory(email="admin2@test.com")
 
     @pytest.fixture
     def missionary(self):
-        return UserFactory(email='missionary@test.com')
+        return UserFactory(email="missionary@test.com")
 
     def test_reassigns_owner_when_imported_by_different_admin(
-        self, admin1, admin2, missionary,
+        self,
+        admin1,
+        admin2,
+        missionary,
     ):
         """Contact owned by admin1 should be reassigned to missionary when gifts
         are imported by admin2 (cross-admin scenario from production Render bug)."""
         contact = Contact.objects.create(
             owner=admin1,
-            external_constituent_id='C-REOWN-01',
-            first_name='Cross',
-            last_name='Admin',
+            external_constituent_id="C-REOWN-01",
+            first_name="Cross",
+            last_name="Admin",
         )
         solicitor = Solicitor.objects.create(
-            normalized_name='doe, john',
-            external_solicitor_id='SOL-REOWN-01',
+            normalized_name="doe, john",
+            external_solicitor_id="SOL-REOWN-01",
             user=missionary,
         )
         csv_data = _to_bytes(
-            'Gift_ID,Constituent_ID,GF_Amount,GF_Date,Solicitor_Name,Credit_Amount\n'
+            "Gift_ID,Constituent_ID,GF_Amount,GF_Date,Solicitor_Name,Credit_Amount\n"
             'G-REOWN-01,C-REOWN-01,100.00,2025-06-15,"Doe, John",100.00\n'
         )
-        batch = import_re_gifts(csv_data, 'gifts_reown.csv', admin2, admin2)
+        batch = import_re_gifts(csv_data, "gifts_reown.csv", admin2, admin2)
         assert batch.status == ImportBatchStatus.COMPLETED
         contact.refresh_from_db()
-        assert contact.owner == missionary, (
-            f"Expected owner={missionary}, got {contact.owner}"
-        )
+        assert contact.owner == missionary, f"Expected owner={missionary}, got {contact.owner}"
 
     def test_does_not_reassign_if_already_owned_by_missionary(
-        self, admin1, missionary,
+        self,
+        admin1,
+        missionary,
     ):
         """Contact already owned by a missionary (has Solicitor record) should NOT
         be reassigned to a different missionary."""
         # Create a Solicitor record for missionary (they are already a missionary)
         Solicitor.objects.create(
-            normalized_name='existing, missionary',
-            external_solicitor_id='SOL-EXIST-01',
+            normalized_name="existing, missionary",
+            external_solicitor_id="SOL-EXIST-01",
             user=missionary,
         )
         contact = Contact.objects.create(
             owner=missionary,
-            external_constituent_id='C-EXIST-01',
-            first_name='Existing',
-            last_name='Missionary',
+            external_constituent_id="C-EXIST-01",
+            first_name="Existing",
+            last_name="Missionary",
         )
         # A different solicitor will try to claim the contact
-        other_missionary = UserFactory(email='other-missionary@test.com')
+        other_missionary = UserFactory(email="other-missionary@test.com")
         Solicitor.objects.create(
-            normalized_name='other, solicitor',
-            external_solicitor_id='SOL-OTHER-01',
+            normalized_name="other, solicitor",
+            external_solicitor_id="SOL-OTHER-01",
             user=other_missionary,
         )
         csv_data = _to_bytes(
-            'Gift_ID,Constituent_ID,GF_Amount,GF_Date,Solicitor_Name,Credit_Amount\n'
+            "Gift_ID,Constituent_ID,GF_Amount,GF_Date,Solicitor_Name,Credit_Amount\n"
             'G-EXIST-01,C-EXIST-01,200.00,2025-07-01,"Other, Solicitor",200.00\n'
         )
-        batch = import_re_gifts(csv_data, 'gifts_exist.csv', admin1, admin1)
+        batch = import_re_gifts(csv_data, "gifts_exist.csv", admin1, admin1)
         assert batch.status == ImportBatchStatus.COMPLETED
         contact.refresh_from_db()
         # Owner should remain the original missionary, not be changed to other_missionary
-        assert contact.owner == missionary, (
-            f"Expected owner to remain {missionary}, got {contact.owner}"
-        )
+        assert (
+            contact.owner == missionary
+        ), f"Expected owner to remain {missionary}, got {contact.owner}"
 
     def test_no_reassign_if_no_solicitor_match(self, admin1):
         """If no solicitor credit in CSV, contact owner is unchanged."""
         contact = Contact.objects.create(
             owner=admin1,
-            external_constituent_id='C-NOSOL-01',
-            first_name='No',
-            last_name='Solicitor',
+            external_constituent_id="C-NOSOL-01",
+            first_name="No",
+            last_name="Solicitor",
         )
         csv_data = _to_bytes(
-            'Gift_ID,Constituent_ID,GF_Amount,GF_Date\n'
-            'G-NOSOL-01,C-NOSOL-01,50.00,2025-08-01\n'
+            "Gift_ID,Constituent_ID,GF_Amount,GF_Date\n" "G-NOSOL-01,C-NOSOL-01,50.00,2025-08-01\n"
         )
-        batch = import_re_gifts(csv_data, 'gifts_nosol.csv', admin1, admin1)
+        batch = import_re_gifts(csv_data, "gifts_nosol.csv", admin1, admin1)
         assert batch.status == ImportBatchStatus.COMPLETED
         contact.refresh_from_db()
-        assert contact.owner == admin1, (
-            f"Expected owner to remain {admin1}, got {contact.owner}"
-        )
+        assert contact.owner == admin1, f"Expected owner to remain {admin1}, got {contact.owner}"
 
 
 # ---------------------------------------------------------------------------
 # Recurring gift owner reassignment tests
 # ---------------------------------------------------------------------------
+
 
 @pytest.mark.django_db
 class TestImportRERecurringGiftsOwnerReassignment:
@@ -579,105 +569,106 @@ class TestImportRERecurringGiftsOwnerReassignment:
 
     @pytest.fixture
     def admin1(self):
-        return AdminUserFactory(email='rg-admin1@test.com')
+        return AdminUserFactory(email="rg-admin1@test.com")
 
     @pytest.fixture
     def missionary(self):
-        return UserFactory(email='rg-missionary@test.com')
+        return UserFactory(email="rg-missionary@test.com")
 
     def test_recurring_gift_reassigns_contact_owner_from_admin(
-        self, admin1, missionary,
+        self,
+        admin1,
+        missionary,
     ):
         """Contact owned by admin should be reassigned to missionary when
         recurring gifts are imported with a solicitor linked to that missionary."""
         contact = Contact.objects.create(
             owner=admin1,
-            external_constituent_id='C-RGREOWN-01',
-            first_name='Recurring',
-            last_name='Donor',
+            external_constituent_id="C-RGREOWN-01",
+            first_name="Recurring",
+            last_name="Donor",
         )
         Solicitor.objects.create(
-            normalized_name='doe, john',
-            external_solicitor_id='SOL-RGREOWN-01',
+            normalized_name="doe, john",
+            external_solicitor_id="SOL-RGREOWN-01",
             user=missionary,
         )
         csv_data = _to_bytes(
-            'Gift_ID,Constituent_ID,Amount,Frequency,Start_Date,Status,'
-            'Solicitor_Name,Credit_Amount\n'
-            'RG-REOWN-01,C-RGREOWN-01,200.00,Monthly,2025-01-01,Active,'
+            "Gift_ID,Constituent_ID,Amount,Frequency,Start_Date,Status,"
+            "Solicitor_Name,Credit_Amount\n"
+            "RG-REOWN-01,C-RGREOWN-01,200.00,Monthly,2025-01-01,Active,"
             '"Doe, John",200.00\n'
         )
-        batch = import_re_recurring_gifts(csv_data, 'rg_reown.csv', admin1, admin1)
+        batch = import_re_recurring_gifts(csv_data, "rg_reown.csv", admin1, admin1)
         assert batch.status == ImportBatchStatus.COMPLETED
         contact.refresh_from_db()
-        assert contact.owner == missionary, (
-            f"Expected owner={missionary}, got {contact.owner}"
-        )
+        assert contact.owner == missionary, f"Expected owner={missionary}, got {contact.owner}"
 
     def test_recurring_gift_no_reassign_if_already_missionary(
-        self, admin1, missionary,
+        self,
+        admin1,
+        missionary,
     ):
         """Contact already owned by a missionary should NOT be reassigned."""
         Solicitor.objects.create(
-            normalized_name='existing, missionary',
-            external_solicitor_id='SOL-RGEXIST-01',
+            normalized_name="existing, missionary",
+            external_solicitor_id="SOL-RGEXIST-01",
             user=missionary,
         )
         contact = Contact.objects.create(
             owner=missionary,
-            external_constituent_id='C-RGEXIST-01',
-            first_name='Already',
-            last_name='Missionary',
+            external_constituent_id="C-RGEXIST-01",
+            first_name="Already",
+            last_name="Missionary",
         )
-        other_missionary = UserFactory(email='rg-other@test.com')
+        other_missionary = UserFactory(email="rg-other@test.com")
         Solicitor.objects.create(
-            normalized_name='other, solicitor',
-            external_solicitor_id='SOL-RGOTHER-01',
+            normalized_name="other, solicitor",
+            external_solicitor_id="SOL-RGOTHER-01",
             user=other_missionary,
         )
         csv_data = _to_bytes(
-            'Gift_ID,Constituent_ID,Amount,Frequency,Start_Date,Status,'
-            'Solicitor_Name,Credit_Amount\n'
-            'RG-EXIST-01,C-RGEXIST-01,150.00,Monthly,2025-01-01,Active,'
+            "Gift_ID,Constituent_ID,Amount,Frequency,Start_Date,Status,"
+            "Solicitor_Name,Credit_Amount\n"
+            "RG-EXIST-01,C-RGEXIST-01,150.00,Monthly,2025-01-01,Active,"
             '"Other, Solicitor",150.00\n'
         )
-        batch = import_re_recurring_gifts(csv_data, 'rg_exist.csv', admin1, admin1)
+        batch = import_re_recurring_gifts(csv_data, "rg_exist.csv", admin1, admin1)
         assert batch.status == ImportBatchStatus.COMPLETED
         contact.refresh_from_db()
-        assert contact.owner == missionary, (
-            f"Expected owner to remain {missionary}, got {contact.owner}"
-        )
+        assert (
+            contact.owner == missionary
+        ), f"Expected owner to remain {missionary}, got {contact.owner}"
 
     def test_recurring_gift_no_reassign_if_solicitor_unlinked(self, admin1):
         """If solicitor has no linked user, contact stays with admin."""
         contact = Contact.objects.create(
             owner=admin1,
-            external_constituent_id='C-RGUNLINK-01',
-            first_name='Unlinked',
-            last_name='Solicitor',
+            external_constituent_id="C-RGUNLINK-01",
+            first_name="Unlinked",
+            last_name="Solicitor",
         )
         Solicitor.objects.create(
-            normalized_name='doe, john',
-            external_solicitor_id='SOL-RGUNLINK-01',
+            normalized_name="doe, john",
+            external_solicitor_id="SOL-RGUNLINK-01",
             user=None,  # Not linked to any user
         )
         csv_data = _to_bytes(
-            'Gift_ID,Constituent_ID,Amount,Frequency,Start_Date,Status,'
-            'Solicitor_Name,Credit_Amount\n'
-            'RG-UNLINK-01,C-RGUNLINK-01,100.00,Monthly,2025-01-01,Active,'
+            "Gift_ID,Constituent_ID,Amount,Frequency,Start_Date,Status,"
+            "Solicitor_Name,Credit_Amount\n"
+            "RG-UNLINK-01,C-RGUNLINK-01,100.00,Monthly,2025-01-01,Active,"
             '"Doe, John",100.00\n'
         )
-        batch = import_re_recurring_gifts(csv_data, 'rg_unlink.csv', admin1, admin1)
+        batch = import_re_recurring_gifts(csv_data, "rg_unlink.csv", admin1, admin1)
         assert batch.status == ImportBatchStatus.COMPLETED
         contact.refresh_from_db()
-        assert contact.owner == admin1, (
-            f"Expected owner to remain {admin1}, got {contact.owner}"
-        )
+        assert contact.owner == admin1, f"Expected owner to remain {admin1}, got {contact.owner}"
 
 
 # ---------------------------------------------------------------------------
 # Constituent import skip details tests
 # ---------------------------------------------------------------------------
+
 
 @pytest.mark.django_db
 class TestConstituentSkipDetails:
@@ -687,61 +678,61 @@ class TestConstituentSkipDetails:
         """When all fields are already populated, skip details include reason and match_type."""
         Contact.objects.create(
             owner=staff_user,
-            external_constituent_id='C-SKIP-01',
-            first_name='Alice',
-            last_name='Johnson',
-            email='alice@example.com',
-            phone='555-0001',
-            street_address='123 Main St',
-            city='Anytown',
-            state='CA',
-            postal_code='90210',
-            country='US',
+            external_constituent_id="C-SKIP-01",
+            first_name="Alice",
+            last_name="Johnson",
+            email="alice@example.com",
+            phone="555-0001",
+            street_address="123 Main St",
+            city="Anytown",
+            state="CA",
+            postal_code="90210",
+            country="US",
         )
         csv_data = _to_bytes(
-            'Constituent_ID,First_Name,Last_Name,Email,Phone,'
-            'Address,City,State,ZIP,Country\n'
-            'C-SKIP-01,Alice,Johnson,alice@example.com,555-0001,'
-            '123 Main St,Anytown,CA,90210,US\n'
+            "Constituent_ID,First_Name,Last_Name,Email,Phone,"
+            "Address,City,State,ZIP,Country\n"
+            "C-SKIP-01,Alice,Johnson,alice@example.com,555-0001,"
+            "123 Main St,Anytown,CA,90210,US\n"
         )
-        batch = import_re_constituents(csv_data, 'skip.csv', admin_user, staff_user)
+        batch = import_re_constituents(csv_data, "skip.csv", admin_user, staff_user)
         assert batch.status == ImportBatchStatus.COMPLETED
         assert batch.skipped_count == 1
         assert batch.created_count == 0
-        details = batch.summary['skipped_details']
+        details = batch.summary["skipped_details"]
         assert len(details) == 1
-        assert details[0]['reason'] == 'all_fields_populated'
-        assert details[0]['match_type'] == 'constituent_id'
-        assert details[0]['contact_name'] == 'Alice Johnson'
-        assert details[0]['constituent_id'] == 'C-SKIP-01'
+        assert details[0]["reason"] == "all_fields_populated"
+        assert details[0]["match_type"] == "constituent_id"
+        assert details[0]["contact_name"] == "Alice Johnson"
+        assert details[0]["constituent_id"] == "C-SKIP-01"
 
     def test_merge_partial_no_skip_details(self, admin_user, staff_user):
         """When merge fills blank fields, no skip details are recorded."""
         Contact.objects.create(
             owner=staff_user,
-            external_constituent_id='C-MERGE-01',
-            first_name='Bob',
-            last_name='Williams',
-            email='',  # blank -- will be filled
+            external_constituent_id="C-MERGE-01",
+            first_name="Bob",
+            last_name="Williams",
+            email="",  # blank -- will be filled
         )
         csv_data = _to_bytes(
-            'Constituent_ID,First_Name,Last_Name,Email\n'
-            'C-MERGE-01,Bob,Williams,bob@example.com\n'
+            "Constituent_ID,First_Name,Last_Name,Email\n"
+            "C-MERGE-01,Bob,Williams,bob@example.com\n"
         )
-        batch = import_re_constituents(csv_data, 'merge.csv', admin_user, staff_user)
+        batch = import_re_constituents(csv_data, "merge.csv", admin_user, staff_user)
         assert batch.status == ImportBatchStatus.COMPLETED
         assert batch.updated_count == 1
         assert batch.skipped_count == 0
-        assert batch.summary['skipped_details'] == []
+        assert batch.summary["skipped_details"] == []
 
     def test_no_skips_empty_details(self, admin_user, staff_user):
         """Fresh import with no pre-existing contacts has empty skipped_details."""
         csv_data = _to_bytes(
-            'Constituent_ID,First_Name,Last_Name,Email\n'
-            'C-NEW-01,Charlie,Brown,charlie@example.com\n'
+            "Constituent_ID,First_Name,Last_Name,Email\n"
+            "C-NEW-01,Charlie,Brown,charlie@example.com\n"
         )
-        batch = import_re_constituents(csv_data, 'fresh.csv', admin_user, staff_user)
+        batch = import_re_constituents(csv_data, "fresh.csv", admin_user, staff_user)
         assert batch.status == ImportBatchStatus.COMPLETED
         assert batch.created_count == 1
         assert batch.skipped_count == 0
-        assert batch.summary['skipped_details'] == []
+        assert batch.summary["skipped_details"] == []

--- a/apps/imports/tests/test_re_services.py
+++ b/apps/imports/tests/test_re_services.py
@@ -9,13 +9,11 @@ Covers all 4 RE import functions with minimal CSV inputs:
 
 Plus SHA256 dedup and malformed CSV handling.
 """
-from datetime import date
-
 import pytest
 
 from apps.contacts.models import Contact
 from apps.gifts.models import Gift, RecurringGift, Solicitor
-from apps.imports.models import ImportBatch, ImportBatchStatus, ImportBatchType
+from apps.imports.models import ImportBatch, ImportBatchStatus
 from apps.imports.re_services import (
     import_re_constituents,
     import_re_gifts,
@@ -488,7 +486,7 @@ class TestImportREGiftsOwnerReassignment:
             first_name="Cross",
             last_name="Admin",
         )
-        solicitor = Solicitor.objects.create(
+        Solicitor.objects.create(
             normalized_name="doe, john",
             external_solicitor_id="SOL-REOWN-01",
             user=missionary,

--- a/apps/imports/tests/test_services.py
+++ b/apps/imports/tests/test_services.py
@@ -34,8 +34,8 @@ Jane,Smith,jane@example.com,555-5678"""
 
         assert len(valid) == 2
         assert len(errors) == 0
-        assert valid[0]['first_name'] == 'John'
-        assert valid[1]['email'] == 'jane@example.com'
+        assert valid[0]["first_name"] == "John"
+        assert valid[1]["email"] == "jane@example.com"
 
     def test_parse_contacts_missing_required_field(self):
         """Test parsing contacts with missing required field."""
@@ -47,12 +47,12 @@ John,,john@example.com"""
 
         assert len(valid) == 0
         assert len(errors) == 1
-        assert 'Missing required field: last_name' in errors[0]['errors']
+        assert "Missing required field: last_name" in errors[0]["errors"]
 
     def test_parse_contacts_duplicate_email(self):
         """Test parsing contacts with duplicate email."""
         user = UserFactory()
-        ContactFactory(owner=user, email='existing@example.com')
+        ContactFactory(owner=user, email="existing@example.com")
 
         csv_content = """first_name,last_name,email
 John,Doe,existing@example.com"""
@@ -61,22 +61,31 @@ John,Doe,existing@example.com"""
 
         assert len(valid) == 0
         assert len(errors) == 1
-        assert 'already exists' in errors[0]['errors'][0]
+        assert "already exists" in errors[0]["errors"][0]
 
     def test_import_contacts(self):
         """Test importing valid contact records."""
         user = UserFactory()
         records = [
-            {'first_name': 'John', 'last_name': 'Doe', 'email': 'john@example.com',
-             'phone': '', 'street_address': '', 'city': '', 'state': '',
-             'postal_code': '', 'country': 'USA', 'notes': ''},
+            {
+                "first_name": "John",
+                "last_name": "Doe",
+                "email": "john@example.com",
+                "phone": "",
+                "street_address": "",
+                "city": "",
+                "state": "",
+                "postal_code": "",
+                "country": "USA",
+                "notes": "",
+            },
         ]
 
         count, contacts = import_contacts(records, user)
 
         assert count == 1
         assert len(contacts) == 1
-        assert contacts[0].first_name == 'John'
+        assert contacts[0].first_name == "John"
         assert contacts[0].owner == user
 
 
@@ -87,15 +96,15 @@ class TestContactExport:
     def test_export_contacts_csv(self):
         """Test exporting contacts to CSV."""
         user = UserFactory()
-        ContactFactory(owner=user, first_name='John', last_name='Doe', email='john@example.com')
-        ContactFactory(owner=user, first_name='Jane', last_name='Smith', email='jane@example.com')
+        ContactFactory(owner=user, first_name="John", last_name="Doe", email="john@example.com")
+        ContactFactory(owner=user, first_name="Jane", last_name="Smith", email="jane@example.com")
 
         queryset = Contact.objects.filter(owner=user)
         csv_output = export_contacts_csv(queryset)
 
-        assert 'first_name,last_name,email' in csv_output
-        assert 'John,Doe,john@example.com' in csv_output
-        assert 'Jane,Smith,jane@example.com' in csv_output
+        assert "first_name,last_name,email" in csv_output
+        assert "John,Doe,john@example.com" in csv_output
+        assert "Jane,Smith,jane@example.com" in csv_output
 
 
 @pytest.mark.django_db
@@ -104,15 +113,15 @@ class TestGiftExport:
 
     def test_export_gifts_csv(self):
         """Test exporting gifts to CSV."""
-        contact = ContactFactory(first_name='John', last_name='Doe', email='john@example.com')
+        contact = ContactFactory(first_name="John", last_name="Doe", email="john@example.com")
         GiftFactory(donor_contact=contact, amount_cents=10000)  # $100.00
 
         queryset = Gift.objects.all()
         csv_output = export_gifts_csv(queryset)
 
-        assert 'contact_first_name,contact_last_name' in csv_output
-        assert 'John,Doe' in csv_output
-        assert '100.00' in csv_output
+        assert "contact_first_name,contact_last_name" in csv_output
+        assert "John,Doe" in csv_output
+        assert "100.00" in csv_output
 
 
 class TestTemplates:
@@ -121,6 +130,6 @@ class TestTemplates:
     def test_get_contacts_template(self):
         """Test getting contacts CSV template."""
         template = get_contacts_template()
-        assert 'first_name' in template
-        assert 'last_name' in template
-        assert 'email' in template
+        assert "first_name" in template
+        assert "last_name" in template
+        assert "email" in template

--- a/apps/imports/tests/test_services.py
+++ b/apps/imports/tests/test_services.py
@@ -1,8 +1,6 @@
 """
 Tests for import/export services.
 """
-from decimal import Decimal
-
 import pytest
 
 from apps.contacts.models import Contact

--- a/apps/imports/tests/test_spo_commands.py
+++ b/apps/imports/tests/test_spo_commands.py
@@ -188,9 +188,9 @@ class TestReconcileMissionariesCommand(TestCase):
         )
         # Ensure it's on the John Smith line
         lines = output.splitlines()
-        john_lines = [l for l in lines if "John Smith" in l]
+        john_lines = [line for line in lines if "John Smith" in line]
         self.assertTrue(
-            any("ZERO DONATIONS" in l for l in john_lines),
+            any("ZERO DONATIONS" in line for line in john_lines),
             f"Expected 'ZERO DONATIONS' near 'John Smith' in output:\n{output}",
         )
 

--- a/apps/imports/tests/test_spo_commands.py
+++ b/apps/imports/tests/test_spo_commands.py
@@ -15,20 +15,20 @@ from django.test import TestCase
 from apps.imports.models import ImportBatch, ImportBatchStatus
 from apps.users.models import User
 
-
 # ---------------------------------------------------------------------------
 # CSV helpers
 # ---------------------------------------------------------------------------
+
 
 def _make_solicitor_csv(*names):
     """Build minimal SPO Solicitor CSV bytes with type-label row."""
     buf = io.StringIO()
     writer = csv_mod.writer(buf)
-    writer.writerow(['Solicitor'])
-    writer.writerow(['Name'])
+    writer.writerow(["Solicitor"])
+    writer.writerow(["Name"])
     for name in names:
         writer.writerow([name])
-    return buf.getvalue().encode('utf-8')
+    return buf.getvalue().encode("utf-8")
 
 
 def _make_gifts_csv(*rows, include_type_label=True):
@@ -36,39 +36,48 @@ def _make_gifts_csv(*rows, include_type_label=True):
     buf = io.StringIO()
     writer = csv_mod.writer(buf)
     if include_type_label:
-        writer.writerow(['Gift'])
-    writer.writerow([
-        'Gift ID', 'Constituent ID', 'Gift Is Anonymous',
-        'Solicitor Name', 'Solicitor Amount', 'Gift Amount', 'Gift Date',
-        'Gift Specific Attributes Prayer Requests Description',
-    ])
+        writer.writerow(["Gift"])
+    writer.writerow(
+        [
+            "Gift ID",
+            "Constituent ID",
+            "Gift Is Anonymous",
+            "Solicitor Name",
+            "Solicitor Amount",
+            "Gift Amount",
+            "Gift Date",
+            "Gift Specific Attributes Prayer Requests Description",
+        ]
+    )
     for row in rows:
-        writer.writerow([
-            row.get('gift_id', ''),
-            row.get('constituent_id', ''),
-            row.get('is_anonymous', 'No'),
-            row.get('solicitor_name', ''),
-            row.get('solicitor_amount', ''),
-            row.get('gift_amount', '0.00'),
-            row.get('gift_date', '2024-01-01'),
-            row.get('prayer_description', ''),
-        ])
-    return buf.getvalue().encode('utf-8')
+        writer.writerow(
+            [
+                row.get("gift_id", ""),
+                row.get("constituent_id", ""),
+                row.get("is_anonymous", "No"),
+                row.get("solicitor_name", ""),
+                row.get("solicitor_amount", ""),
+                row.get("gift_amount", "0.00"),
+                row.get("gift_date", "2024-01-01"),
+                row.get("prayer_description", ""),
+            ]
+        )
+    return buf.getvalue().encode("utf-8")
 
 
 def _make_admin():
     return User.objects.create_user(
-        email='admin@example.com',
-        password='adminpass',
-        first_name='Admin',
-        last_name='User',
-        role='admin',
+        email="admin@example.com",
+        password="adminpass",
+        first_name="Admin",
+        last_name="User",
+        role="admin",
     )
 
 
 def _write_temp_csv(content_bytes):
     """Write bytes to a temp file. Caller must delete."""
-    fd, path = tempfile.mkstemp(suffix='.csv')
+    fd, path = tempfile.mkstemp(suffix=".csv")
     os.write(fd, content_bytes)
     os.close(fd)
     return path
@@ -78,6 +87,7 @@ def _write_temp_csv(content_bytes):
 # TestReconcileMissionariesCommand
 # ---------------------------------------------------------------------------
 
+
 class TestReconcileMissionariesCommand(TestCase):
     """Integration tests for reconcile_missionaries management command."""
 
@@ -86,24 +96,26 @@ class TestReconcileMissionariesCommand(TestCase):
 
     def test_command_runs_successfully(self):
         """Command accepts file + --owner args, creates ImportBatch, prints summary."""
-        csv_bytes = _make_solicitor_csv('Peter Anderson')
+        csv_bytes = _make_solicitor_csv("Peter Anderson")
         path = _write_temp_csv(csv_bytes)
         try:
             out = io.StringIO()
-            call_command('reconcile_missionaries', path, owner=self.admin.email, stdout=out)
+            call_command("reconcile_missionaries", path, owner=self.admin.email, stdout=out)
             self.assertTrue(ImportBatch.objects.exists())
         finally:
             os.unlink(path)
 
     def test_force_flag_accepted(self):
         """--force flag accepted and passed to service without CommandError."""
-        csv_bytes = _make_solicitor_csv('Peter Anderson')
+        csv_bytes = _make_solicitor_csv("Peter Anderson")
         path = _write_temp_csv(csv_bytes)
         try:
             out = io.StringIO()
             # Run twice; second run with --force should not raise
-            call_command('reconcile_missionaries', path, owner=self.admin.email, stdout=out)
-            call_command('reconcile_missionaries', path, owner=self.admin.email, force=True, stdout=out)
+            call_command("reconcile_missionaries", path, owner=self.admin.email, stdout=out)
+            call_command(
+                "reconcile_missionaries", path, owner=self.admin.email, force=True, stdout=out
+            )
             # Force creates a new batch (old one deleted)
             self.assertEqual(ImportBatch.objects.count(), 1)
         finally:
@@ -111,48 +123,49 @@ class TestReconcileMissionariesCommand(TestCase):
 
     def test_missing_owner_raises_error(self):
         """Missing --owner (unknown email) raises CommandError."""
-        csv_bytes = _make_solicitor_csv('Peter Anderson')
+        csv_bytes = _make_solicitor_csv("Peter Anderson")
         path = _write_temp_csv(csv_bytes)
         try:
             with self.assertRaises(CommandError):
-                call_command('reconcile_missionaries', path, owner='nobody@example.com')
+                call_command("reconcile_missionaries", path, owner="nobody@example.com")
         finally:
             os.unlink(path)
 
     def test_zero_donation_flag_in_output(self):
         """_print_summary shows 'ZERO DONATIONS' for missionaries with gifts_imported==0."""
-        from apps.imports.management.commands.reconcile_missionaries import Command
         from unittest.mock import MagicMock
+
+        from apps.imports.management.commands.reconcile_missionaries import Command
 
         # Build a fake batch with a per_missionary entry where gifts_imported=0
         batch = MagicMock()
         batch.status = ImportBatchStatus.COMPLETED
-        batch.filename = 'test.csv'
+        batch.filename = "test.csv"
         batch.created_count = 1
         batch.updated_count = 0
         batch.skipped_count = 0
         batch.error_count = 0
-        batch.id = 'test-batch-id'
+        batch.id = "test-batch-id"
         batch.summary = {
-            'missionaries_expected': 2,
-            'matched_exact': 1,
-            'matched_normalized': 0,
-            'matched_alias': 0,
-            'created': 1,
-            'unresolved': 0,
-            'unresolved_names': [],
-            'per_missionary': [
+            "missionaries_expected": 2,
+            "matched_exact": 1,
+            "matched_normalized": 0,
+            "matched_alias": 0,
+            "created": 1,
+            "unresolved": 0,
+            "unresolved_names": [],
+            "per_missionary": [
                 {
-                    'name': 'Peter Anderson',
-                    'match_type': 'exact',
-                    'action': 'matched',
-                    'gifts_imported': 12,
+                    "name": "Peter Anderson",
+                    "match_type": "exact",
+                    "action": "matched",
+                    "gifts_imported": 12,
                 },
                 {
-                    'name': 'John Smith',
-                    'match_type': 'created',
-                    'action': 'created',
-                    'gifts_imported': 0,
+                    "name": "John Smith",
+                    "match_type": "created",
+                    "action": "created",
+                    "gifts_imported": 0,
                 },
             ],
         }
@@ -160,26 +173,32 @@ class TestReconcileMissionariesCommand(TestCase):
         cmd = Command()
         cmd.style = MagicMock()
         # Make style.WARNING return a recognizable string
-        cmd.style.WARNING = lambda s: f'WARNING:{s}'
-        cmd.style.SUCCESS = lambda s: f'SUCCESS:{s}'
-        cmd.style.ERROR = lambda s: f'ERROR:{s}'
+        cmd.style.WARNING = lambda s: f"WARNING:{s}"
+        cmd.style.SUCCESS = lambda s: f"SUCCESS:{s}"
+        cmd.style.ERROR = lambda s: f"ERROR:{s}"
 
         out = io.StringIO()
         cmd._print_summary(batch, out)
         output = out.getvalue()
 
-        self.assertIn('ZERO DONATIONS', output)
-        self.assertNotIn('ZERO DONATIONS', output.split('Peter Anderson')[0] if 'Peter Anderson' in output else '')
+        self.assertIn("ZERO DONATIONS", output)
+        self.assertNotIn(
+            "ZERO DONATIONS",
+            output.split("Peter Anderson")[0] if "Peter Anderson" in output else "",
+        )
         # Ensure it's on the John Smith line
         lines = output.splitlines()
-        john_lines = [l for l in lines if 'John Smith' in l]
-        self.assertTrue(any('ZERO DONATIONS' in l for l in john_lines),
-                        f"Expected 'ZERO DONATIONS' near 'John Smith' in output:\n{output}")
+        john_lines = [l for l in lines if "John Smith" in l]
+        self.assertTrue(
+            any("ZERO DONATIONS" in l for l in john_lines),
+            f"Expected 'ZERO DONATIONS' near 'John Smith' in output:\n{output}",
+        )
 
 
 # ---------------------------------------------------------------------------
 # TestImportSpoGiftsCommand
 # ---------------------------------------------------------------------------
+
 
 class TestImportSpoGiftsCommand(TestCase):
     """Integration tests for import_spo_gifts management command."""
@@ -188,45 +207,49 @@ class TestImportSpoGiftsCommand(TestCase):
         self.admin = _make_admin()
         # Create a missionary user so the solicitor name resolves
         self.missionary = User.objects.create_user(
-            email='peter.anderson@spo.org',
-            password='testpass',
-            first_name='Peter',
-            last_name='Anderson',
-            role='missionary',
+            email="peter.anderson@spo.org",
+            password="testpass",
+            first_name="Peter",
+            last_name="Anderson",
+            role="missionary",
             is_active=True,
         )
 
     def test_command_runs_successfully(self):
         """Command accepts file + --owner args, creates ImportBatch."""
-        csv_bytes = _make_gifts_csv({
-            'gift_id': 'G001',
-            'solicitor_name': 'Anderson, Peter',
-            'gift_amount': '100.00',
-            'gift_date': '2024-01-15',
-            'is_anonymous': 'Yes',
-        })
+        csv_bytes = _make_gifts_csv(
+            {
+                "gift_id": "G001",
+                "solicitor_name": "Anderson, Peter",
+                "gift_amount": "100.00",
+                "gift_date": "2024-01-15",
+                "is_anonymous": "Yes",
+            }
+        )
         path = _write_temp_csv(csv_bytes)
         try:
             out = io.StringIO()
-            call_command('import_spo_gifts', path, owner=self.admin.email, stdout=out)
+            call_command("import_spo_gifts", path, owner=self.admin.email, stdout=out)
             self.assertTrue(ImportBatch.objects.exists())
         finally:
             os.unlink(path)
 
     def test_force_flag_accepted(self):
         """--force flag accepted without CommandError."""
-        csv_bytes = _make_gifts_csv({
-            'gift_id': 'G002',
-            'solicitor_name': 'Anderson, Peter',
-            'gift_amount': '50.00',
-            'gift_date': '2024-02-01',
-            'is_anonymous': 'Yes',
-        })
+        csv_bytes = _make_gifts_csv(
+            {
+                "gift_id": "G002",
+                "solicitor_name": "Anderson, Peter",
+                "gift_amount": "50.00",
+                "gift_date": "2024-02-01",
+                "is_anonymous": "Yes",
+            }
+        )
         path = _write_temp_csv(csv_bytes)
         try:
             out = io.StringIO()
-            call_command('import_spo_gifts', path, owner=self.admin.email, stdout=out)
-            call_command('import_spo_gifts', path, owner=self.admin.email, force=True, stdout=out)
+            call_command("import_spo_gifts", path, owner=self.admin.email, stdout=out)
+            call_command("import_spo_gifts", path, owner=self.admin.email, force=True, stdout=out)
             self.assertEqual(ImportBatch.objects.count(), 1)
         finally:
             os.unlink(path)
@@ -236,6 +259,7 @@ class TestImportSpoGiftsCommand(TestCase):
 # TestImportSpoPrayersCommand
 # ---------------------------------------------------------------------------
 
+
 class TestImportSpoPrayersCommand(TestCase):
     """Integration tests for import_spo_prayers management command."""
 
@@ -244,36 +268,40 @@ class TestImportSpoPrayersCommand(TestCase):
 
     def test_command_runs_successfully(self):
         """Command accepts file + --owner args, creates ImportBatch."""
-        csv_bytes = _make_gifts_csv({
-            'gift_id': 'G003',
-            'solicitor_name': 'Some Missionary',
-            'gift_amount': '75.00',
-            'gift_date': '2024-03-01',
-            'is_anonymous': 'Yes',
-            'prayer_description': '',
-        })
+        csv_bytes = _make_gifts_csv(
+            {
+                "gift_id": "G003",
+                "solicitor_name": "Some Missionary",
+                "gift_amount": "75.00",
+                "gift_date": "2024-03-01",
+                "is_anonymous": "Yes",
+                "prayer_description": "",
+            }
+        )
         path = _write_temp_csv(csv_bytes)
         try:
             out = io.StringIO()
-            call_command('import_spo_prayers', path, owner=self.admin.email, stdout=out)
+            call_command("import_spo_prayers", path, owner=self.admin.email, stdout=out)
             self.assertTrue(ImportBatch.objects.exists())
         finally:
             os.unlink(path)
 
     def test_force_flag_accepted(self):
         """--force flag accepted without CommandError."""
-        csv_bytes = _make_gifts_csv({
-            'gift_id': 'G004',
-            'solicitor_name': 'Some Missionary',
-            'gift_amount': '25.00',
-            'gift_date': '2024-04-01',
-            'is_anonymous': 'Yes',
-        })
+        csv_bytes = _make_gifts_csv(
+            {
+                "gift_id": "G004",
+                "solicitor_name": "Some Missionary",
+                "gift_amount": "25.00",
+                "gift_date": "2024-04-01",
+                "is_anonymous": "Yes",
+            }
+        )
         path = _write_temp_csv(csv_bytes)
         try:
             out = io.StringIO()
-            call_command('import_spo_prayers', path, owner=self.admin.email, stdout=out)
-            call_command('import_spo_prayers', path, owner=self.admin.email, force=True, stdout=out)
+            call_command("import_spo_prayers", path, owner=self.admin.email, stdout=out)
+            call_command("import_spo_prayers", path, owner=self.admin.email, force=True, stdout=out)
             self.assertEqual(ImportBatch.objects.count(), 1)
         finally:
             os.unlink(path)

--- a/apps/imports/tests/test_spo_csv_fixture_mapping.py
+++ b/apps/imports/tests/test_spo_csv_fixture_mapping.py
@@ -17,7 +17,7 @@ from django.test import TestCase
 
 import pytest
 
-from apps.imports.models import ImportBatch, ImportBatchStatus
+from apps.imports.models import ImportBatchStatus
 from apps.users.models import User
 
 FIXTURE_DIR = os.path.join(os.path.dirname(__file__), "..", "..", "..", "test_data")

--- a/apps/imports/tests/test_spo_services.py
+++ b/apps/imports/tests/test_spo_services.py
@@ -2,14 +2,15 @@
 Tests for SPO reconcile_missionaries() and import_spo_gifts() services.
 
 TDD plan 02: TestReconcileMissionaries stubs filled in.
-TDD plan 03: TestImportSpoGifts stubs filled in (import_spo_gifts, import_spo_prayers, TestIdempotency).
+TDD plan 03: TestImportSpoGifts stubs filled in
+(import_spo_gifts, import_spo_prayers, TestIdempotency).
 """
 import csv as csv_mod
 import io
 
 from django.test import TestCase
 
-from apps.imports.models import ImportBatch, ImportBatchStatus, MissionaryAlias
+from apps.imports.models import ImportBatchStatus, MissionaryAlias
 from apps.users.models import User
 
 
@@ -112,7 +113,7 @@ class TestReconcileMissionaries(TestCase):
         from apps.imports.spo_services import reconcile_missionaries
 
         admin = _make_admin()
-        missionary = _make_user("peter.anderson@test.com", "Peter", "Anderson")
+        _make_user("peter.anderson@test.com", "Peter", "Anderson")
 
         csv_bytes = _make_solicitor_csv("Peter Anderson")
         batch = reconcile_missionaries(csv_bytes, "solicitors.csv", admin)
@@ -128,7 +129,7 @@ class TestReconcileMissionaries(TestCase):
 
         admin = _make_admin()
         # User stored as "O'Brien" (with apostrophe)
-        missionary = _make_user("pat.obrien@test.com", "Pat", "O'Brien")
+        _make_user("pat.obrien@test.com", "Pat", "O'Brien")
 
         # CSV has "OBrien, Pat" (no apostrophe) — normalized match
         csv_bytes = _make_solicitor_csv("OBrien, Pat")
@@ -192,7 +193,7 @@ class TestReconcileMissionaries(TestCase):
 
         admin = _make_admin()
         # Pre-existing user with the expected placeholder email
-        existing = _make_user("john.smith@spo.org", "John", "Smith")
+        _make_user("john.smith@spo.org", "John", "Smith")
 
         # Another John Smith in CSV (different person)
         csv_bytes = _make_solicitor_csv("John Smith")
@@ -211,7 +212,7 @@ class TestReconcileMissionaries(TestCase):
 
         admin = _make_admin()
         # Create user with the expected placeholder email
-        existing = User.objects.create_user(
+        User.objects.create_user(
             email="bob.jones@spo.org",
             password="pass",
             first_name="Bob",
@@ -258,7 +259,7 @@ class TestReconcileMissionaries(TestCase):
         original_first = missionary.first_name
 
         csv_bytes = _make_solicitor_csv("Carol White")
-        batch = reconcile_missionaries(csv_bytes, "solicitors.csv", admin)
+        reconcile_missionaries(csv_bytes, "solicitors.csv", admin)
 
         missionary.refresh_from_db()
         # first_name should NOT be overwritten (it was already set)
@@ -324,7 +325,7 @@ class TestReconcileMissionaries(TestCase):
         missionary = _make_user("alice.resolved@test.com", "Alice", "Resolved")
 
         csv_bytes = _make_solicitor_csv("Alice Resolved")
-        batch = reconcile_missionaries(csv_bytes, "solicitors.csv", admin)
+        reconcile_missionaries(csv_bytes, "solicitors.csv", admin)
 
         self.assertTrue(
             Solicitor.objects.filter(user=missionary).exists(),
@@ -341,7 +342,7 @@ class TestReconcileMissionaries(TestCase):
 
         initial_solicitor_count = Solicitor.objects.count()
         csv_bytes = _make_solicitor_csv("No Solicitor Person")
-        batch = reconcile_missionaries(csv_bytes, "solicitors.csv", admin)
+        reconcile_missionaries(csv_bytes, "solicitors.csv", admin)
 
         # No new Solicitor records should have been created
         self.assertEqual(Solicitor.objects.count(), initial_solicitor_count)
@@ -460,7 +461,6 @@ class TestGetOrCreateMissionarySolicitor(TestCase):
 
     def test_creates_solicitor_for_missionary(self):
         """Creates Solicitor record for a missionary User."""
-        from apps.gifts.models import Solicitor
         from apps.imports.spo_services import _get_or_create_missionary_solicitor
 
         missionary = User.objects.create_user(
@@ -497,7 +497,6 @@ class TestGetOrCreateAnonymousContact(TestCase):
 
     def test_creates_contact(self):
         """Creates Anonymous Donor contact for missionary."""
-        from apps.contacts.models import Contact
         from apps.imports.spo_services import _get_or_create_anonymous_contact
 
         missionary = User.objects.create_user(
@@ -665,7 +664,7 @@ class TestImportSpoGifts(TestCase):
 
         admin = _make_admin()
         missionary = _make_user("peter.attr@test.com", "Peter", "Attr")
-        solicitor = Solicitor.objects.create(
+        Solicitor.objects.create(
             user=missionary,
             normalized_name=normalize_solicitor_name(missionary.full_name),
         )
@@ -746,7 +745,7 @@ class TestImportSpoGifts(TestCase):
 
     def test_type_label_row_skipped(self):
         """Leading SPO type-label row (Gift,...) is skipped before DictReader."""
-        from apps.gifts.models import Gift, Solicitor
+        from apps.gifts.models import Solicitor
         from apps.imports.re_services import normalize_solicitor_name
         from apps.imports.spo_services import import_spo_gifts
 
@@ -813,7 +812,7 @@ class TestImportSpoGifts(TestCase):
             {"gift_id": "G-ZERO-02", "solicitor_name": "Zero Amt", "gift_amount": "N/A"},
             {"gift_id": "G-GOOD-01", "solicitor_name": "Zero Amt", "gift_amount": "50.00"},
         )
-        batch = import_spo_gifts(csv_bytes, "gifts.csv", admin)
+        import_spo_gifts(csv_bytes, "gifts.csv", admin)
 
         # Only the valid $50 gift should be created
         self.assertEqual(Gift.objects.filter(external_gift_id="G-GOOD-01").count(), 1)
@@ -826,7 +825,6 @@ class TestImportSpoPrayers(TestCase):
 
     def test_prayer_extracted_without_gift_creation(self):
         """import_spo_prayers() creates PrayerIntention but NOT Gift records."""
-        from apps.contacts.models import Contact
         from apps.gifts.models import Gift, Solicitor
         from apps.imports.re_services import normalize_solicitor_name
         from apps.imports.spo_services import import_spo_prayers

--- a/apps/imports/tests/test_spo_services.py
+++ b/apps/imports/tests/test_spo_services.py
@@ -20,19 +20,20 @@ def _make_solicitor_csv(*names):
     """
     import csv as csv_mod
     import io as io_mod
+
     buf = io_mod.StringIO()
     writer = csv_mod.writer(buf)
-    writer.writerow(['Solicitor'])
-    writer.writerow(['Name'])
+    writer.writerow(["Solicitor"])
+    writer.writerow(["Name"])
     for name in names:
         writer.writerow([name])
-    return buf.getvalue().encode('utf-8')
+    return buf.getvalue().encode("utf-8")
 
 
-def _make_user(email, first, last, role='missionary', active=True):
+def _make_user(email, first, last, role="missionary", active=True):
     return User.objects.create_user(
         email=email,
-        password='testpass123',
+        password="testpass123",
         first_name=first,
         last_name=last,
         role=role,
@@ -42,11 +43,11 @@ def _make_user(email, first, last, role='missionary', active=True):
 
 def _make_admin():
     return User.objects.create_user(
-        email='admin@example.com',
-        password='adminpass',
-        first_name='Admin',
-        last_name='User',
-        role='admin',
+        email="admin@example.com",
+        password="adminpass",
+        first_name="Admin",
+        last_name="User",
+        role="admin",
     )
 
 
@@ -60,38 +61,47 @@ def _make_gifts_csv(*rows, include_type_label=True):
     buf = io.StringIO()
     writer = csv_mod.writer(buf)
     if include_type_label:
-        writer.writerow(['Gift'])
-    writer.writerow([
-        'Gift ID', 'Constituent ID', 'Gift Is Anonymous', 'Solicitor Name',
-        'Solicitor Amount', 'Gift Amount', 'Gift Date',
-        'Gift Specific Attributes Prayer Requests Description',
-        'Gift Payment Type',
-    ])
+        writer.writerow(["Gift"])
+    writer.writerow(
+        [
+            "Gift ID",
+            "Constituent ID",
+            "Gift Is Anonymous",
+            "Solicitor Name",
+            "Solicitor Amount",
+            "Gift Amount",
+            "Gift Date",
+            "Gift Specific Attributes Prayer Requests Description",
+            "Gift Payment Type",
+        ]
+    )
     defaults = {
-        'gift_id': 'G001',
-        'constituent_id': '',
-        'is_anonymous': '',
-        'solicitor_name': '',
-        'solicitor_amount': '50.00',
-        'gift_amount': '50.00',
-        'gift_date': '2025-01-15',
-        'prayer_description': '',
-        'payment_type': '',
+        "gift_id": "G001",
+        "constituent_id": "",
+        "is_anonymous": "",
+        "solicitor_name": "",
+        "solicitor_amount": "50.00",
+        "gift_amount": "50.00",
+        "gift_date": "2025-01-15",
+        "prayer_description": "",
+        "payment_type": "",
     }
     for row in rows:
         r = {**defaults, **row}
-        writer.writerow([
-            r['gift_id'],
-            r['constituent_id'],
-            r['is_anonymous'],
-            r['solicitor_name'],
-            r['solicitor_amount'],
-            r['gift_amount'],
-            r['gift_date'],
-            r['prayer_description'],
-            r['payment_type'],
-        ])
-    return buf.getvalue().encode('utf-8')
+        writer.writerow(
+            [
+                r["gift_id"],
+                r["constituent_id"],
+                r["is_anonymous"],
+                r["solicitor_name"],
+                r["solicitor_amount"],
+                r["gift_amount"],
+                r["gift_date"],
+                r["prayer_description"],
+                r["payment_type"],
+            ]
+        )
+    return buf.getvalue().encode("utf-8")
 
 
 class TestReconcileMissionaries(TestCase):
@@ -102,15 +112,15 @@ class TestReconcileMissionaries(TestCase):
         from apps.imports.spo_services import reconcile_missionaries
 
         admin = _make_admin()
-        missionary = _make_user('peter.anderson@test.com', 'Peter', 'Anderson')
+        missionary = _make_user("peter.anderson@test.com", "Peter", "Anderson")
 
-        csv_bytes = _make_solicitor_csv('Peter Anderson')
-        batch = reconcile_missionaries(csv_bytes, 'solicitors.csv', admin)
+        csv_bytes = _make_solicitor_csv("Peter Anderson")
+        batch = reconcile_missionaries(csv_bytes, "solicitors.csv", admin)
 
         self.assertEqual(batch.status, ImportBatchStatus.COMPLETED)
         # Peter Anderson was matched, not created
         self.assertEqual(batch.created_count, 0)
-        self.assertEqual(batch.summary['matched_exact'], 1)
+        self.assertEqual(batch.summary["matched_exact"], 1)
 
     def test_normalized_match(self):
         """Punctuation-stripped lowercase match links to User."""
@@ -122,10 +132,10 @@ class TestReconcileMissionaries(TestCase):
 
         # CSV has "OBrien, Pat" (no apostrophe) — normalized match
         csv_bytes = _make_solicitor_csv("OBrien, Pat")
-        batch = reconcile_missionaries(csv_bytes, 'solicitors.csv', admin)
+        batch = reconcile_missionaries(csv_bytes, "solicitors.csv", admin)
 
         self.assertEqual(batch.status, ImportBatchStatus.COMPLETED)
-        self.assertEqual(batch.summary['matched_normalized'], 1)
+        self.assertEqual(batch.summary["matched_normalized"], 1)
         self.assertEqual(batch.created_count, 0)
 
     def test_alias_match(self):
@@ -133,14 +143,14 @@ class TestReconcileMissionaries(TestCase):
         from apps.imports.spo_services import reconcile_missionaries
 
         admin = _make_admin()
-        missionary = _make_user('james.marshall@test.com', 'James', 'Marshall')
-        MissionaryAlias.objects.create(source_name='Jim Marshall', user=missionary)
+        missionary = _make_user("james.marshall@test.com", "James", "Marshall")
+        MissionaryAlias.objects.create(source_name="Jim Marshall", user=missionary)
 
-        csv_bytes = _make_solicitor_csv('Jim Marshall')
-        batch = reconcile_missionaries(csv_bytes, 'solicitors.csv', admin)
+        csv_bytes = _make_solicitor_csv("Jim Marshall")
+        batch = reconcile_missionaries(csv_bytes, "solicitors.csv", admin)
 
         self.assertEqual(batch.status, ImportBatchStatus.COMPLETED)
-        self.assertEqual(batch.summary['matched_alias'], 1)
+        self.assertEqual(batch.summary["matched_alias"], 1)
         self.assertEqual(batch.created_count, 0)
 
     def test_alias_unresolved(self):
@@ -149,31 +159,31 @@ class TestReconcileMissionaries(TestCase):
 
         admin = _make_admin()
         # Admin has flagged this name as unresolvable
-        MissionaryAlias.objects.create(source_name='Unknown Person', user=None)
+        MissionaryAlias.objects.create(source_name="Unknown Person", user=None)
 
-        csv_bytes = _make_solicitor_csv('Unknown Person')
-        batch = reconcile_missionaries(csv_bytes, 'solicitors.csv', admin)
+        csv_bytes = _make_solicitor_csv("Unknown Person")
+        batch = reconcile_missionaries(csv_bytes, "solicitors.csv", admin)
 
         self.assertEqual(batch.status, ImportBatchStatus.COMPLETED)
-        self.assertEqual(batch.summary['unresolved'], 1)
+        self.assertEqual(batch.summary["unresolved"], 1)
         self.assertEqual(batch.created_count, 0)
-        self.assertIn('Unknown Person', batch.summary['unresolved_names'])
+        self.assertIn("Unknown Person", batch.summary["unresolved_names"])
 
     def test_auto_create_user(self):
         """No match → auto-create User with role=missionary, placeholder email."""
         from apps.imports.spo_services import reconcile_missionaries
 
         admin = _make_admin()
-        csv_bytes = _make_solicitor_csv('Alice Newcomer')
-        batch = reconcile_missionaries(csv_bytes, 'solicitors.csv', admin)
+        csv_bytes = _make_solicitor_csv("Alice Newcomer")
+        batch = reconcile_missionaries(csv_bytes, "solicitors.csv", admin)
 
         self.assertEqual(batch.status, ImportBatchStatus.COMPLETED)
         self.assertEqual(batch.created_count, 1)
-        self.assertEqual(batch.summary['created'], 1)
+        self.assertEqual(batch.summary["created"], 1)
 
-        created_user = User.objects.get(first_name='Alice', last_name='Newcomer')
-        self.assertEqual(created_user.role, 'missionary')
-        self.assertEqual(created_user.email, 'alice.newcomer@spo.org')
+        created_user = User.objects.get(first_name="Alice", last_name="Newcomer")
+        self.assertEqual(created_user.role, "missionary")
+        self.assertEqual(created_user.email, "alice.newcomer@spo.org")
         self.assertTrue(created_user.is_active)
 
     def test_placeholder_email_collision(self):
@@ -182,11 +192,11 @@ class TestReconcileMissionaries(TestCase):
 
         admin = _make_admin()
         # Pre-existing user with the expected placeholder email
-        existing = _make_user('john.smith@spo.org', 'John', 'Smith')
+        existing = _make_user("john.smith@spo.org", "John", "Smith")
 
         # Another John Smith in CSV (different person)
-        csv_bytes = _make_solicitor_csv('John Smith')
-        batch = reconcile_missionaries(csv_bytes, 'solicitors.csv', admin)
+        csv_bytes = _make_solicitor_csv("John Smith")
+        batch = reconcile_missionaries(csv_bytes, "solicitors.csv", admin)
 
         # Should have found existing John Smith by exact match (not created new)
         # But if there are genuinely two different Johns: second gets suffix
@@ -202,27 +212,27 @@ class TestReconcileMissionaries(TestCase):
         admin = _make_admin()
         # Create user with the expected placeholder email
         existing = User.objects.create_user(
-            email='bob.jones@spo.org',
-            password='pass',
-            first_name='Bob',
-            last_name='Jones',
+            email="bob.jones@spo.org",
+            password="pass",
+            first_name="Bob",
+            last_name="Jones",
         )
         # Now auto-create another Bob Jones (different person)
-        user, email = _auto_create_missionary_user('Bob Jones', admin)
-        self.assertEqual(email, 'bob.jones2@spo.org')
-        self.assertEqual(user.email, 'bob.jones2@spo.org')
+        user, email = _auto_create_missionary_user("Bob Jones", admin)
+        self.assertEqual(email, "bob.jones2@spo.org")
+        self.assertEqual(user.email, "bob.jones2@spo.org")
 
     def test_sha256_dedup(self):
         """Same file bytes → DUPLICATE status returned."""
         from apps.imports.spo_services import reconcile_missionaries
 
         admin = _make_admin()
-        csv_bytes = _make_solicitor_csv('Alice Test')
+        csv_bytes = _make_solicitor_csv("Alice Test")
 
-        batch1 = reconcile_missionaries(csv_bytes, 'solicitors.csv', admin)
+        batch1 = reconcile_missionaries(csv_bytes, "solicitors.csv", admin)
         self.assertNotEqual(batch1.status, ImportBatchStatus.DUPLICATE)
 
-        batch2 = reconcile_missionaries(csv_bytes, 'solicitors.csv', admin)
+        batch2 = reconcile_missionaries(csv_bytes, "solicitors.csv", admin)
         self.assertEqual(batch2.status, ImportBatchStatus.DUPLICATE)
 
     def test_force_bypasses_dedup(self):
@@ -230,12 +240,12 @@ class TestReconcileMissionaries(TestCase):
         from apps.imports.spo_services import reconcile_missionaries
 
         admin = _make_admin()
-        csv_bytes = _make_solicitor_csv('Alice Force')
+        csv_bytes = _make_solicitor_csv("Alice Force")
 
-        batch1 = reconcile_missionaries(csv_bytes, 'solicitors.csv', admin)
+        batch1 = reconcile_missionaries(csv_bytes, "solicitors.csv", admin)
         self.assertNotEqual(batch1.status, ImportBatchStatus.DUPLICATE)
 
-        batch2 = reconcile_missionaries(csv_bytes, 'solicitors.csv', admin, force=True)
+        batch2 = reconcile_missionaries(csv_bytes, "solicitors.csv", admin, force=True)
         self.assertNotEqual(batch2.status, ImportBatchStatus.DUPLICATE)
 
     def test_merge_only_existing_user(self):
@@ -244,11 +254,11 @@ class TestReconcileMissionaries(TestCase):
 
         admin = _make_admin()
         # User exists with no first_name filled (edge case for merge logic)
-        missionary = _make_user('carol.white@test.com', 'Carol', 'White')
+        missionary = _make_user("carol.white@test.com", "Carol", "White")
         original_first = missionary.first_name
 
-        csv_bytes = _make_solicitor_csv('Carol White')
-        batch = reconcile_missionaries(csv_bytes, 'solicitors.csv', admin)
+        csv_bytes = _make_solicitor_csv("Carol White")
+        batch = reconcile_missionaries(csv_bytes, "solicitors.csv", admin)
 
         missionary.refresh_from_db()
         # first_name should NOT be overwritten (it was already set)
@@ -259,13 +269,20 @@ class TestReconcileMissionaries(TestCase):
         from apps.imports.spo_services import reconcile_missionaries
 
         admin = _make_admin()
-        csv_bytes = _make_solicitor_csv('Test Person')
-        batch = reconcile_missionaries(csv_bytes, 'solicitors.csv', admin)
+        csv_bytes = _make_solicitor_csv("Test Person")
+        batch = reconcile_missionaries(csv_bytes, "solicitors.csv", admin)
 
         required_keys = [
-            'missionaries_expected', 'matched_exact', 'matched_normalized',
-            'matched_alias', 'created', 'unresolved', 'unresolved_names',
-            'needs_real_email', 'per_missionary', 'tri_source',
+            "missionaries_expected",
+            "matched_exact",
+            "matched_normalized",
+            "matched_alias",
+            "created",
+            "unresolved",
+            "unresolved_names",
+            "needs_real_email",
+            "per_missionary",
+            "tri_source",
         ]
         for key in required_keys:
             self.assertIn(key, batch.summary, f"Missing key: {key}")
@@ -275,28 +292,28 @@ class TestReconcileMissionaries(TestCase):
         from apps.imports.spo_services import reconcile_missionaries
 
         admin = _make_admin()
-        csv_bytes = _make_solicitor_csv('Tri Source Person')
-        batch = reconcile_missionaries(csv_bytes, 'solicitors.csv', admin)
+        csv_bytes = _make_solicitor_csv("Tri Source Person")
+        batch = reconcile_missionaries(csv_bytes, "solicitors.csv", admin)
 
-        self.assertIn('tri_source', batch.summary)
-        tri = batch.summary['tri_source']
-        self.assertIn('csv_only', tri)
-        self.assertIn('mpd_only', tri)
-        self.assertIn('db_only', tri)
-        self.assertIn('all_three', tri)
+        self.assertIn("tri_source", batch.summary)
+        tri = batch.summary["tri_source"]
+        self.assertIn("csv_only", tri)
+        self.assertIn("mpd_only", tri)
+        self.assertIn("db_only", tri)
+        self.assertIn("all_three", tri)
 
     def test_unresolved_stored_in_summary(self):
         """Unresolved names saved to ImportBatch.summary['unresolved_names']."""
         from apps.imports.spo_services import reconcile_missionaries
 
         admin = _make_admin()
-        MissionaryAlias.objects.create(source_name='Unresolvable Name', user=None)
+        MissionaryAlias.objects.create(source_name="Unresolvable Name", user=None)
 
-        csv_bytes = _make_solicitor_csv('Unresolvable Name')
-        batch = reconcile_missionaries(csv_bytes, 'solicitors.csv', admin)
+        csv_bytes = _make_solicitor_csv("Unresolvable Name")
+        batch = reconcile_missionaries(csv_bytes, "solicitors.csv", admin)
 
-        self.assertIn('unresolved_names', batch.summary)
-        self.assertIn('Unresolvable Name', batch.summary['unresolved_names'])
+        self.assertIn("unresolved_names", batch.summary)
+        self.assertIn("Unresolvable Name", batch.summary["unresolved_names"])
 
     def test_solicitor_record_created_for_resolved_missionary(self):
         """Resolved missionary has a Solicitor record after reconciliation."""
@@ -304,14 +321,14 @@ class TestReconcileMissionaries(TestCase):
         from apps.imports.spo_services import reconcile_missionaries
 
         admin = _make_admin()
-        missionary = _make_user('alice.resolved@test.com', 'Alice', 'Resolved')
+        missionary = _make_user("alice.resolved@test.com", "Alice", "Resolved")
 
-        csv_bytes = _make_solicitor_csv('Alice Resolved')
-        batch = reconcile_missionaries(csv_bytes, 'solicitors.csv', admin)
+        csv_bytes = _make_solicitor_csv("Alice Resolved")
+        batch = reconcile_missionaries(csv_bytes, "solicitors.csv", admin)
 
         self.assertTrue(
             Solicitor.objects.filter(user=missionary).exists(),
-            'Resolved missionary should have a Solicitor record'
+            "Resolved missionary should have a Solicitor record",
         )
 
     def test_unresolved_missionary_has_no_solicitor_record(self):
@@ -320,11 +337,11 @@ class TestReconcileMissionaries(TestCase):
         from apps.imports.spo_services import reconcile_missionaries
 
         admin = _make_admin()
-        MissionaryAlias.objects.create(source_name='No Solicitor Person', user=None)
+        MissionaryAlias.objects.create(source_name="No Solicitor Person", user=None)
 
         initial_solicitor_count = Solicitor.objects.count()
-        csv_bytes = _make_solicitor_csv('No Solicitor Person')
-        batch = reconcile_missionaries(csv_bytes, 'solicitors.csv', admin)
+        csv_bytes = _make_solicitor_csv("No Solicitor Person")
+        batch = reconcile_missionaries(csv_bytes, "solicitors.csv", admin)
 
         # No new Solicitor records should have been created
         self.assertEqual(Solicitor.objects.count(), initial_solicitor_count)
@@ -335,67 +352,72 @@ class TestMatchMissionaryName(TestCase):
 
     def _make_user(self, email, first, last):
         return User.objects.create_user(
-            email=email, password='pass', first_name=first, last_name=last,
-            role='missionary',
+            email=email,
+            password="pass",
+            first_name=first,
+            last_name=last,
+            role="missionary",
         )
 
     def test_exact_match(self):
         """Exact full name → ('user', 'exact')."""
-        from apps.imports.spo_services import _match_missionary_name, _build_user_lookup
+        from apps.imports.spo_services import _build_user_lookup, _match_missionary_name
 
-        user = self._make_user('peter@test.com', 'Peter', 'Anderson')
-        user_lookup = _build_user_lookup(User.objects.filter(role='missionary'))
+        user = self._make_user("peter@test.com", "Peter", "Anderson")
+        user_lookup = _build_user_lookup(User.objects.filter(role="missionary"))
         alias_lookup = {}
 
-        result_user, match_type = _match_missionary_name('Peter Anderson', user_lookup, alias_lookup)
-        self.assertEqual(match_type, 'exact')
+        result_user, match_type = _match_missionary_name(
+            "Peter Anderson", user_lookup, alias_lookup
+        )
+        self.assertEqual(match_type, "exact")
         self.assertEqual(result_user, user)
 
     def test_normalized_match(self):
         """Punctuation-stripped match → ('user', 'normalized')."""
-        from apps.imports.spo_services import _match_missionary_name, _build_user_lookup
+        from apps.imports.spo_services import _build_user_lookup, _match_missionary_name
 
         user = self._make_user("pat.obrien@test.com", "Pat", "O'Brien")
-        user_lookup = _build_user_lookup(User.objects.filter(role='missionary'))
+        user_lookup = _build_user_lookup(User.objects.filter(role="missionary"))
         alias_lookup = {}
 
         # CSV name has no apostrophe — should normalize-match
         result_user, match_type = _match_missionary_name("OBrien, Pat", user_lookup, alias_lookup)
-        self.assertEqual(match_type, 'normalized')
+        self.assertEqual(match_type, "normalized")
         self.assertEqual(result_user, user)
 
     def test_alias_match_with_user(self):
         """Alias entry with user set → ('user', 'alias')."""
-        from apps.imports.spo_services import _match_missionary_name, _build_alias_lookup
+        from apps.imports.spo_services import _build_alias_lookup, _match_missionary_name
 
-        user = self._make_user('james@test.com', 'James', 'Marshall')
-        MissionaryAlias.objects.create(source_name='Jim Marshall', user=user)
+        user = self._make_user("james@test.com", "James", "Marshall")
+        MissionaryAlias.objects.create(source_name="Jim Marshall", user=user)
         alias_lookup = _build_alias_lookup()
         user_lookup = {}
 
-        result_user, match_type = _match_missionary_name('Jim Marshall', user_lookup, alias_lookup)
-        self.assertEqual(match_type, 'alias')
+        result_user, match_type = _match_missionary_name("Jim Marshall", user_lookup, alias_lookup)
+        self.assertEqual(match_type, "alias")
         self.assertEqual(result_user, user)
 
     def test_alias_match_unresolved(self):
         """Alias entry with user=None → (None, 'unresolved')."""
-        from apps.imports.spo_services import _match_missionary_name, _build_alias_lookup
+        from apps.imports.spo_services import _build_alias_lookup, _match_missionary_name
 
-        MissionaryAlias.objects.create(source_name='Ghost Person', user=None)
+        MissionaryAlias.objects.create(source_name="Ghost Person", user=None)
         alias_lookup = _build_alias_lookup()
         user_lookup = {}
 
-        result_user, match_type = _match_missionary_name('Ghost Person', user_lookup, alias_lookup)
+        result_user, match_type = _match_missionary_name("Ghost Person", user_lookup, alias_lookup)
         self.assertIsNone(result_user)
-        self.assertEqual(match_type, 'unresolved')
+        self.assertEqual(match_type, "unresolved")
 
     def test_no_match(self):
         """No match at all → (None, 'new')."""
         from apps.imports.spo_services import _match_missionary_name
 
-        result_user, match_type = _match_missionary_name('Brand New Person', {}, {})
+        result_user, match_type = _match_missionary_name("Brand New Person", {}, {})
         self.assertIsNone(result_user)
-        self.assertEqual(match_type, 'new')
+        self.assertEqual(match_type, "new")
 
 
 class TestBuildTriSourceComparison(TestCase):
@@ -405,32 +427,32 @@ class TestBuildTriSourceComparison(TestCase):
         """Name in all three sets → in all_three."""
         from apps.imports.spo_services import _build_tri_source_comparison
 
-        result = _build_tri_source_comparison({'Alice'}, {'Alice'}, {'Alice'})
-        self.assertIn('Alice', result['all_three'])
-        self.assertNotIn('Alice', result['csv_only'])
-        self.assertNotIn('Alice', result['mpd_only'])
-        self.assertNotIn('Alice', result['db_only'])
+        result = _build_tri_source_comparison({"Alice"}, {"Alice"}, {"Alice"})
+        self.assertIn("Alice", result["all_three"])
+        self.assertNotIn("Alice", result["csv_only"])
+        self.assertNotIn("Alice", result["mpd_only"])
+        self.assertNotIn("Alice", result["db_only"])
 
     def test_csv_only(self):
         """Name only in CSV → csv_only."""
         from apps.imports.spo_services import _build_tri_source_comparison
 
-        result = _build_tri_source_comparison({'Bob'}, set(), set())
-        self.assertIn('Bob', result['csv_only'])
+        result = _build_tri_source_comparison({"Bob"}, set(), set())
+        self.assertIn("Bob", result["csv_only"])
 
     def test_mpd_only(self):
         """Name only in MPD → mpd_only."""
         from apps.imports.spo_services import _build_tri_source_comparison
 
-        result = _build_tri_source_comparison(set(), {'Carol'}, set())
-        self.assertIn('Carol', result['mpd_only'])
+        result = _build_tri_source_comparison(set(), {"Carol"}, set())
+        self.assertIn("Carol", result["mpd_only"])
 
     def test_db_only(self):
         """Name only in DB → db_only."""
         from apps.imports.spo_services import _build_tri_source_comparison
 
-        result = _build_tri_source_comparison(set(), set(), {'Dave'})
-        self.assertIn('Dave', result['db_only'])
+        result = _build_tri_source_comparison(set(), set(), {"Dave"})
+        self.assertIn("Dave", result["db_only"])
 
 
 class TestGetOrCreateMissionarySolicitor(TestCase):
@@ -442,8 +464,11 @@ class TestGetOrCreateMissionarySolicitor(TestCase):
         from apps.imports.spo_services import _get_or_create_missionary_solicitor
 
         missionary = User.objects.create_user(
-            email='sol.test@test.com', password='pass',
-            first_name='Sol', last_name='Test', role='missionary',
+            email="sol.test@test.com",
+            password="pass",
+            first_name="Sol",
+            last_name="Test",
+            role="missionary",
         )
         solicitor = _get_or_create_missionary_solicitor(missionary)
         self.assertIsNotNone(solicitor)
@@ -455,8 +480,11 @@ class TestGetOrCreateMissionarySolicitor(TestCase):
         from apps.imports.spo_services import _get_or_create_missionary_solicitor
 
         missionary = User.objects.create_user(
-            email='idempotent@test.com', password='pass',
-            first_name='Idem', last_name='Potent', role='missionary',
+            email="idempotent@test.com",
+            password="pass",
+            first_name="Idem",
+            last_name="Potent",
+            role="missionary",
         )
         s1 = _get_or_create_missionary_solicitor(missionary)
         s2 = _get_or_create_missionary_solicitor(missionary)
@@ -473,14 +501,17 @@ class TestGetOrCreateAnonymousContact(TestCase):
         from apps.imports.spo_services import _get_or_create_anonymous_contact
 
         missionary = User.objects.create_user(
-            email='anon.test@test.com', password='pass',
-            first_name='Anon', last_name='Test', role='missionary',
+            email="anon.test@test.com",
+            password="pass",
+            first_name="Anon",
+            last_name="Test",
+            role="missionary",
         )
         contact = _get_or_create_anonymous_contact(missionary)
-        self.assertEqual(contact.first_name, 'Anonymous')
-        self.assertEqual(contact.last_name, 'Donor')
+        self.assertEqual(contact.first_name, "Anonymous")
+        self.assertEqual(contact.last_name, "Donor")
         self.assertEqual(contact.owner, missionary)
-        self.assertEqual(contact.external_id, f'spo_anonymous_{missionary.id}')
+        self.assertEqual(contact.external_id, f"spo_anonymous_{missionary.id}")
 
     def test_idempotent(self):
         """Second call returns same Contact (not a duplicate)."""
@@ -488,21 +519,32 @@ class TestGetOrCreateAnonymousContact(TestCase):
         from apps.imports.spo_services import _get_or_create_anonymous_contact
 
         missionary = User.objects.create_user(
-            email='anon.idem@test.com', password='pass',
-            first_name='Anon', last_name='Idem', role='missionary',
+            email="anon.idem@test.com",
+            password="pass",
+            first_name="Anon",
+            last_name="Idem",
+            role="missionary",
         )
         c1 = _get_or_create_anonymous_contact(missionary)
         c2 = _get_or_create_anonymous_contact(missionary)
         self.assertEqual(c1.id, c2.id)
-        self.assertEqual(Contact.objects.filter(owner=missionary, external_id=f'spo_anonymous_{missionary.id}').count(), 1)
+        self.assertEqual(
+            Contact.objects.filter(
+                owner=missionary, external_id=f"spo_anonymous_{missionary.id}"
+            ).count(),
+            1,
+        )
 
     def test_contact_owner_is_missionary(self):
         """Contact.owner is the missionary User."""
         from apps.imports.spo_services import _get_or_create_anonymous_contact
 
         missionary = User.objects.create_user(
-            email='anon.owner@test.com', password='pass',
-            first_name='Owner', last_name='Check', role='missionary',
+            email="anon.owner@test.com",
+            password="pass",
+            first_name="Owner",
+            last_name="Check",
+            role="missionary",
         )
         contact = _get_or_create_anonymous_contact(missionary)
         self.assertEqual(contact.owner, missionary)
@@ -516,36 +558,42 @@ class TestImportSpoGifts(TestCase):
         from apps.contacts.models import Contact
         from apps.imports.spo_services import _get_or_create_anonymous_contact
 
-        missionary = _make_user('anon.first@test.com', 'Anon', 'First')
+        missionary = _make_user("anon.first@test.com", "Anon", "First")
         contact = _get_or_create_anonymous_contact(missionary)
 
         self.assertIsNotNone(contact)
-        self.assertEqual(contact.first_name, 'Anonymous')
-        self.assertEqual(contact.last_name, 'Donor')
+        self.assertEqual(contact.first_name, "Anonymous")
+        self.assertEqual(contact.last_name, "Donor")
         self.assertEqual(contact.owner, missionary)
-        self.assertEqual(contact.external_id, f'spo_anonymous_{missionary.id}')
-        self.assertEqual(contact.status, 'donor')
-        self.assertTrue(Contact.objects.filter(owner=missionary, external_id=f'spo_anonymous_{missionary.id}').exists())
+        self.assertEqual(contact.external_id, f"spo_anonymous_{missionary.id}")
+        self.assertEqual(contact.status, "donor")
+        self.assertTrue(
+            Contact.objects.filter(
+                owner=missionary, external_id=f"spo_anonymous_{missionary.id}"
+            ).exists()
+        )
 
     def test_anonymous_contact_reused(self):
         """Second anonymous gift reuses the same anonymous contact."""
         from apps.contacts.models import Contact
         from apps.imports.spo_services import _get_or_create_anonymous_contact
 
-        missionary = _make_user('anon.reuse@test.com', 'Anon', 'Reuse')
+        missionary = _make_user("anon.reuse@test.com", "Anon", "Reuse")
         c1 = _get_or_create_anonymous_contact(missionary)
         c2 = _get_or_create_anonymous_contact(missionary)
         self.assertEqual(c1.id, c2.id)
         self.assertEqual(
-            Contact.objects.filter(owner=missionary, external_id=f'spo_anonymous_{missionary.id}').count(),
-            1
+            Contact.objects.filter(
+                owner=missionary, external_id=f"spo_anonymous_{missionary.id}"
+            ).count(),
+            1,
         )
 
     def test_anonymous_contact_owner_is_missionary(self):
         """Anonymous contact owner=missionary for correct scope visibility."""
         from apps.imports.spo_services import _get_or_create_anonymous_contact
 
-        missionary = _make_user('anon.owner2@test.com', 'Anon', 'Owner')
+        missionary = _make_user("anon.owner2@test.com", "Anon", "Owner")
         contact = _get_or_create_anonymous_contact(missionary)
         self.assertEqual(contact.owner, missionary)
 
@@ -553,33 +601,35 @@ class TestImportSpoGifts(TestCase):
         """Blank Constituent ID is treated as anonymous even without 'Yes' flag."""
         from apps.contacts.models import Contact
         from apps.gifts.models import Gift, Solicitor
-        from apps.imports.spo_services import import_spo_gifts
         from apps.imports.re_services import normalize_solicitor_name
+        from apps.imports.spo_services import import_spo_gifts
 
         admin = _make_admin()
         # first='Sam', last='Blank' → full_name='Sam Blank' → normalized='blank, sam'
         # CSV solicitor_name 'Sam Blank' → normalized 'blank, sam' → exact match
-        missionary = _make_user('sam.blank@test.com', 'Sam', 'Blank')
+        missionary = _make_user("sam.blank@test.com", "Sam", "Blank")
         Solicitor.objects.create(
             user=missionary,
             normalized_name=normalize_solicitor_name(missionary.full_name),
         )
 
-        csv_bytes = _make_gifts_csv({
-            'gift_id': 'G-ANON-01',
-            'constituent_id': '',   # blank → anonymous
-            'is_anonymous': '',
-            'solicitor_name': 'Sam Blank',
-            'gift_amount': '25.00',
-        })
-        batch = import_spo_gifts(csv_bytes, 'gifts.csv', admin)
+        csv_bytes = _make_gifts_csv(
+            {
+                "gift_id": "G-ANON-01",
+                "constituent_id": "",  # blank → anonymous
+                "is_anonymous": "",
+                "solicitor_name": "Sam Blank",
+                "gift_amount": "25.00",
+            }
+        )
+        batch = import_spo_gifts(csv_bytes, "gifts.csv", admin)
 
         self.assertEqual(batch.status, ImportBatchStatus.COMPLETED)
         self.assertEqual(batch.created_count, 1)
-        gift = Gift.objects.get(external_gift_id='G-ANON-01')
+        gift = Gift.objects.get(external_gift_id="G-ANON-01")
         anon_contact = Contact.objects.get(
             owner=missionary,
-            external_id=f'spo_anonymous_{missionary.id}',
+            external_id=f"spo_anonymous_{missionary.id}",
         )
         self.assertEqual(gift.donor_contact, anon_contact)
 
@@ -591,28 +641,30 @@ class TestImportSpoGifts(TestCase):
         admin = _make_admin()
         # 'Unknown Person' has no User and no alias → match_type='new'
         # For gift import, 'new' means unresolved (no Solicitor exists yet) — skip
-        csv_bytes = _make_gifts_csv({
-            'gift_id': 'G-UNRES-01',
-            'solicitor_name': 'Unknown Person Nobody',
-            'gift_amount': '100.00',
-        })
-        batch = import_spo_gifts(csv_bytes, 'gifts.csv', admin)
+        csv_bytes = _make_gifts_csv(
+            {
+                "gift_id": "G-UNRES-01",
+                "solicitor_name": "Unknown Person Nobody",
+                "gift_amount": "100.00",
+            }
+        )
+        batch = import_spo_gifts(csv_bytes, "gifts.csv", admin)
 
         self.assertEqual(batch.status, ImportBatchStatus.COMPLETED)
         self.assertEqual(batch.created_count, 0)
         self.assertEqual(Gift.objects.count(), 0)
-        self.assertIn('unmatched_unresolved', batch.summary)
-        self.assertGreater(len(batch.summary['unmatched_unresolved']), 0)
+        self.assertIn("unmatched_unresolved", batch.summary)
+        self.assertGreater(len(batch.summary["unmatched_unresolved"]), 0)
 
     def test_gift_attributed_to_missionary(self):
         """Gift Solicitor Name maps to missionary User, GiftCredit created."""
         from apps.contacts.models import Contact
         from apps.gifts.models import Gift, GiftCredit, Solicitor
-        from apps.imports.spo_services import import_spo_gifts
         from apps.imports.re_services import normalize_solicitor_name
+        from apps.imports.spo_services import import_spo_gifts
 
         admin = _make_admin()
-        missionary = _make_user('peter.attr@test.com', 'Peter', 'Attr')
+        missionary = _make_user("peter.attr@test.com", "Peter", "Attr")
         solicitor = Solicitor.objects.create(
             user=missionary,
             normalized_name=normalize_solicitor_name(missionary.full_name),
@@ -620,24 +672,26 @@ class TestImportSpoGifts(TestCase):
         # Named donor contact with constituent_id
         contact = Contact.objects.create(
             owner=missionary,
-            first_name='John',
-            last_name='Donor',
-            external_constituent_id='CONST-001',
-            status='donor',
+            first_name="John",
+            last_name="Donor",
+            external_constituent_id="CONST-001",
+            status="donor",
         )
 
-        csv_bytes = _make_gifts_csv({
-            'gift_id': 'G-ATTR-01',
-            'constituent_id': 'CONST-001',
-            'solicitor_name': 'Peter Attr',
-            'solicitor_amount': '75.00',
-            'gift_amount': '75.00',
-        })
-        batch = import_spo_gifts(csv_bytes, 'gifts.csv', admin)
+        csv_bytes = _make_gifts_csv(
+            {
+                "gift_id": "G-ATTR-01",
+                "constituent_id": "CONST-001",
+                "solicitor_name": "Peter Attr",
+                "solicitor_amount": "75.00",
+                "gift_amount": "75.00",
+            }
+        )
+        batch = import_spo_gifts(csv_bytes, "gifts.csv", admin)
 
         self.assertEqual(batch.status, ImportBatchStatus.COMPLETED)
         self.assertEqual(batch.created_count, 1)
-        gift = Gift.objects.get(external_gift_id='G-ATTR-01')
+        gift = Gift.objects.get(external_gift_id="G-ATTR-01")
         self.assertEqual(gift.donor_contact, contact)
         # GiftCredit links gift to missionary's solicitor
         self.assertEqual(GiftCredit.objects.count(), 1)
@@ -648,56 +702,58 @@ class TestImportSpoGifts(TestCase):
     def test_prayer_extracted_from_gift_description(self):
         """Gift with prayer description column creates PrayerIntention."""
         from apps.gifts.models import Solicitor
-        from apps.imports.spo_services import import_spo_gifts
         from apps.imports.re_services import normalize_solicitor_name
+        from apps.imports.spo_services import import_spo_gifts
         from apps.prayers.models import PrayerIntention
 
         admin = _make_admin()
         # first='Tom', last='Prayer' → full_name 'Tom Prayer' → normalized 'prayer, tom'
         # CSV 'Tom Prayer' → exact match
-        missionary = _make_user('tom.prayer@test.com', 'Tom', 'Prayer')
+        missionary = _make_user("tom.prayer@test.com", "Tom", "Prayer")
         Solicitor.objects.create(
             user=missionary,
             normalized_name=normalize_solicitor_name(missionary.full_name),
         )
 
-        csv_bytes = _make_gifts_csv({
-            'gift_id': 'G-PRAY-01',
-            'constituent_id': '',
-            'solicitor_name': 'Tom Prayer',
-            'gift_amount': '50.00',
-            'prayer_description': 'Healing for my mother',
-        })
-        batch = import_spo_gifts(csv_bytes, 'gifts.csv', admin)
+        csv_bytes = _make_gifts_csv(
+            {
+                "gift_id": "G-PRAY-01",
+                "constituent_id": "",
+                "solicitor_name": "Tom Prayer",
+                "gift_amount": "50.00",
+                "prayer_description": "Healing for my mother",
+            }
+        )
+        batch = import_spo_gifts(csv_bytes, "gifts.csv", admin)
 
         self.assertEqual(batch.status, ImportBatchStatus.COMPLETED)
         self.assertEqual(PrayerIntention.objects.count(), 1)
         prayer = PrayerIntention.objects.first()
-        self.assertIn('mother', prayer.description)
+        self.assertIn("mother", prayer.description)
 
     def test_dedup_same_file(self):
         """Same file bytes returns DUPLICATE ImportBatch."""
         from apps.imports.spo_services import import_spo_gifts
 
         admin = _make_admin()
-        csv_bytes = _make_gifts_csv({'gift_id': 'G-DEDUP-01', 'gift_amount': '10.00'})
+        csv_bytes = _make_gifts_csv({"gift_id": "G-DEDUP-01", "gift_amount": "10.00"})
 
-        batch1 = import_spo_gifts(csv_bytes, 'gifts.csv', admin)
+        batch1 = import_spo_gifts(csv_bytes, "gifts.csv", admin)
         self.assertNotEqual(batch1.status, ImportBatchStatus.DUPLICATE)
 
-        batch2 = import_spo_gifts(csv_bytes, 'gifts.csv', admin)
+        batch2 = import_spo_gifts(csv_bytes, "gifts.csv", admin)
         self.assertEqual(batch2.status, ImportBatchStatus.DUPLICATE)
 
     def test_type_label_row_skipped(self):
         """Leading SPO type-label row (Gift,...) is skipped before DictReader."""
         from apps.gifts.models import Gift, Solicitor
-        from apps.imports.spo_services import import_spo_gifts
         from apps.imports.re_services import normalize_solicitor_name
+        from apps.imports.spo_services import import_spo_gifts
 
         admin = _make_admin()
         # first='Luke', last='Type' → full_name 'Luke Type' → normalized 'type, luke'
         # CSV 'Luke Type' → exact match
-        missionary = _make_user('luke.type@test.com', 'Luke', 'Type')
+        missionary = _make_user("luke.type@test.com", "Luke", "Type")
         Solicitor.objects.create(
             user=missionary,
             normalized_name=normalize_solicitor_name(missionary.full_name),
@@ -705,10 +761,10 @@ class TestImportSpoGifts(TestCase):
 
         # include_type_label=True is default — ensures the type row is present
         csv_bytes = _make_gifts_csv(
-            {'gift_id': 'G-TYPELABEL-01', 'solicitor_name': 'Luke Type', 'gift_amount': '20.00'},
+            {"gift_id": "G-TYPELABEL-01", "solicitor_name": "Luke Type", "gift_amount": "20.00"},
             include_type_label=True,
         )
-        batch = import_spo_gifts(csv_bytes, 'gifts.csv', admin)
+        batch = import_spo_gifts(csv_bytes, "gifts.csv", admin)
 
         self.assertEqual(batch.status, ImportBatchStatus.COMPLETED)
         # Type-label row skipped; exactly 1 data row processed
@@ -717,50 +773,52 @@ class TestImportSpoGifts(TestCase):
     def test_payment_type_set_on_spo_gift(self):
         """Gift Payment Type column is mapped and stored on Gift.payment_type."""
         from apps.gifts.models import Gift, Solicitor
-        from apps.imports.spo_services import import_spo_gifts
         from apps.imports.re_services import normalize_solicitor_name
+        from apps.imports.spo_services import import_spo_gifts
 
         admin = _make_admin()
-        missionary = _make_user('pay.type@test.com', 'Pay', 'Type')
+        missionary = _make_user("pay.type@test.com", "Pay", "Type")
         Solicitor.objects.create(
             user=missionary,
             normalized_name=normalize_solicitor_name(missionary.full_name),
         )
-        csv_bytes = _make_gifts_csv({
-            'gift_id': 'G-PAY-01',
-            'solicitor_name': 'Pay Type',
-            'gift_amount': '100.00',
-            'payment_type': 'EFT',
-        })
-        batch = import_spo_gifts(csv_bytes, 'gifts.csv', admin)
+        csv_bytes = _make_gifts_csv(
+            {
+                "gift_id": "G-PAY-01",
+                "solicitor_name": "Pay Type",
+                "gift_amount": "100.00",
+                "payment_type": "EFT",
+            }
+        )
+        batch = import_spo_gifts(csv_bytes, "gifts.csv", admin)
         self.assertEqual(batch.status, ImportBatchStatus.COMPLETED)
-        gift = Gift.objects.get(external_gift_id='G-PAY-01')
-        self.assertEqual(gift.payment_type, 'direct_deposit')  # EFT maps to direct_deposit
+        gift = Gift.objects.get(external_gift_id="G-PAY-01")
+        self.assertEqual(gift.payment_type, "direct_deposit")  # EFT maps to direct_deposit
 
     def test_zero_amount_gift_skipped(self):
         """SPO import should skip rows with unparseable/zero amounts."""
         from apps.gifts.models import Gift, Solicitor
-        from apps.imports.spo_services import import_spo_gifts
         from apps.imports.re_services import normalize_solicitor_name
+        from apps.imports.spo_services import import_spo_gifts
 
         admin = _make_admin()
-        missionary = _make_user('zero.amt@test.com', 'Zero', 'Amt')
+        missionary = _make_user("zero.amt@test.com", "Zero", "Amt")
         Solicitor.objects.create(
             user=missionary,
             normalized_name=normalize_solicitor_name(missionary.full_name),
         )
 
         csv_bytes = _make_gifts_csv(
-            {'gift_id': 'G-ZERO-01', 'solicitor_name': 'Zero Amt', 'gift_amount': '$0.00'},
-            {'gift_id': 'G-ZERO-02', 'solicitor_name': 'Zero Amt', 'gift_amount': 'N/A'},
-            {'gift_id': 'G-GOOD-01', 'solicitor_name': 'Zero Amt', 'gift_amount': '50.00'},
+            {"gift_id": "G-ZERO-01", "solicitor_name": "Zero Amt", "gift_amount": "$0.00"},
+            {"gift_id": "G-ZERO-02", "solicitor_name": "Zero Amt", "gift_amount": "N/A"},
+            {"gift_id": "G-GOOD-01", "solicitor_name": "Zero Amt", "gift_amount": "50.00"},
         )
-        batch = import_spo_gifts(csv_bytes, 'gifts.csv', admin)
+        batch = import_spo_gifts(csv_bytes, "gifts.csv", admin)
 
         # Only the valid $50 gift should be created
-        self.assertEqual(Gift.objects.filter(external_gift_id='G-GOOD-01').count(), 1)
-        self.assertFalse(Gift.objects.filter(external_gift_id='G-ZERO-01').exists())
-        self.assertFalse(Gift.objects.filter(external_gift_id='G-ZERO-02').exists())
+        self.assertEqual(Gift.objects.filter(external_gift_id="G-GOOD-01").count(), 1)
+        self.assertFalse(Gift.objects.filter(external_gift_id="G-ZERO-01").exists())
+        self.assertFalse(Gift.objects.filter(external_gift_id="G-ZERO-02").exists())
 
 
 class TestImportSpoPrayers(TestCase):
@@ -770,27 +828,29 @@ class TestImportSpoPrayers(TestCase):
         """import_spo_prayers() creates PrayerIntention but NOT Gift records."""
         from apps.contacts.models import Contact
         from apps.gifts.models import Gift, Solicitor
-        from apps.imports.spo_services import import_spo_prayers
         from apps.imports.re_services import normalize_solicitor_name
+        from apps.imports.spo_services import import_spo_prayers
         from apps.prayers.models import PrayerIntention
 
         admin = _make_admin()
         # first='Kate', last='Miller' → full_name 'Kate Miller' → normalized 'miller, kate'
         # CSV 'Kate Miller' → exact match
-        missionary = _make_user('kate.miller@test.com', 'Kate', 'Miller')
+        missionary = _make_user("kate.miller@test.com", "Kate", "Miller")
         Solicitor.objects.create(
             user=missionary,
             normalized_name=normalize_solicitor_name(missionary.full_name),
         )
 
-        csv_bytes = _make_gifts_csv({
-            'gift_id': 'G-PONLY-01',
-            'constituent_id': '',
-            'solicitor_name': 'Kate Miller',
-            'gift_amount': '50.00',
-            'prayer_description': 'Safe travels for the family',
-        })
-        batch = import_spo_prayers(csv_bytes, 'gifts.csv', admin)
+        csv_bytes = _make_gifts_csv(
+            {
+                "gift_id": "G-PONLY-01",
+                "constituent_id": "",
+                "solicitor_name": "Kate Miller",
+                "gift_amount": "50.00",
+                "prayer_description": "Safe travels for the family",
+            }
+        )
+        batch = import_spo_prayers(csv_bytes, "gifts.csv", admin)
 
         self.assertEqual(batch.status, ImportBatchStatus.COMPLETED)
         # No Gift records should be created
@@ -805,14 +865,14 @@ class TestImportSpoPrayers(TestCase):
         from apps.imports.spo_services import import_spo_gifts, import_spo_prayers
 
         admin = _make_admin()
-        csv_bytes = _make_gifts_csv({'gift_id': 'G-PDEDUP-01', 'gift_amount': '10.00'})
+        csv_bytes = _make_gifts_csv({"gift_id": "G-PDEDUP-01", "gift_amount": "10.00"})
 
         # Import as gifts
-        batch_gift = import_spo_gifts(csv_bytes, 'gifts.csv', admin)
+        batch_gift = import_spo_gifts(csv_bytes, "gifts.csv", admin)
         self.assertEqual(batch_gift.import_type, ImportBatchType.SPO_GIFT)
 
         # Import same file as prayers — separate dedup namespace
-        batch_prayer = import_spo_prayers(csv_bytes, 'gifts.csv', admin)
+        batch_prayer = import_spo_prayers(csv_bytes, "gifts.csv", admin)
         self.assertEqual(batch_prayer.import_type, ImportBatchType.SPO_PRAYER)
         self.assertNotEqual(batch_prayer.status, ImportBatchStatus.DUPLICATE)
 
@@ -825,12 +885,12 @@ class TestIdempotency(TestCase):
         from apps.imports.spo_services import reconcile_missionaries
 
         admin = _make_admin()
-        csv_bytes = _make_solicitor_csv('Alice Force')
+        csv_bytes = _make_solicitor_csv("Alice Force")
 
-        batch1 = reconcile_missionaries(csv_bytes, 'solicitors.csv', admin)
+        batch1 = reconcile_missionaries(csv_bytes, "solicitors.csv", admin)
         self.assertNotEqual(batch1.status, ImportBatchStatus.DUPLICATE)
 
-        batch2 = reconcile_missionaries(csv_bytes, 'solicitors.csv', admin, force=True)
+        batch2 = reconcile_missionaries(csv_bytes, "solicitors.csv", admin, force=True)
         self.assertNotEqual(batch2.status, ImportBatchStatus.DUPLICATE)
         self.assertEqual(batch2.status, ImportBatchStatus.COMPLETED)
 
@@ -839,11 +899,11 @@ class TestIdempotency(TestCase):
         from apps.imports.spo_services import import_spo_gifts
 
         admin = _make_admin()
-        csv_bytes = _make_gifts_csv({'gift_id': 'G-FORCE-01', 'gift_amount': '10.00'})
+        csv_bytes = _make_gifts_csv({"gift_id": "G-FORCE-01", "gift_amount": "10.00"})
 
-        batch1 = import_spo_gifts(csv_bytes, 'gifts.csv', admin)
+        batch1 = import_spo_gifts(csv_bytes, "gifts.csv", admin)
         self.assertNotEqual(batch1.status, ImportBatchStatus.DUPLICATE)
 
-        batch2 = import_spo_gifts(csv_bytes, 'gifts.csv', admin, force=True)
+        batch2 = import_spo_gifts(csv_bytes, "gifts.csv", admin, force=True)
         self.assertNotEqual(batch2.status, ImportBatchStatus.DUPLICATE)
         self.assertEqual(batch2.status, ImportBatchStatus.COMPLETED)

--- a/apps/imports/tests/test_spo_views.py
+++ b/apps/imports/tests/test_spo_views.py
@@ -9,69 +9,79 @@ TDD plan 04: Stubs filled in.
 import csv as csv_mod
 import io
 
-from django.urls import reverse
-from rest_framework.test import APIClient
 from django.test import TestCase
+from django.urls import reverse
+
+from rest_framework.test import APIClient
 
 from apps.users.models import User
-
 
 # ---------------------------------------------------------------------------
 # CSV helpers
 # ---------------------------------------------------------------------------
 
+
 def _make_solicitor_csv(*names):
     """Build minimal SPO Solicitor CSV bytes with type-label row."""
     buf = io.StringIO()
     writer = csv_mod.writer(buf)
-    writer.writerow(['Solicitor'])
-    writer.writerow(['Name'])
+    writer.writerow(["Solicitor"])
+    writer.writerow(["Name"])
     for name in names:
         writer.writerow([name])
-    return buf.getvalue().encode('utf-8')
+    return buf.getvalue().encode("utf-8")
 
 
 def _make_gifts_csv(*rows):
     """Build minimal SPO Gifts CSV bytes."""
     buf = io.StringIO()
     writer = csv_mod.writer(buf)
-    writer.writerow(['Gift'])
-    writer.writerow([
-        'Gift ID', 'Constituent ID', 'Gift Is Anonymous',
-        'Solicitor Name', 'Solicitor Amount', 'Gift Amount', 'Gift Date',
-        'Gift Specific Attributes Prayer Requests Description',
-    ])
+    writer.writerow(["Gift"])
+    writer.writerow(
+        [
+            "Gift ID",
+            "Constituent ID",
+            "Gift Is Anonymous",
+            "Solicitor Name",
+            "Solicitor Amount",
+            "Gift Amount",
+            "Gift Date",
+            "Gift Specific Attributes Prayer Requests Description",
+        ]
+    )
     for row in rows:
-        writer.writerow([
-            row.get('gift_id', ''),
-            row.get('constituent_id', ''),
-            row.get('is_anonymous', 'No'),
-            row.get('solicitor_name', ''),
-            row.get('solicitor_amount', ''),
-            row.get('gift_amount', '0.00'),
-            row.get('gift_date', '2024-01-01'),
-            row.get('prayer_description', ''),
-        ])
-    return buf.getvalue().encode('utf-8')
+        writer.writerow(
+            [
+                row.get("gift_id", ""),
+                row.get("constituent_id", ""),
+                row.get("is_anonymous", "No"),
+                row.get("solicitor_name", ""),
+                row.get("solicitor_amount", ""),
+                row.get("gift_amount", "0.00"),
+                row.get("gift_date", "2024-01-01"),
+                row.get("prayer_description", ""),
+            ]
+        )
+    return buf.getvalue().encode("utf-8")
 
 
 def _make_admin():
     return User.objects.create_user(
-        email='admin@example.com',
-        password='adminpass',
-        first_name='Admin',
-        last_name='User',
-        role='admin',
+        email="admin@example.com",
+        password="adminpass",
+        first_name="Admin",
+        last_name="User",
+        role="admin",
     )
 
 
 def _make_staff():
     return User.objects.create_user(
-        email='staff@example.com',
-        password='staffpass',
-        first_name='Staff',
-        last_name='User',
-        role='missionary',
+        email="staff@example.com",
+        password="staffpass",
+        first_name="Staff",
+        last_name="User",
+        role="missionary",
     )
 
 
@@ -79,42 +89,43 @@ def _make_staff():
 # TestSPOMissionaryImportView
 # ---------------------------------------------------------------------------
 
+
 class TestSPOMissionaryImportView(TestCase):
     """Tests for POST /api/imports/spo/missionaries/ view."""
 
     def setUp(self):
         self.client = APIClient()
         self.admin = _make_admin()
-        self.url = reverse('imports:import-spo-missionaries')
+        self.url = reverse("imports:import-spo-missionaries")
 
     def test_requires_admin(self):
         """Non-admin user receives 403 Forbidden."""
         staff = _make_staff()
         self.client.force_authenticate(user=staff)
-        csv_bytes = _make_solicitor_csv('Peter Anderson')
+        csv_bytes = _make_solicitor_csv("Peter Anderson")
         file_obj = io.BytesIO(csv_bytes)
-        file_obj.name = 'solicitors.csv'
-        response = self.client.post(self.url, {'file': file_obj}, format='multipart')
+        file_obj.name = "solicitors.csv"
+        response = self.client.post(self.url, {"file": file_obj}, format="multipart")
         self.assertEqual(response.status_code, 403)
 
     def test_returns_batch_result(self):
         """Admin upload returns 200 with ImportBatch JSON shape."""
         self.client.force_authenticate(user=self.admin)
-        csv_bytes = _make_solicitor_csv('Peter Anderson')
+        csv_bytes = _make_solicitor_csv("Peter Anderson")
         file_obj = io.BytesIO(csv_bytes)
-        file_obj.name = 'solicitors.csv'
-        response = self.client.post(self.url, {'file': file_obj}, format='multipart')
+        file_obj.name = "solicitors.csv"
+        response = self.client.post(self.url, {"file": file_obj}, format="multipart")
         self.assertEqual(response.status_code, 200)
         data = response.json()
-        self.assertIn('batch_id', data)
-        self.assertIn('status', data)
-        self.assertIn('created_count', data)
-        self.assertIn('is_duplicate', data)
+        self.assertIn("batch_id", data)
+        self.assertIn("status", data)
+        self.assertIn("created_count", data)
+        self.assertIn("is_duplicate", data)
 
     def test_no_file_returns_400(self):
         """Missing file in request returns 400."""
         self.client.force_authenticate(user=self.admin)
-        response = self.client.post(self.url, {}, format='multipart')
+        response = self.client.post(self.url, {}, format="multipart")
         self.assertEqual(response.status_code, 400)
 
     def test_unauthenticated_returns_401(self):
@@ -127,43 +138,59 @@ class TestSPOMissionaryImportView(TestCase):
 # TestSPOGiftImportView
 # ---------------------------------------------------------------------------
 
+
 class TestSPOGiftImportView(TestCase):
     """Tests for POST /api/imports/spo/gifts/ view."""
 
     def setUp(self):
         self.client = APIClient()
         self.admin = _make_admin()
-        self.url = reverse('imports:import-spo-gifts')
+        self.url = reverse("imports:import-spo-gifts")
 
     def test_requires_admin(self):
         """Non-admin user receives 403 Forbidden."""
         staff = _make_staff()
         self.client.force_authenticate(user=staff)
-        csv_bytes = _make_gifts_csv({'gift_id': 'G001', 'solicitor_name': 'Some Person',
-                                     'gift_amount': '10.00', 'gift_date': '2024-01-01', 'is_anonymous': 'Yes'})
+        csv_bytes = _make_gifts_csv(
+            {
+                "gift_id": "G001",
+                "solicitor_name": "Some Person",
+                "gift_amount": "10.00",
+                "gift_date": "2024-01-01",
+                "is_anonymous": "Yes",
+            }
+        )
         file_obj = io.BytesIO(csv_bytes)
-        file_obj.name = 'gifts.csv'
-        response = self.client.post(self.url, {'file': file_obj}, format='multipart')
+        file_obj.name = "gifts.csv"
+        response = self.client.post(self.url, {"file": file_obj}, format="multipart")
         self.assertEqual(response.status_code, 403)
 
     def test_returns_batch_result(self):
         """Admin upload returns 200 with ImportBatch JSON shape."""
         self.client.force_authenticate(user=self.admin)
-        csv_bytes = _make_gifts_csv({'gift_id': 'G001', 'solicitor_name': 'Some Person',
-                                     'gift_amount': '10.00', 'gift_date': '2024-01-01', 'is_anonymous': 'Yes'})
+        csv_bytes = _make_gifts_csv(
+            {
+                "gift_id": "G001",
+                "solicitor_name": "Some Person",
+                "gift_amount": "10.00",
+                "gift_date": "2024-01-01",
+                "is_anonymous": "Yes",
+            }
+        )
         file_obj = io.BytesIO(csv_bytes)
-        file_obj.name = 'gifts.csv'
-        response = self.client.post(self.url, {'file': file_obj}, format='multipart')
+        file_obj.name = "gifts.csv"
+        response = self.client.post(self.url, {"file": file_obj}, format="multipart")
         self.assertEqual(response.status_code, 200)
         data = response.json()
-        self.assertIn('batch_id', data)
-        self.assertIn('status', data)
-        self.assertIn('created_count', data)
+        self.assertIn("batch_id", data)
+        self.assertIn("status", data)
+        self.assertIn("created_count", data)
 
 
 # ---------------------------------------------------------------------------
 # TestSPOPrayerImportView
 # ---------------------------------------------------------------------------
+
 
 class TestSPOPrayerImportView(TestCase):
     """Tests for POST /api/imports/spo/prayers/ view."""
@@ -171,29 +198,43 @@ class TestSPOPrayerImportView(TestCase):
     def setUp(self):
         self.client = APIClient()
         self.admin = _make_admin()
-        self.url = reverse('imports:import-spo-prayers')
+        self.url = reverse("imports:import-spo-prayers")
 
     def test_requires_admin(self):
         """Non-admin user receives 403 Forbidden."""
         staff = _make_staff()
         self.client.force_authenticate(user=staff)
-        csv_bytes = _make_gifts_csv({'gift_id': 'G002', 'solicitor_name': 'Someone',
-                                     'gift_amount': '10.00', 'gift_date': '2024-01-01', 'is_anonymous': 'Yes'})
+        csv_bytes = _make_gifts_csv(
+            {
+                "gift_id": "G002",
+                "solicitor_name": "Someone",
+                "gift_amount": "10.00",
+                "gift_date": "2024-01-01",
+                "is_anonymous": "Yes",
+            }
+        )
         file_obj = io.BytesIO(csv_bytes)
-        file_obj.name = 'prayers.csv'
-        response = self.client.post(self.url, {'file': file_obj}, format='multipart')
+        file_obj.name = "prayers.csv"
+        response = self.client.post(self.url, {"file": file_obj}, format="multipart")
         self.assertEqual(response.status_code, 403)
 
     def test_returns_batch_result(self):
         """Admin upload returns 200 with ImportBatch JSON shape."""
         self.client.force_authenticate(user=self.admin)
-        csv_bytes = _make_gifts_csv({'gift_id': 'G002', 'solicitor_name': 'Someone',
-                                     'gift_amount': '10.00', 'gift_date': '2024-01-01', 'is_anonymous': 'Yes'})
+        csv_bytes = _make_gifts_csv(
+            {
+                "gift_id": "G002",
+                "solicitor_name": "Someone",
+                "gift_amount": "10.00",
+                "gift_date": "2024-01-01",
+                "is_anonymous": "Yes",
+            }
+        )
         file_obj = io.BytesIO(csv_bytes)
-        file_obj.name = 'prayers.csv'
-        response = self.client.post(self.url, {'file': file_obj}, format='multipart')
+        file_obj.name = "prayers.csv"
+        response = self.client.post(self.url, {"file": file_obj}, format="multipart")
         self.assertEqual(response.status_code, 200)
         data = response.json()
-        self.assertIn('batch_id', data)
-        self.assertIn('status', data)
-        self.assertIn('created_count', data)
+        self.assertIn("batch_id", data)
+        self.assertIn("status", data)
+        self.assertIn("created_count", data)

--- a/apps/imports/tests/test_transaction_import.py
+++ b/apps/imports/tests/test_transaction_import.py
@@ -6,11 +6,12 @@ import_transactions, update_contact_stats_for_import) were removed in
 Phase 30-02 and replaced by the RE Gift import pipeline. This test file
 verifies the legacy endpoint returns 410 Gone.
 """
-import pytest
+from django.contrib.auth import get_user_model
 from django.urls import reverse
+
 from rest_framework.test import APIClient
 
-from django.contrib.auth import get_user_model
+import pytest
 
 User = get_user_model()
 
@@ -18,11 +19,7 @@ User = get_user_model()
 @pytest.fixture
 def admin_user(db):
     """Create admin user for testing."""
-    return User.objects.create_user(
-        email='admin@example.com',
-        password='testpass',
-        role='admin'
-    )
+    return User.objects.create_user(email="admin@example.com", password="testpass", role="admin")
 
 
 @pytest.fixture
@@ -40,16 +37,14 @@ class TestLegacyTransactionImportView:
         api_client.force_authenticate(user=admin_user)
         from django.core.files.uploadedfile import SimpleUploadedFile
 
-        file = SimpleUploadedFile('test.csv', b'header\n', content_type='text/csv')
+        file = SimpleUploadedFile("test.csv", b"header\n", content_type="text/csv")
         response = api_client.post(
-            reverse('imports:import-transactions'),
-            {'file': file},
-            format='multipart'
+            reverse("imports:import-transactions"), {"file": file}, format="multipart"
         )
         assert response.status_code == 410
 
     def test_legacy_template_returns_410(self, api_client, admin_user):
         """Legacy transaction template GET returns 410 Gone."""
         api_client.force_authenticate(user=admin_user)
-        response = api_client.get(reverse('imports:template-transactions'))
+        response = api_client.get(reverse("imports:template-transactions"))
         assert response.status_code == 410

--- a/apps/imports/tests/test_views.py
+++ b/apps/imports/tests/test_views.py
@@ -67,7 +67,7 @@ class TestLatestImportRunsView:
         url = reverse("imports:latest-import-runs")
 
         # Create two fund import runs (older and newer)
-        older_run = ImportRun.objects.create(
+        ImportRun.objects.create(
             type=ImportType.FUNDS,
             status=ImportStatus.COMPLETED,
             filename="funds_old.csv",

--- a/apps/imports/tests/test_views.py
+++ b/apps/imports/tests/test_views.py
@@ -1,14 +1,16 @@
 """
 Tests for import views.
 """
-import pytest
 from django.contrib.auth import get_user_model
 from django.urls import reverse
+
 from rest_framework import status
 from rest_framework.test import APIClient
 
-from apps.imports.models import Fund, ImportRun, ImportType, ImportStatus
+import pytest
+
 from apps.contacts.models import Contact
+from apps.imports.models import Fund, ImportRun, ImportStatus, ImportType
 
 User = get_user_model()
 
@@ -17,10 +19,7 @@ User = get_user_model()
 def test_user(db):
     """Create a test user."""
     return User.objects.create_user(
-        email='test@example.com',
-        password='testpass123',
-        first_name='Test',
-        last_name='User'
+        email="test@example.com", password="testpass123", first_name="Test", last_name="User"
     )
 
 
@@ -28,11 +27,11 @@ def test_user(db):
 def admin_user(db):
     """Create an admin user."""
     return User.objects.create_user(
-        email='admin@example.com',
-        password='adminpass123',
-        first_name='Admin',
-        last_name='User',
-        role='admin'
+        email="admin@example.com",
+        password="adminpass123",
+        first_name="Admin",
+        last_name="User",
+        role="admin",
     )
 
 
@@ -49,65 +48,65 @@ class TestLatestImportRunsView:
     def test_latest_import_runs_returns_null_for_no_imports(self, api_client, admin_user):
         """With no imports, should return null for all types and zero counts."""
         api_client.force_authenticate(user=admin_user)
-        url = reverse('imports:latest-import-runs')
+        url = reverse("imports:latest-import-runs")
 
         response = api_client.get(url)
 
         assert response.status_code == status.HTTP_200_OK
-        assert response.data['funds'] is None
-        assert response.data['entities'] is None
-        assert response.data['transactions'] is None
-        assert response.data['pledges'] is None
-        assert 'dependency_counts' in response.data
-        assert response.data['dependency_counts']['funds_count'] == 0
-        assert response.data['dependency_counts']['entities_with_external_id_count'] == 0
+        assert response.data["funds"] is None
+        assert response.data["entities"] is None
+        assert response.data["transactions"] is None
+        assert response.data["pledges"] is None
+        assert "dependency_counts" in response.data
+        assert response.data["dependency_counts"]["funds_count"] == 0
+        assert response.data["dependency_counts"]["entities_with_external_id_count"] == 0
 
     def test_latest_import_runs_returns_latest_run(self, api_client, admin_user):
         """Should return the most recent import run for each type."""
         api_client.force_authenticate(user=admin_user)
-        url = reverse('imports:latest-import-runs')
+        url = reverse("imports:latest-import-runs")
 
         # Create two fund import runs (older and newer)
         older_run = ImportRun.objects.create(
             type=ImportType.FUNDS,
             status=ImportStatus.COMPLETED,
-            filename='funds_old.csv',
+            filename="funds_old.csv",
             uploaded_by=admin_user,
             created_count=5,
             updated_count=2,
-            error_count=0
+            error_count=0,
         )
 
         # Create newer run
         newer_run = ImportRun.objects.create(
             type=ImportType.FUNDS,
             status=ImportStatus.COMPLETED,
-            filename='funds_new.csv',
+            filename="funds_new.csv",
             uploaded_by=admin_user,
             created_count=10,
             updated_count=3,
-            error_count=1
+            error_count=1,
         )
 
         response = api_client.get(url)
 
         assert response.status_code == status.HTTP_200_OK
-        assert response.data['funds'] is not None
+        assert response.data["funds"] is not None
         # Should return the newer run
-        assert response.data['funds']['id'] == str(newer_run.id)
-        assert response.data['funds']['status'] == ImportStatus.COMPLETED
-        assert response.data['funds']['created_count'] == 10
-        assert response.data['funds']['updated_count'] == 3
-        assert response.data['funds']['error_count'] == 1
+        assert response.data["funds"]["id"] == str(newer_run.id)
+        assert response.data["funds"]["status"] == ImportStatus.COMPLETED
+        assert response.data["funds"]["created_count"] == 10
+        assert response.data["funds"]["updated_count"] == 3
+        assert response.data["funds"]["error_count"] == 1
         # Other types should still be null
-        assert response.data['entities'] is None
-        assert response.data['transactions'] is None
-        assert response.data['pledges'] is None
+        assert response.data["entities"] is None
+        assert response.data["transactions"] is None
+        assert response.data["pledges"] is None
 
     def test_latest_import_runs_requires_admin(self, api_client, test_user):
         """Non-admin users should receive 403 Forbidden."""
         api_client.force_authenticate(user=test_user)
-        url = reverse('imports:latest-import-runs')
+        url = reverse("imports:latest-import-runs")
 
         response = api_client.get(url)
 
@@ -116,49 +115,49 @@ class TestLatestImportRunsView:
     def test_latest_import_runs_includes_dependency_counts(self, api_client, admin_user, test_user):
         """Should return accurate counts for funds and entities with external_id."""
         api_client.force_authenticate(user=admin_user)
-        url = reverse('imports:latest-import-runs')
+        url = reverse("imports:latest-import-runs")
 
         # Create some Funds
-        Fund.objects.create(external_id='FUND001', name='Fund 1', status='active')
-        Fund.objects.create(external_id='FUND002', name='Fund 2', status='active')
-        Fund.objects.create(external_id='FUND003', name='Fund 3', status='inactive')
+        Fund.objects.create(external_id="FUND001", name="Fund 1", status="active")
+        Fund.objects.create(external_id="FUND002", name="Fund 2", status="active")
+        Fund.objects.create(external_id="FUND003", name="Fund 3", status="inactive")
 
         # Create some Contacts with and without external_id
         Contact.objects.create(
-            first_name='John',
-            last_name='Doe',
-            email='john@example.com',
+            first_name="John",
+            last_name="Doe",
+            email="john@example.com",
             owner=test_user,
-            external_id='EXT001'
+            external_id="EXT001",
         )
         Contact.objects.create(
-            first_name='Jane',
-            last_name='Smith',
-            email='jane@example.com',
+            first_name="Jane",
+            last_name="Smith",
+            email="jane@example.com",
             owner=test_user,
-            external_id='EXT002'
+            external_id="EXT002",
         )
         # Contacts without external_id (should not be counted)
         Contact.objects.create(
-            first_name='Bob',
-            last_name='Jones',
-            email='bob@example.com',
+            first_name="Bob",
+            last_name="Jones",
+            email="bob@example.com",
             owner=test_user,
-            external_id=''
+            external_id="",
         )
         Contact.objects.create(
-            first_name='Alice',
-            last_name='Brown',
-            email='alice@example.com',
+            first_name="Alice",
+            last_name="Brown",
+            email="alice@example.com",
             owner=test_user,
-            external_id=''
+            external_id="",
         )
 
         response = api_client.get(url)
 
         assert response.status_code == status.HTTP_200_OK
-        assert response.data['dependency_counts']['funds_count'] == 3
-        assert response.data['dependency_counts']['entities_with_external_id_count'] == 2
+        assert response.data["dependency_counts"]["funds_count"] == 3
+        assert response.data["dependency_counts"]["entities_with_external_id_count"] == 2
 
 
 @pytest.mark.django_db
@@ -175,51 +174,51 @@ class TestImportRunErrorsCSVView:
         import_run = ImportRun.objects.create(
             type=ImportType.FUNDS,
             status=ImportStatus.COMPLETED,
-            filename='test.csv',
+            filename="test.csv",
             uploaded_by=admin_user,
-            error_count=2
+            error_count=2,
         )
 
         ImportRowError.objects.create(
             import_run=import_run,
             row_number=2,
-            error_messages=['Invalid status value'],
-            row_data={'fund_id': 'F001', 'name': 'Test Fund', 'status': 'invalid'}
+            error_messages=["Invalid status value"],
+            row_data={"fund_id": "F001", "name": "Test Fund", "status": "invalid"},
         )
         ImportRowError.objects.create(
             import_run=import_run,
             row_number=5,
-            error_messages=['Missing required field: name', 'Invalid fund_id format'],
-            row_data={'fund_id': '123', 'name': '', 'status': 'active'}
+            error_messages=["Missing required field: name", "Invalid fund_id format"],
+            row_data={"fund_id": "123", "name": "", "status": "active"},
         )
 
-        url = reverse('imports:import-run-errors-csv', kwargs={'import_run_id': import_run.id})
+        url = reverse("imports:import-run-errors-csv", kwargs={"import_run_id": import_run.id})
         response = api_client.get(url)
 
         assert response.status_code == status.HTTP_200_OK
-        assert response['Content-Type'] == 'text/csv'
-        assert 'attachment' in response['Content-Disposition']
-        assert 'funds_errors_' in response['Content-Disposition']
+        assert response["Content-Type"] == "text/csv"
+        assert "attachment" in response["Content-Disposition"]
+        assert "funds_errors_" in response["Content-Disposition"]
 
         # Parse CSV content
-        content = response.content.decode('utf-8')
-        lines = content.strip().split('\n')
+        content = response.content.decode("utf-8")
+        lines = content.strip().split("\n")
         assert len(lines) == 3  # header + 2 error rows
 
         # Check headers include error_message
-        assert 'error_message' in lines[0]
-        assert 'fund_id' in lines[0]
+        assert "error_message" in lines[0]
+        assert "fund_id" in lines[0]
 
         # Check error messages in content
-        assert 'Invalid status value' in content
-        assert 'Missing required field: name' in content
+        assert "Invalid status value" in content
+        assert "Missing required field: name" in content
 
     def test_download_errors_csv_not_found(self, api_client, admin_user):
         """Should return 404 for non-existent import run."""
         import uuid
 
         api_client.force_authenticate(user=admin_user)
-        url = reverse('imports:import-run-errors-csv', kwargs={'import_run_id': uuid.uuid4()})
+        url = reverse("imports:import-run-errors-csv", kwargs={"import_run_id": uuid.uuid4()})
         response = api_client.get(url)
 
         assert response.status_code == status.HTTP_404_NOT_FOUND
@@ -231,12 +230,12 @@ class TestImportRunErrorsCSVView:
         import_run = ImportRun.objects.create(
             type=ImportType.FUNDS,
             status=ImportStatus.COMPLETED,
-            filename='test.csv',
+            filename="test.csv",
             uploaded_by=admin_user,
-            error_count=0
+            error_count=0,
         )
 
-        url = reverse('imports:import-run-errors-csv', kwargs={'import_run_id': import_run.id})
+        url = reverse("imports:import-run-errors-csv", kwargs={"import_run_id": import_run.id})
         response = api_client.get(url)
 
         assert response.status_code == status.HTTP_404_NOT_FOUND
@@ -249,22 +248,22 @@ class TestImportRunErrorsCSVView:
         import_run = ImportRun.objects.create(
             type=ImportType.FUNDS,
             status=ImportStatus.COMPLETED,
-            filename='test.csv',
+            filename="test.csv",
             uploaded_by=admin_user,
-            error_count=1
+            error_count=1,
         )
 
         ImportRowError.objects.create(
             import_run=import_run,
             row_number=2,
-            error_messages=['Invalid status value'],
-            row_data={'fund_id': 'F001', 'name': 'Test Fund', 'status': 'invalid'}
+            error_messages=["Invalid status value"],
+            row_data={"fund_id": "F001", "name": "Test Fund", "status": "invalid"},
         )
 
         # Authenticate as non-admin user
         api_client.force_authenticate(user=test_user)
 
-        url = reverse('imports:import-run-errors-csv', kwargs={'import_run_id': import_run.id})
+        url = reverse("imports:import-run-errors-csv", kwargs={"import_run_id": import_run.id})
         response = api_client.get(url)
 
         assert response.status_code == status.HTTP_403_FORBIDDEN

--- a/apps/imports/urls.py
+++ b/apps/imports/urls.py
@@ -38,40 +38,50 @@ from apps.imports.views import (
     TransactionTemplateView,
 )
 
-app_name = 'imports'
+app_name = "imports"
 
 urlpatterns = [
-    path('contacts/', ContactImportView.as_view(), name='import-contacts'),
-    path('donations/', DonationImportView.as_view(), name='import-donations'),
-    path('entities/', EntityImportView.as_view(), name='import-entities'),
-    path('funds/', FundImportView.as_view(), name='import-funds'),
-    path('funds/list/', FundListView.as_view(), name='fund-list'),
-    path('mpd/', MPDImportView.as_view(), name='import-mpd'),
-    path('mpd/overview/', MPDOverviewView.as_view(), name='mpd-overview'),
-    path('mpd/me/', MPDMyDataView.as_view(), name='mpd-my-data'),
-    path('mpd/uploads/', MPDUploadHistoryView.as_view(), name='mpd-upload-history'),
-    path('batches/', ImportBatchListView.as_view(), name='import-batch-list'),
-    path('generic/contacts/', GenericContactImportView.as_view(), name='import-generic-contacts'),
-    path('generic/donations/', GenericDonationImportView.as_view(), name='import-generic-donations'),
-    path('re/constituents/', REConstituentImportView.as_view(), name='import-re-constituents'),
-    path('re/gifts/', REGiftImportView.as_view(), name='import-re-gifts'),
-    path('re/recurring-gifts/', RERecurringGiftImportView.as_view(), name='import-re-recurring-gifts'),
-    path('re/solicitors/', RESolicitorImportView.as_view(), name='import-re-solicitors'),
+    path("contacts/", ContactImportView.as_view(), name="import-contacts"),
+    path("donations/", DonationImportView.as_view(), name="import-donations"),
+    path("entities/", EntityImportView.as_view(), name="import-entities"),
+    path("funds/", FundImportView.as_view(), name="import-funds"),
+    path("funds/list/", FundListView.as_view(), name="fund-list"),
+    path("mpd/", MPDImportView.as_view(), name="import-mpd"),
+    path("mpd/overview/", MPDOverviewView.as_view(), name="mpd-overview"),
+    path("mpd/me/", MPDMyDataView.as_view(), name="mpd-my-data"),
+    path("mpd/uploads/", MPDUploadHistoryView.as_view(), name="mpd-upload-history"),
+    path("batches/", ImportBatchListView.as_view(), name="import-batch-list"),
+    path("generic/contacts/", GenericContactImportView.as_view(), name="import-generic-contacts"),
+    path(
+        "generic/donations/", GenericDonationImportView.as_view(), name="import-generic-donations"
+    ),
+    path("re/constituents/", REConstituentImportView.as_view(), name="import-re-constituents"),
+    path("re/gifts/", REGiftImportView.as_view(), name="import-re-gifts"),
+    path(
+        "re/recurring-gifts/", RERecurringGiftImportView.as_view(), name="import-re-recurring-gifts"
+    ),
+    path("re/solicitors/", RESolicitorImportView.as_view(), name="import-re-solicitors"),
     # SPO import pipeline (three-step workflow)
-    path('spo/missionaries/', SPOMissionaryImportView.as_view(), name='import-spo-missionaries'),
-    path('spo/gifts/', SPOGiftImportView.as_view(), name='import-spo-gifts'),
-    path('spo/prayers/', SPOPrayerImportView.as_view(), name='import-spo-prayers'),
-    path('pledges/', PledgeImportView.as_view(), name='import-pledges'),
-    path('transactions/', TransactionImportView.as_view(), name='import-transactions'),
-    path('export/contacts/', ContactExportView.as_view(), name='export-contacts'),
-    path('export/donations/', DonationExportView.as_view(), name='export-donations'),
-    path('templates/contacts/', ContactTemplateView.as_view(), name='template-contacts'),
-    path('templates/donations/', DonationTemplateView.as_view(), name='template-donations'),
-    path('templates/entities/', EntityTemplateView.as_view(), name='template-entities'),
-    path('templates/funds/', FundTemplateView.as_view(), name='template-funds'),
-    path('templates/pledges/', PledgeTemplateView.as_view(), name='template-pledges'),
-    path('templates/transactions/', TransactionTemplateView.as_view(), name='template-transactions'),
-    path('runs/latest/', LatestImportRunsView.as_view(), name='latest-import-runs'),
-    path('runs/<uuid:import_run_id>/errors/csv/', ImportRunErrorsCSVView.as_view(), name='import-run-errors-csv'),
-    path('status/<str:import_id>/', ImportStatusView.as_view(), name='import-status'),
+    path("spo/missionaries/", SPOMissionaryImportView.as_view(), name="import-spo-missionaries"),
+    path("spo/gifts/", SPOGiftImportView.as_view(), name="import-spo-gifts"),
+    path("spo/prayers/", SPOPrayerImportView.as_view(), name="import-spo-prayers"),
+    path("pledges/", PledgeImportView.as_view(), name="import-pledges"),
+    path("transactions/", TransactionImportView.as_view(), name="import-transactions"),
+    path("export/contacts/", ContactExportView.as_view(), name="export-contacts"),
+    path("export/donations/", DonationExportView.as_view(), name="export-donations"),
+    path("templates/contacts/", ContactTemplateView.as_view(), name="template-contacts"),
+    path("templates/donations/", DonationTemplateView.as_view(), name="template-donations"),
+    path("templates/entities/", EntityTemplateView.as_view(), name="template-entities"),
+    path("templates/funds/", FundTemplateView.as_view(), name="template-funds"),
+    path("templates/pledges/", PledgeTemplateView.as_view(), name="template-pledges"),
+    path(
+        "templates/transactions/", TransactionTemplateView.as_view(), name="template-transactions"
+    ),
+    path("runs/latest/", LatestImportRunsView.as_view(), name="latest-import-runs"),
+    path(
+        "runs/<uuid:import_run_id>/errors/csv/",
+        ImportRunErrorsCSVView.as_view(),
+        name="import-run-errors-csv",
+    ),
+    path("status/<str:import_id>/", ImportStatusView.as_view(), name="import-status"),
 ]

--- a/apps/imports/views.py
+++ b/apps/imports/views.py
@@ -146,7 +146,10 @@ class DonationImportView(APIView):
     def post(self, request):
         return Response(
             {
-                "detail": "Legacy donation import has been removed. Use the RE Gift import endpoint instead."
+                "detail": (
+                    "Legacy donation import has been removed. "
+                    "Use the RE Gift import endpoint instead."
+                )
             },
             status=status.HTTP_410_GONE,
         )
@@ -245,7 +248,9 @@ class DonationTemplateView(APIView):
     def get(self, request):
         return Response(
             {
-                "detail": "Legacy donation template has been removed. Use the RE Gift import instead."
+                "detail": (
+                    "Legacy donation template has been removed. " "Use the RE Gift import instead."
+                )
             },
             status=status.HTTP_410_GONE,
         )
@@ -453,7 +458,10 @@ class TransactionImportView(APIView):
     def post(self, request):
         return Response(
             {
-                "detail": "Legacy transaction import has been removed. Use the RE Gift import endpoint instead."
+                "detail": (
+                    "Legacy transaction import has been removed. "
+                    "Use the RE Gift import endpoint instead."
+                )
             },
             status=status.HTTP_410_GONE,
         )
@@ -470,7 +478,10 @@ class TransactionTemplateView(APIView):
     def get(self, request):
         return Response(
             {
-                "detail": "Legacy transaction template has been removed. Use the RE Gift import instead."
+                "detail": (
+                    "Legacy transaction template has been removed. "
+                    "Use the RE Gift import instead."
+                )
             },
             status=status.HTTP_410_GONE,
         )
@@ -500,7 +511,10 @@ class PledgeImportView(APIView):
     def post(self, request):
         return Response(
             {
-                "detail": "Legacy pledge import has been removed. Use the RE Recurring Gift import endpoint instead."
+                "detail": (
+                    "Legacy pledge import has been removed. "
+                    "Use the RE Recurring Gift import endpoint instead."
+                )
             },
             status=status.HTTP_410_GONE,
         )
@@ -517,7 +531,10 @@ class PledgeTemplateView(APIView):
     def get(self, request):
         return Response(
             {
-                "detail": "Legacy pledge template has been removed. Use the RE Recurring Gift import instead."
+                "detail": (
+                    "Legacy pledge template has been removed. "
+                    "Use the RE Recurring Gift import instead."
+                )
             },
             status=status.HTTP_410_GONE,
         )

--- a/apps/insights/admin_analytics_services.py
+++ b/apps/insights/admin_analytics_services.py
@@ -153,9 +153,7 @@ def get_fiscal_year_pace(request):
         annual_goal_source = "org_setting"
     else:
         goal_qs = _active_missionaries(owner_ids).filter(monthly_support_goal_cents__gt=0)
-        monthly_goal_sum = (
-            goal_qs.aggregate(total=Sum("monthly_support_goal_cents"))["total"] or 0
-        )
+        monthly_goal_sum = goal_qs.aggregate(total=Sum("monthly_support_goal_cents"))["total"] or 0
         annual_goal_cents = int(monthly_goal_sum * 12)
         annual_goal_source = "missionary_sum"
 

--- a/apps/insights/apps.py
+++ b/apps/insights/apps.py
@@ -2,6 +2,6 @@ from django.apps import AppConfig
 
 
 class InsightsConfig(AppConfig):
-    default_auto_field = 'django.db.models.BigAutoField'
-    name = 'apps.insights'
-    verbose_name = 'Insights'
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "apps.insights"
+    verbose_name = "Insights"

--- a/apps/insights/export_views.py
+++ b/apps/insights/export_views.py
@@ -5,10 +5,12 @@ import csv
 import logging
 from datetime import datetime
 
-from drf_spectacular.utils import OpenApiParameter, extend_schema
+from django.http import StreamingHttpResponse
+
 from rest_framework import permissions
 from rest_framework.views import APIView
-from django.http import StreamingHttpResponse
+
+from drf_spectacular.utils import OpenApiParameter, extend_schema
 
 from apps.core.permissions import IsAdmin
 from apps.core.utils import get_safe_int_param, validate_date_params
@@ -20,6 +22,7 @@ logger = logging.getLogger(__name__)
 
 class Echo:
     """Pseudo-buffer for csv.writer to write to StreamingHttpResponse."""
+
     def write(self, value):
         return value
 
@@ -44,10 +47,12 @@ def _safe_csv_stream(generator_fn, *, export_name):
         yield from generator_fn(writer)
     except Exception:  # noqa: BLE001 — we want to keep the stream alive
         logger.exception("CSV export %s failed mid-stream", export_name)
-        yield writer.writerow([
-            "__ERROR__",
-            "Export failed; this row is incomplete. Engineering has been notified.",
-        ])
+        yield writer.writerow(
+            [
+                "__ERROR__",
+                "Export failed; this row is incomplete. Engineering has been notified.",
+            ]
+        )
 
 
 class StalledContactsCSVView(APIView):
@@ -55,16 +60,23 @@ class StalledContactsCSVView(APIView):
     GET: Export stalled contacts as CSV file.
     Admin-only endpoint.
     """
+
     permission_classes = [permissions.IsAuthenticated, IsAdmin]
 
     @extend_schema(
-        tags=['insights'],
-        summary='Export stalled contacts CSV (admin only)',
+        tags=["insights"],
+        summary="Export stalled contacts CSV (admin only)",
         parameters=[
-            OpenApiParameter(name='date_from', description='Filter start date (YYYY-MM-DD)', type=str),
-            OpenApiParameter(name='date_to', description='Filter end date (YYYY-MM-DD)', type=str),
-            OpenApiParameter(name='sort_by', description='Sort field (days_stalled, full_name, owner_name, last_activity_date)', type=str),
-            OpenApiParameter(name='sort_dir', description='Sort direction (asc, desc)', type=str),
+            OpenApiParameter(
+                name="date_from", description="Filter start date (YYYY-MM-DD)", type=str
+            ),
+            OpenApiParameter(name="date_to", description="Filter end date (YYYY-MM-DD)", type=str),
+            OpenApiParameter(
+                name="sort_by",
+                description="Sort field (days_stalled, full_name, owner_name, last_activity_date)",
+                type=str,
+            ),
+            OpenApiParameter(name="sort_dir", description="Sort direction (asc, desc)", type=str),
         ],
     )
     def get(self, request):
@@ -72,16 +84,16 @@ class StalledContactsCSVView(APIView):
         _, err = validate_date_params(request)
         if err:
             return err
-        date_from = request.query_params.get('date_from')
-        date_to = request.query_params.get('date_to')
-        sort_by = request.query_params.get('sort_by', 'days_stalled')
-        sort_dir = request.query_params.get('sort_dir', 'desc')
+        date_from = request.query_params.get("date_from")
+        date_to = request.query_params.get("date_to")
+        sort_by = request.query_params.get("sort_by", "days_stalled")
+        sort_dir = request.query_params.get("sort_dir", "desc")
 
         # Validate sort parameters
-        if sort_by not in ('days_stalled', 'full_name', 'owner_name', 'last_activity_date'):
-            sort_by = 'days_stalled'
-        if sort_dir not in ('asc', 'desc'):
-            sort_dir = 'desc'
+        if sort_by not in ("days_stalled", "full_name", "owner_name", "last_activity_date"):
+            sort_by = "days_stalled"
+        if sort_dir not in ("asc", "desc"):
+            sort_dir = "desc"
 
         # Get all stalled contacts (no limit)
         data = get_stalled_contacts(
@@ -90,43 +102,47 @@ class StalledContactsCSVView(APIView):
             sort_by=sort_by,
             sort_dir=sort_dir,
             date_from=date_from,
-            date_to=date_to
+            date_to=date_to,
         )
 
         # Build filename with date range
         if date_from and date_to:
-            filename = f'stalled_contacts_{date_from}_to_{date_to}.csv'
+            filename = f"stalled_contacts_{date_from}_to_{date_to}.csv"
         elif date_from:
-            filename = f'stalled_contacts_from_{date_from}.csv'
+            filename = f"stalled_contacts_from_{date_from}.csv"
         elif date_to:
-            filename = f'stalled_contacts_to_{date_to}.csv'
+            filename = f"stalled_contacts_to_{date_to}.csv"
         else:
-            filename = f'stalled_contacts_{datetime.now().date().isoformat()}.csv'
+            filename = f"stalled_contacts_{datetime.now().date().isoformat()}.csv"
 
         def rows(writer):
-            yield writer.writerow([
-                'Contact Name',
-                'Email',
-                'Owner',
-                'Last Activity Date',
-                'Days Stalled',
-                'Status',
-            ])
-            for contact in data['stalled_contacts']:
-                yield writer.writerow([
-                    sanitize_csv_value(contact['full_name']),
-                    sanitize_csv_value(contact['email'] or ''),
-                    sanitize_csv_value(contact['owner_name']),
-                    contact['last_activity_date'] or '',
-                    contact['days_stalled'] or '',
-                    sanitize_csv_value(contact['status']),
-                ])
+            yield writer.writerow(
+                [
+                    "Contact Name",
+                    "Email",
+                    "Owner",
+                    "Last Activity Date",
+                    "Days Stalled",
+                    "Status",
+                ]
+            )
+            for contact in data["stalled_contacts"]:
+                yield writer.writerow(
+                    [
+                        sanitize_csv_value(contact["full_name"]),
+                        sanitize_csv_value(contact["email"] or ""),
+                        sanitize_csv_value(contact["owner_name"]),
+                        contact["last_activity_date"] or "",
+                        contact["days_stalled"] or "",
+                        sanitize_csv_value(contact["status"]),
+                    ]
+                )
 
         response = StreamingHttpResponse(
-            _safe_csv_stream(rows, export_name='stalled_contacts'),
-            content_type='text/csv',
+            _safe_csv_stream(rows, export_name="stalled_contacts"),
+            content_type="text/csv",
         )
-        response['Content-Disposition'] = f'attachment; filename="{filename}"'
+        response["Content-Disposition"] = f'attachment; filename="{filename}"'
         return response
 
 
@@ -135,15 +151,18 @@ class TeamActivityCSVView(APIView):
     GET: Export team activity as CSV file.
     Admin-only endpoint.
     """
+
     permission_classes = [permissions.IsAuthenticated, IsAdmin]
 
     @extend_schema(
-        tags=['insights'],
-        summary='Export team activity CSV (admin only)',
+        tags=["insights"],
+        summary="Export team activity CSV (admin only)",
         parameters=[
-            OpenApiParameter(name='date_from', description='Filter start date (YYYY-MM-DD)', type=str),
-            OpenApiParameter(name='date_to', description='Filter end date (YYYY-MM-DD)', type=str),
-            OpenApiParameter(name='limit', description='Max results (default: 10000)', type=int),
+            OpenApiParameter(
+                name="date_from", description="Filter start date (YYYY-MM-DD)", type=str
+            ),
+            OpenApiParameter(name="date_to", description="Filter end date (YYYY-MM-DD)", type=str),
+            OpenApiParameter(name="limit", description="Max results (default: 10000)", type=int),
         ],
     )
     def get(self, request):
@@ -151,43 +170,47 @@ class TeamActivityCSVView(APIView):
         _, err = validate_date_params(request)
         if err:
             return err
-        date_from = request.query_params.get('date_from')
-        date_to = request.query_params.get('date_to')
-        limit = get_safe_int_param(request, 'limit', default=10000, min_val=1, max_val=100000)
+        date_from = request.query_params.get("date_from")
+        date_to = request.query_params.get("date_to")
+        limit = get_safe_int_param(request, "limit", default=10000, min_val=1, max_val=100000)
 
         # Get team activity with high limit for export
         data = get_team_activity(limit=limit, date_from=date_from, date_to=date_to)
 
         # Build filename with date range
         if date_from and date_to:
-            filename = f'team_activity_{date_from}_to_{date_to}.csv'
+            filename = f"team_activity_{date_from}_to_{date_to}.csv"
         elif date_from:
-            filename = f'team_activity_from_{date_from}.csv'
+            filename = f"team_activity_from_{date_from}.csv"
         elif date_to:
-            filename = f'team_activity_to_{date_to}.csv'
+            filename = f"team_activity_to_{date_to}.csv"
         else:
-            filename = f'team_activity_{datetime.now().date().isoformat()}.csv'
+            filename = f"team_activity_{datetime.now().date().isoformat()}.csv"
 
         def rows(writer):
-            yield writer.writerow([
-                'Date',
-                'User',
-                'Event Type',
-                'Title',
-                'Contact Name',
-            ])
-            for activity in data['activities']:
-                yield writer.writerow([
-                    activity['created_at'],
-                    sanitize_csv_value(activity['user_name']),
-                    sanitize_csv_value(activity['event_type']),
-                    sanitize_csv_value(activity['title']),
-                    sanitize_csv_value(activity['contact_name'] or ''),
-                ])
+            yield writer.writerow(
+                [
+                    "Date",
+                    "User",
+                    "Event Type",
+                    "Title",
+                    "Contact Name",
+                ]
+            )
+            for activity in data["activities"]:
+                yield writer.writerow(
+                    [
+                        activity["created_at"],
+                        sanitize_csv_value(activity["user_name"]),
+                        sanitize_csv_value(activity["event_type"]),
+                        sanitize_csv_value(activity["title"]),
+                        sanitize_csv_value(activity["contact_name"] or ""),
+                    ]
+                )
 
         response = StreamingHttpResponse(
-            _safe_csv_stream(rows, export_name='team_activity'),
-            content_type='text/csv',
+            _safe_csv_stream(rows, export_name="team_activity"),
+            content_type="text/csv",
         )
-        response['Content-Disposition'] = f'attachment; filename="{filename}"'
+        response["Content-Disposition"] = f'attachment; filename="{filename}"'
         return response

--- a/apps/insights/services.py
+++ b/apps/insights/services.py
@@ -3,16 +3,17 @@ Service functions for insights/reports data aggregations.
 """
 from datetime import date, timedelta
 
-from dateutil.relativedelta import relativedelta
-from django.db.models import Count, Sum, Q, OuterRef, Subquery, Value, CharField, IntegerField
-from django.db.models.functions import TruncMonth, TruncYear, TruncWeek, Coalesce
+from django.db.models import CharField, Count, IntegerField, OuterRef, Q, Subquery, Sum, Value
+from django.db.models.functions import Coalesce, TruncMonth, TruncWeek, TruncYear
 from django.utils import timezone
+
+from dateutil.relativedelta import relativedelta
 
 from apps.contacts.models import Contact
 from apps.core.permissions import get_visible_user_ids
 from apps.events.models import Event
 from apps.gifts.models import Gift, RecurringGift, RecurringGiftStatus
-from apps.journals.models import Journal, JournalContact, JournalStageEvent, PipelineStage, Decision
+from apps.journals.models import Decision, Journal, JournalContact, JournalStageEvent, PipelineStage
 from apps.tasks.models import Task, TaskStatus
 from apps.users.models import User
 
@@ -37,20 +38,18 @@ def _parse_date_range(date_from=None, date_to=None):
     dt_to_val = None
     if date_from:
         try:
-            dt_from_val = timezone.make_aware(dt_class.strptime(date_from, '%Y-%m-%d'))
+            dt_from_val = timezone.make_aware(dt_class.strptime(date_from, "%Y-%m-%d"))
         except ValueError as exc:
             raise ValidationError(
-                {'date_from': 'Invalid date_from format. Use YYYY-MM-DD.'}
+                {"date_from": "Invalid date_from format. Use YYYY-MM-DD."}
             ) from exc
     if date_to:
         try:
-            dt_to_val = timezone.make_aware(
-                dt_class.strptime(date_to, '%Y-%m-%d')
-            ) + timedelta(days=1)
+            dt_to_val = timezone.make_aware(dt_class.strptime(date_to, "%Y-%m-%d")) + timedelta(
+                days=1
+            )
         except ValueError as exc:
-            raise ValidationError(
-                {'date_to': 'Invalid date_to format. Use YYYY-MM-DD.'}
-            ) from exc
+            raise ValidationError({"date_to": "Invalid date_to format. Use YYYY-MM-DD."}) from exc
     return dt_from_val, dt_to_val
 
 
@@ -84,38 +83,37 @@ def get_donations_by_month(user, year=None, request=None):
 
     monthly_data = (
         gifts.filter(gift_date__year=year)
-        .annotate(month=TruncMonth('gift_date'))
-        .values('month')
-        .annotate(
-            total=Sum('amount_cents'),
-            count=Count('id')
-        )
-        .order_by('month')
+        .annotate(month=TruncMonth("gift_date"))
+        .values("month")
+        .annotate(total=Sum("amount_cents"), count=Count("id"))
+        .order_by("month")
     )
 
     # Build complete 12-month list (fill gaps with 0)
-    monthly_map = {item['month'].month: item for item in monthly_data}
+    monthly_map = {item["month"].month: item for item in monthly_data}
 
     result = []
     for month_num in range(1, 13):
         month_date = date(year, month_num, 1)
-        month_data = monthly_map.get(month_num, {'total': 0, 'count': 0})
-        result.append({
-            'month': month_date.strftime('%Y-%m'),
-            'label': month_date.strftime('%B %Y'),
-            'short_label': month_date.strftime('%b'),
-            'total': float(month_data['total'] or 0) / 100,
-            'count': month_data['count'],
-        })
+        month_data = monthly_map.get(month_num, {"total": 0, "count": 0})
+        result.append(
+            {
+                "month": month_date.strftime("%Y-%m"),
+                "label": month_date.strftime("%B %Y"),
+                "short_label": month_date.strftime("%b"),
+                "total": float(month_data["total"] or 0) / 100,
+                "count": month_data["count"],
+            }
+        )
 
     # Calculate year total
-    year_total = sum(m['total'] for m in result)
+    year_total = sum(m["total"] for m in result)
 
     return {
-        'year': year,
-        'months': result,
-        'year_total': year_total,
-        'donation_count': sum(m['count'] for m in result),
+        "year": year,
+        "months": result,
+        "year_total": year_total,
+        "donation_count": sum(m["count"] for m in result),
     }
 
 
@@ -130,31 +128,30 @@ def get_donations_by_year(user, years=5, request=None):
 
     yearly_data = (
         gifts.filter(gift_date__year__gte=start_year)
-        .annotate(year=TruncYear('gift_date'))
-        .values('year')
-        .annotate(
-            total=Sum('amount_cents'),
-            count=Count('id')
-        )
-        .order_by('year')
+        .annotate(year=TruncYear("gift_date"))
+        .values("year")
+        .annotate(total=Sum("amount_cents"), count=Count("id"))
+        .order_by("year")
     )
 
     # Build map
-    yearly_map = {item['year'].year: item for item in yearly_data}
+    yearly_map = {item["year"].year: item for item in yearly_data}
 
     result = []
     for year in range(start_year, current_year + 1):
-        year_data = yearly_map.get(year, {'total': 0, 'count': 0})
-        result.append({
-            'year': year,
-            'total': float(year_data['total'] or 0) / 100,
-            'count': year_data['count'],
-        })
+        year_data = yearly_map.get(year, {"total": 0, "count": 0})
+        result.append(
+            {
+                "year": year,
+                "total": float(year_data["total"] or 0) / 100,
+                "count": year_data["count"],
+            }
+        )
 
     return {
-        'years': result,
-        'grand_total': sum(y['total'] for y in result),
-        'total_donations': sum(y['count'] for y in result),
+        "years": result,
+        "grand_total": sum(y["total"] for y in result),
+        "total_donations": sum(y["count"] for y in result),
     }
 
 
@@ -171,15 +168,15 @@ def get_monthly_commitments(user, request=None):
     recurring_gifts = _scope_recurring_gifts(user, request=request)
 
     last_fulfilled_subq = (
-        Gift.objects.filter(recurring_gift_id=OuterRef('pk'))
+        Gift.objects.filter(recurring_gift_id=OuterRef("pk"))
         .order_by()
-        .values('recurring_gift_id')
-        .annotate(latest=Max('gift_date'))
-        .values('latest')
+        .values("recurring_gift_id")
+        .annotate(latest=Max("gift_date"))
+        .values("latest")
     )
     active_recurring = (
         recurring_gifts.filter(status=RecurringGiftStatus.ACTIVE)
-        .select_related('donor_contact')
+        .select_related("donor_contact")
         .annotate(last_fulfilled_date=Subquery(last_fulfilled_subq))
     )
 
@@ -194,33 +191,35 @@ def get_monthly_commitments(user, request=None):
 
         freq = rg.frequency
         if freq not in by_frequency:
-            by_frequency[freq] = {'count': 0, 'monthly_total': 0}
-        by_frequency[freq]['count'] += 1
-        by_frequency[freq]['monthly_total'] += monthly_equiv
+            by_frequency[freq] = {"count": 0, "monthly_total": 0}
+        by_frequency[freq]["count"] += 1
+        by_frequency[freq]["monthly_total"] += monthly_equiv
 
-        rg_list.append({
-            'id': str(rg.id),
-            'contact_id': str(rg.donor_contact.id),
-            'contact_name': rg.donor_contact.full_name,
-            'amount': float(rg.amount_dollars),
-            'frequency': rg.frequency,
-            'monthly_equivalent': round(monthly_equiv, 2),
-            'start_date': rg.start_date.isoformat(),
-            'last_fulfilled_date': (
-                rg.last_fulfilled_date.isoformat() if rg.last_fulfilled_date else None
-            ),
-        })
+        rg_list.append(
+            {
+                "id": str(rg.id),
+                "contact_id": str(rg.donor_contact.id),
+                "contact_name": rg.donor_contact.full_name,
+                "amount": float(rg.amount_dollars),
+                "frequency": rg.frequency,
+                "monthly_equivalent": round(monthly_equiv, 2),
+                "start_date": rg.start_date.isoformat(),
+                "last_fulfilled_date": (
+                    rg.last_fulfilled_date.isoformat() if rg.last_fulfilled_date else None
+                ),
+            }
+        )
 
     return {
-        'pledges': rg_list,
-        'total_monthly': round(total_monthly, 2),
-        'total_annual': round(total_monthly * 12, 2),
-        'active_count': len(rg_list),
-        'by_frequency': [
+        "pledges": rg_list,
+        "total_monthly": round(total_monthly, 2),
+        "total_annual": round(total_monthly * 12, 2),
+        "active_count": len(rg_list),
+        "by_frequency": [
             {
-                'frequency': freq,
-                'count': data['count'],
-                'monthly_total': round(data['monthly_total'], 2),
+                "frequency": freq,
+                "count": data["count"],
+                "monthly_total": round(data["monthly_total"], 2),
             }
             for freq, data in by_frequency.items()
         ],
@@ -244,8 +243,8 @@ def get_late_donations(user, limit=50, request=None):
     page = compute_late_donations(base_qs, limit=limit)
     total = count_late_donations(base_qs)
     return {
-        'late_donations': page,
-        'total_count': total,
+        "late_donations": page,
+        "total_count": total,
     }
 
 
@@ -255,29 +254,35 @@ def get_follow_ups(user, limit=50, request=None):
     """
     tasks = _scope_tasks(user, request=request)
 
-    follow_ups = tasks.filter(
-        status__in=[TaskStatus.PENDING, TaskStatus.IN_PROGRESS]
-    ).select_related('contact', 'owner').order_by('due_date', '-priority')[:limit]
+    follow_ups = (
+        tasks.filter(status__in=[TaskStatus.PENDING, TaskStatus.IN_PROGRESS])
+        .select_related("contact", "owner")
+        .order_by("due_date", "-priority")[:limit]
+    )
 
     today = date.today()
 
     return {
-        'tasks': [{
-            'id': str(t.id),
-            'title': t.title,
-            'description': t.description,
-            'task_type': t.task_type,
-            'priority': t.priority,
-            'status': t.status,
-            'due_date': t.due_date.isoformat(),
-            'is_overdue': t.due_date < today,
-            'contact_id': str(t.contact.id) if t.contact else None,
-            'contact_name': t.contact.full_name if t.contact else None,
-        } for t in follow_ups],
-        'total_count': tasks.filter(status__in=[TaskStatus.PENDING, TaskStatus.IN_PROGRESS]).count(),
-        'overdue_count': tasks.filter(
-            status__in=[TaskStatus.PENDING, TaskStatus.IN_PROGRESS],
-            due_date__lt=today
+        "tasks": [
+            {
+                "id": str(t.id),
+                "title": t.title,
+                "description": t.description,
+                "task_type": t.task_type,
+                "priority": t.priority,
+                "status": t.status,
+                "due_date": t.due_date.isoformat(),
+                "is_overdue": t.due_date < today,
+                "contact_id": str(t.contact.id) if t.contact else None,
+                "contact_name": t.contact.full_name if t.contact else None,
+            }
+            for t in follow_ups
+        ],
+        "total_count": tasks.filter(
+            status__in=[TaskStatus.PENDING, TaskStatus.IN_PROGRESS]
+        ).count(),
+        "overdue_count": tasks.filter(
+            status__in=[TaskStatus.PENDING, TaskStatus.IN_PROGRESS], due_date__lt=today
         ).count(),
     }
 
@@ -287,7 +292,7 @@ def get_transactions(user, limit=100, offset=0, contact_id=None, date_from=None,
     Get full transaction ledger (gifts).
     Admin-only endpoint.
     """
-    gifts = Gift.objects.all().select_related('donor_contact')
+    gifts = Gift.objects.all().select_related("donor_contact")
 
     # Apply filters
     if contact_id:
@@ -298,20 +303,23 @@ def get_transactions(user, limit=100, offset=0, contact_id=None, date_from=None,
         gifts = gifts.filter(gift_date__lte=date_to)
 
     total_count = gifts.count()
-    transactions = gifts.order_by('-gift_date', '-created_at')[offset:offset + limit]
+    transactions = gifts.order_by("-gift_date", "-created_at")[offset : offset + limit]
 
     return {
-        'transactions': [{
-            'id': str(d.id),
-            'contact_id': str(d.donor_contact.id),
-            'contact_name': d.donor_contact.full_name,
-            'amount': float(d.amount_dollars),
-            'date': d.gift_date.isoformat(),
-            'notes': d.description,
-        } for d in transactions],
-        'total_count': total_count,
-        'limit': limit,
-        'offset': offset,
+        "transactions": [
+            {
+                "id": str(d.id),
+                "contact_id": str(d.donor_contact.id),
+                "contact_name": d.donor_contact.full_name,
+                "amount": float(d.amount_dollars),
+                "date": d.gift_date.isoformat(),
+                "notes": d.description,
+            }
+            for d in transactions
+        ],
+        "total_count": total_count,
+        "limit": limit,
+        "offset": offset,
     }
 
 
@@ -349,17 +357,21 @@ def get_dashboard_overview(date_from=None, date_to=None):
     # Stalled contacts count (last journal activity >14 days ago)
     # If date_to provided, use it as "now" for stalled calculation
     cutoff_date = (dt_to if dt_to else timezone.now()) - timedelta(days=14)
-    last_activity = JournalStageEvent.objects.filter(
-        journal_contact__contact=OuterRef('pk')
-    ).order_by('-created_at').values('created_at')[:1]
+    last_activity = (
+        JournalStageEvent.objects.filter(journal_contact__contact=OuterRef("pk"))
+        .order_by("-created_at")
+        .values("created_at")[:1]
+    )
 
-    stalled_qs = Contact.active.annotate(
-        last_activity_date=Subquery(last_activity)
-    ).filter(
-        Q(last_activity_date__lt=cutoff_date) | Q(last_activity_date__isnull=True),
-        # Only count contacts that are in at least one journal
-        journal_memberships__isnull=False
-    ).distinct()
+    stalled_qs = (
+        Contact.active.annotate(last_activity_date=Subquery(last_activity))
+        .filter(
+            Q(last_activity_date__lt=cutoff_date) | Q(last_activity_date__isnull=True),
+            # Only count contacts that are in at least one journal
+            journal_memberships__isnull=False,
+        )
+        .distinct()
+    )
     stalled_count = stalled_qs.count()
 
     # Conversion rate: contacts with a Decision / total contacts in journals
@@ -371,11 +383,10 @@ def get_dashboard_overview(date_from=None, date_to=None):
     if dt_to:
         jc_qs = jc_qs.filter(created_at__lt=dt_to)
         decision_qs = decision_qs.filter(created_at__lt=dt_to)
-    contacts_in_journals = jc_qs.values('contact').distinct().count()
-    contacts_with_decision = decision_qs.values('journal_contact__contact').distinct().count()
+    contacts_in_journals = jc_qs.values("contact").distinct().count()
+    contacts_with_decision = decision_qs.values("journal_contact__contact").distinct().count()
     conversion_rate = round(
-        (contacts_with_decision / contacts_in_journals * 100) if contacts_in_journals > 0 else 0,
-        1
+        (contacts_with_decision / contacts_in_journals * 100) if contacts_in_journals > 0 else 0, 1
     )
 
     # Gift summary - filter by date range if provided, else default to last 12 months
@@ -389,24 +400,23 @@ def get_dashboard_overview(date_from=None, date_to=None):
         twelve_months_ago = date.today() - relativedelta(months=12)
         gift_qs = Gift.objects.filter(gift_date__gte=twelve_months_ago)
 
-    gift_stats = gift_qs.aggregate(
-        total_amount=Sum('amount_cents'),
-        total_count=Count('id')
-    )
+    gift_stats = gift_qs.aggregate(total_amount=Sum("amount_cents"), total_count=Count("id"))
 
     return {
-        'total_contacts': total_contacts,
-        'active_journals': active_journals,
-        'stalled_contacts': stalled_count,
-        'conversion_rate': conversion_rate,
-        'donations_12m': {
-            'total_amount': float((gift_stats['total_amount'] or 0)) / 100,
-            'total_count': gift_stats['total_count'] or 0,
+        "total_contacts": total_contacts,
+        "active_journals": active_journals,
+        "stalled_contacts": stalled_count,
+        "conversion_rate": conversion_rate,
+        "donations_12m": {
+            "total_amount": float((gift_stats["total_amount"] or 0)) / 100,
+            "total_count": gift_stats["total_count"] or 0,
         },
     }
 
 
-def get_stalled_contacts(limit=50, offset=0, sort_by='days_stalled', sort_dir='desc', date_from=None, date_to=None):
+def get_stalled_contacts(
+    limit=50, offset=0, sort_by="days_stalled", sort_dir="desc", date_from=None, date_to=None
+):
     """
     Find contacts with last journal activity >14 days ago.
     Uses Subquery annotation per requirement API-04.
@@ -423,25 +433,34 @@ def get_stalled_contacts(limit=50, offset=0, sort_by='days_stalled', sort_dir='d
     """
     dt_from, dt_to = _parse_date_range(date_from, date_to)
 
-    last_activity = JournalStageEvent.objects.filter(
-        journal_contact__contact=OuterRef('pk')
-    ).order_by('-created_at').values('created_at')[:1]
+    last_activity = (
+        JournalStageEvent.objects.filter(journal_contact__contact=OuterRef("pk"))
+        .order_by("-created_at")
+        .values("created_at")[:1]
+    )
 
     # Subquery for earliest journal membership date (for zero-activity contacts)
-    journal_membership_date = JournalContact.objects.filter(
-        contact=OuterRef('pk')
-    ).order_by('created_at').values('created_at')[:1]
+    journal_membership_date = (
+        JournalContact.objects.filter(contact=OuterRef("pk"))
+        .order_by("created_at")
+        .values("created_at")[:1]
+    )
 
     # Use date_to as "now" if provided, else current time
     cutoff_date = (dt_to if dt_to else timezone.now()) - timedelta(days=14)
 
-    base_qs = Contact.active.annotate(
-        last_activity_date=Subquery(last_activity),
-        journal_membership_date=Subquery(journal_membership_date),
-    ).filter(
-        Q(last_activity_date__lt=cutoff_date) | Q(last_activity_date__isnull=True),
-        journal_memberships__isnull=False
-    ).distinct().select_related('owner')
+    base_qs = (
+        Contact.active.annotate(
+            last_activity_date=Subquery(last_activity),
+            journal_membership_date=Subquery(journal_membership_date),
+        )
+        .filter(
+            Q(last_activity_date__lt=cutoff_date) | Q(last_activity_date__isnull=True),
+            journal_memberships__isnull=False,
+        )
+        .distinct()
+        .select_related("owner")
+    )
 
     # Apply date range filter on last_activity_date if provided
     if dt_from:
@@ -453,33 +472,35 @@ def get_stalled_contacts(limit=50, offset=0, sort_by='days_stalled', sort_dir='d
 
     # Define allowed sort fields (security: prevent arbitrary field ordering)
     SORT_FIELDS = {
-        'days_stalled': Coalesce('last_activity_date', 'journal_membership_date', Value('1970-01-01')),
-        'full_name': 'first_name',
-        'owner_name': 'owner__first_name',
-        'last_activity_date': Coalesce('last_activity_date', Value('1970-01-01')),
+        "days_stalled": Coalesce(
+            "last_activity_date", "journal_membership_date", Value("1970-01-01")
+        ),
+        "full_name": "first_name",
+        "owner_name": "owner__first_name",
+        "last_activity_date": Coalesce("last_activity_date", Value("1970-01-01")),
     }
 
     # Apply sorting
-    sort_field = SORT_FIELDS.get(sort_by, SORT_FIELDS['days_stalled'])
+    sort_field = SORT_FIELDS.get(sort_by, SORT_FIELDS["days_stalled"])
 
     # For days_stalled: older date = more stalled, so desc on days_stalled = asc on date
     # For date fields, we need to invert the direction
-    if sort_by in ('days_stalled', 'last_activity_date'):
+    if sort_by in ("days_stalled", "last_activity_date"):
         # Invert direction for date-based sorting
-        effective_dir = 'asc' if sort_dir == 'desc' else 'desc'
+        effective_dir = "asc" if sort_dir == "desc" else "desc"
     else:
         effective_dir = sort_dir
 
-    if hasattr(sort_field, 'asc'):
+    if hasattr(sort_field, "asc"):
         # Expression object (Coalesce)
-        ordering = sort_field.asc() if effective_dir == 'asc' else sort_field.desc()
+        ordering = sort_field.asc() if effective_dir == "asc" else sort_field.desc()
     else:
         # String field name
-        ordering = sort_field if effective_dir == 'asc' else f'-{sort_field}'
+        ordering = sort_field if effective_dir == "asc" else f"-{sort_field}"
 
     # Apply pagination (limit=None means no limit for CSV export)
     if limit is not None:
-        stalled = base_qs.order_by(ordering)[offset:offset + limit]
+        stalled = base_qs.order_by(ordering)[offset : offset + limit]
     else:
         stalled = base_qs.order_by(ordering)[offset:]
 
@@ -487,28 +508,30 @@ def get_stalled_contacts(limit=50, offset=0, sort_by='days_stalled', sort_dir='d
     reference_time = dt_to if dt_to else timezone.now()
 
     return {
-        'stalled_contacts': [
+        "stalled_contacts": [
             {
-                'id': str(c.id),
-                'full_name': c.full_name,
-                'email': c.email,
-                'owner_email': c.owner.email,
-                'owner_name': f'{c.owner.first_name} {c.owner.last_name}'.strip(),
-                'last_activity_date': c.last_activity_date.isoformat() if c.last_activity_date else None,
-                'days_stalled': (
+                "id": str(c.id),
+                "full_name": c.full_name,
+                "email": c.email,
+                "owner_email": c.owner.email,
+                "owner_name": f"{c.owner.first_name} {c.owner.last_name}".strip(),
+                "last_activity_date": c.last_activity_date.isoformat()
+                if c.last_activity_date
+                else None,
+                "days_stalled": (
                     (reference_time - c.last_activity_date).days
                     if c.last_activity_date
                     else (reference_time - c.journal_membership_date).days
                     if c.journal_membership_date
                     else None
                 ),
-                'status': c.status,
+                "status": c.status,
             }
             for c in stalled
         ],
-        'total_count': total_count,
-        'limit': limit,
-        'offset': offset,
+        "total_count": total_count,
+        "limit": limit,
+        "offset": offset,
     }
 
 
@@ -524,71 +547,70 @@ def _annotate_user_performance(queryset):
     query plan. Scalar subqueries keep complexity at O(users) + O(decisions).
     """
     # Per-user gift total (cents)
-    gift_totals = Gift.objects.filter(
-        donor_contact__owner=OuterRef('pk')
-    ).values('donor_contact__owner').annotate(
-        total=Sum('amount_cents')
-    ).values('total')
+    gift_totals = (
+        Gift.objects.filter(donor_contact__owner=OuterRef("pk"))
+        .values("donor_contact__owner")
+        .annotate(total=Sum("amount_cents"))
+        .values("total")
+    )
 
     # Per-user gift count
-    gift_counts = Gift.objects.filter(
-        donor_contact__owner=OuterRef('pk')
-    ).values('donor_contact__owner').annotate(
-        count=Count('id')
-    ).values('count')
+    gift_counts = (
+        Gift.objects.filter(donor_contact__owner=OuterRef("pk"))
+        .values("donor_contact__owner")
+        .annotate(count=Count("id"))
+        .values("count")
+    )
 
     # Per-user decision count
-    decision_counts = Decision.objects.filter(
-        journal_contact__journal__owner=OuterRef('pk')
-    ).values('journal_contact__journal__owner').annotate(
-        count=Count('id')
-    ).values('count')
+    decision_counts = (
+        Decision.objects.filter(journal_contact__journal__owner=OuterRef("pk"))
+        .values("journal_contact__journal__owner")
+        .annotate(count=Count("id"))
+        .values("count")
+    )
 
     # Per-user distinct-contact count among JournalContacts
-    contacts_in_journals_counts = JournalContact.objects.filter(
-        journal__owner=OuterRef('pk')
-    ).values('journal__owner').annotate(
-        count=Count('contact', distinct=True)
-    ).values('count')
+    contacts_in_journals_counts = (
+        JournalContact.objects.filter(journal__owner=OuterRef("pk"))
+        .values("journal__owner")
+        .annotate(count=Count("contact", distinct=True))
+        .values("count")
+    )
 
     # Per-user distinct-contact count among Decisions
-    contacts_with_decisions_counts = Decision.objects.filter(
-        journal_contact__journal__owner=OuterRef('pk')
-    ).values('journal_contact__journal__owner').annotate(
-        count=Count('journal_contact__contact', distinct=True)
-    ).values('count')
+    contacts_with_decisions_counts = (
+        Decision.objects.filter(journal_contact__journal__owner=OuterRef("pk"))
+        .values("journal_contact__journal__owner")
+        .annotate(count=Count("journal_contact__contact", distinct=True))
+        .values("count")
+    )
 
     # Per-user active-journal count (is_archived=False)
-    active_journal_counts = Journal.objects.filter(
-        owner=OuterRef('pk'),
-        is_archived=False,
-    ).values('owner').annotate(
-        count=Count('id')
-    ).values('count')
+    active_journal_counts = (
+        Journal.objects.filter(
+            owner=OuterRef("pk"),
+            is_archived=False,
+        )
+        .values("owner")
+        .annotate(count=Count("id"))
+        .values("count")
+    )
 
     # Per-user contact count
-    contact_counts = Contact.active.filter(
-        owner=OuterRef('pk')
-    ).values('owner').annotate(
-        count=Count('id')
-    ).values('count')
+    contact_counts = (
+        Contact.active.filter(owner=OuterRef("pk"))
+        .values("owner")
+        .annotate(count=Count("id"))
+        .values("count")
+    )
 
     return queryset.annotate(
-        total_contacts=Coalesce(
-            Subquery(contact_counts, output_field=IntegerField()), 0
-        ),
-        active_journals=Coalesce(
-            Subquery(active_journal_counts, output_field=IntegerField()), 0
-        ),
-        total_gift_amount_cents=Coalesce(
-            Subquery(gift_totals, output_field=IntegerField()), 0
-        ),
-        gift_count=Coalesce(
-            Subquery(gift_counts, output_field=IntegerField()), 0
-        ),
-        decisions_logged=Coalesce(
-            Subquery(decision_counts, output_field=IntegerField()), 0
-        ),
+        total_contacts=Coalesce(Subquery(contact_counts, output_field=IntegerField()), 0),
+        active_journals=Coalesce(Subquery(active_journal_counts, output_field=IntegerField()), 0),
+        total_gift_amount_cents=Coalesce(Subquery(gift_totals, output_field=IntegerField()), 0),
+        gift_count=Coalesce(Subquery(gift_counts, output_field=IntegerField()), 0),
+        decisions_logged=Coalesce(Subquery(decision_counts, output_field=IntegerField()), 0),
         _contacts_with_decisions=Coalesce(
             Subquery(contacts_with_decisions_counts, output_field=IntegerField()), 0
         ),
@@ -607,16 +629,16 @@ def _serialize_user_performance(user):
         1,
     )
     return {
-        'id': str(user.id),
-        'email': user.email,
-        'name': f'{user.first_name} {user.last_name}'.strip(),
-        'role': user.role,
-        'total_contacts': user.total_contacts,
-        'active_journals': user.active_journals,
-        'decisions_logged': user.decisions_logged,
-        'conversion_rate': conversion_rate,
-        'total_donations': float(user.total_gift_amount_cents or 0) / 100,
-        'donation_count': user.gift_count,
+        "id": str(user.id),
+        "email": user.email,
+        "name": f"{user.first_name} {user.last_name}".strip(),
+        "role": user.role,
+        "total_contacts": user.total_contacts,
+        "active_journals": user.active_journals,
+        "decisions_logged": user.decisions_logged,
+        "conversion_rate": conversion_rate,
+        "total_donations": float(user.total_gift_amount_cents or 0) / 100,
+        "donation_count": user.gift_count,
     }
 
 
@@ -632,10 +654,10 @@ def get_user_performance():
     (HIGH-3).
     """
     users = _annotate_user_performance(
-        User.objects.filter(role__in=['missionary', 'admin', 'supervisor'])
-    ).order_by('-total_contacts')
+        User.objects.filter(role__in=["missionary", "admin", "supervisor"])
+    ).order_by("-total_contacts")
 
-    return {'users': [_serialize_user_performance(u) for u in users]}
+    return {"users": [_serialize_user_performance(u) for u in users]}
 
 
 def get_single_user_performance(user_id):
@@ -649,7 +671,7 @@ def get_single_user_performance(user_id):
     SECURITY: same as get_user_performance — admin-gated.
     """
     user = _annotate_user_performance(
-        User.objects.filter(id=user_id, role__in=['missionary', 'admin', 'supervisor'])
+        User.objects.filter(id=user_id, role__in=["missionary", "admin", "supervisor"])
     ).first()
     if user is None:
         return None
@@ -675,18 +697,21 @@ def get_conversion_funnel(date_from=None, date_to=None):
     if dt_to:
         stage_events_qs = stage_events_qs.filter(created_at__lt=dt_to)
 
-    latest_stage = stage_events_qs.filter(
-        journal_contact=OuterRef('pk')
-    ).order_by('-created_at').values('stage')[:1]
+    latest_stage = (
+        stage_events_qs.filter(journal_contact=OuterRef("pk"))
+        .order_by("-created_at")
+        .values("stage")[:1]
+    )
 
     # Annotate each journal_contact with current stage, aggregate counts
-    breakdown = JournalContact.objects.annotate(
-        current_stage=Subquery(latest_stage)
-    ).values('current_stage').annotate(
-        count=Count('id')
-    ).order_by('current_stage')
+    breakdown = (
+        JournalContact.objects.annotate(current_stage=Subquery(latest_stage))
+        .values("current_stage")
+        .annotate(count=Count("id"))
+        .order_by("current_stage")
+    )
 
-    stage_counts = {item['current_stage']: item['count'] for item in breakdown}
+    stage_counts = {item["current_stage"]: item["count"] for item in breakdown}
 
     # Separate null-stage contacts from the pipeline total
     null_count = stage_counts.pop(None, 0)
@@ -699,17 +724,19 @@ def get_conversion_funnel(date_from=None, date_to=None):
     funnel = []
     for stage_value in stage_order:
         count = stage_counts.get(stage_value, 0)
-        funnel.append({
-            'stage': stage_value,
-            'label': stage_labels.get(stage_value, stage_value),
-            'count': count,
-            'percentage': round((count / total * 100) if total > 0 else 0, 1),
-        })
+        funnel.append(
+            {
+                "stage": stage_value,
+                "label": stage_labels.get(stage_value, stage_value),
+                "count": count,
+                "percentage": round((count / total * 100) if total > 0 else 0, 1),
+            }
+        )
 
     return {
-        'funnel': funnel,
-        'total_contacts_in_pipeline': total,
-        'no_activity_count': null_count,
+        "funnel": funnel,
+        "total_contacts_in_pipeline": total,
+        "no_activity_count": null_count,
     }
 
 
@@ -731,31 +758,29 @@ def get_team_activity(limit=50, date_from=None, date_to=None):
     if dt_to:
         events_qs = events_qs.filter(created_at__lt=dt_to)
 
-    recent_events = events_qs.select_related(
-        'user', 'contact'
-    ).order_by('-created_at')[:limit]
+    recent_events = events_qs.select_related("user", "contact").order_by("-created_at")[:limit]
 
     # Count with same filters for total_count
     total_count = events_qs.count()
 
     return {
-        'activities': [
+        "activities": [
             {
-                'id': str(e.id),
-                'user_id': str(e.user.id),
-                'user_email': e.user.email,
-                'user_name': f'{e.user.first_name} {e.user.last_name}'.strip(),
-                'event_type': e.event_type,
-                'title': e.title,
-                'message': e.message,
-                'severity': e.severity,
-                'contact_id': str(e.contact.id) if e.contact else None,
-                'contact_name': e.contact.full_name if e.contact else None,
-                'created_at': e.created_at.isoformat(),
+                "id": str(e.id),
+                "user_id": str(e.user.id),
+                "user_email": e.user.email,
+                "user_name": f"{e.user.first_name} {e.user.last_name}".strip(),
+                "event_type": e.event_type,
+                "title": e.title,
+                "message": e.message,
+                "severity": e.severity,
+                "contact_id": str(e.contact.id) if e.contact else None,
+                "contact_name": e.contact.full_name if e.contact else None,
+                "created_at": e.created_at.isoformat(),
             }
             for e in recent_events
         ],
-        'total_count': total_count,
+        "total_count": total_count,
     }
 
 
@@ -795,60 +820,64 @@ def get_team_trends(weeks=12, date_from=None, date_to=None):
         start_date = current_week_monday - timedelta(weeks=weeks - 1)
 
     # Query decisions by week
-    decisions_by_week = Decision.objects.filter(
-        created_at__gte=start_date
-    ).annotate(
-        week=TruncWeek('created_at')
-    ).values('week').annotate(
-        count=Count('id')
-    ).order_by('week')
+    decisions_by_week = (
+        Decision.objects.filter(created_at__gte=start_date)
+        .annotate(week=TruncWeek("created_at"))
+        .values("week")
+        .annotate(count=Count("id"))
+        .order_by("week")
+    )
 
     # Query gifts by week
-    gifts_by_week = Gift.objects.filter(
-        gift_date__gte=start_date
-    ).annotate(
-        week=TruncWeek('gift_date')
-    ).values('week').annotate(
-        count=Count('id')
-    ).order_by('week')
+    gifts_by_week = (
+        Gift.objects.filter(gift_date__gte=start_date)
+        .annotate(week=TruncWeek("gift_date"))
+        .values("week")
+        .annotate(count=Count("id"))
+        .order_by("week")
+    )
 
     # Query stage progressions by week
-    stage_events_by_week = JournalStageEvent.objects.filter(
-        created_at__gte=start_date
-    ).annotate(
-        week=TruncWeek('created_at')
-    ).values('week').annotate(
-        count=Count('id')
-    ).order_by('week')
+    stage_events_by_week = (
+        JournalStageEvent.objects.filter(created_at__gte=start_date)
+        .annotate(week=TruncWeek("created_at"))
+        .values("week")
+        .annotate(count=Count("id"))
+        .order_by("week")
+    )
 
     # Build maps for quick lookup
     # Note: TruncWeek on DateTimeField returns datetime, on DateField returns date
     def normalize_to_date(dt):
         """Convert datetime or date to date object."""
-        return dt.date() if hasattr(dt, 'date') and callable(dt.date) else dt
+        return dt.date() if hasattr(dt, "date") and callable(dt.date) else dt
 
-    decisions_map = {normalize_to_date(item['week']): item['count'] for item in decisions_by_week}
-    gifts_map = {normalize_to_date(item['week']): item['count'] for item in gifts_by_week}
-    stage_events_map = {normalize_to_date(item['week']): item['count'] for item in stage_events_by_week}
+    decisions_map = {normalize_to_date(item["week"]): item["count"] for item in decisions_by_week}
+    gifts_map = {normalize_to_date(item["week"]): item["count"] for item in gifts_by_week}
+    stage_events_map = {
+        normalize_to_date(item["week"]): item["count"] for item in stage_events_by_week
+    }
 
     # Build complete week list (fill gaps with 0)
     result = []
     for week_num in range(weeks):
         week_start = start_date + timedelta(weeks=week_num)
         # Format label (e.g., "Feb 3")
-        week_label = week_start.strftime('%b %-d')
+        week_label = week_start.strftime("%b %-d")
 
-        result.append({
-            'week_start': week_start.isoformat(),
-            'week_label': week_label,
-            'decisions_logged': decisions_map.get(week_start, 0),
-            'donations_received': gifts_map.get(week_start, 0),
-            'stage_progressions': stage_events_map.get(week_start, 0),
-        })
+        result.append(
+            {
+                "week_start": week_start.isoformat(),
+                "week_label": week_label,
+                "decisions_logged": decisions_map.get(week_start, 0),
+                "donations_received": gifts_map.get(week_start, 0),
+                "stage_progressions": stage_events_map.get(week_start, 0),
+            }
+        )
 
     return {
-        'trends': result,
-        'weeks': weeks,
+        "trends": result,
+        "weeks": weeks,
     }
 
 
@@ -874,63 +903,68 @@ def get_user_trends(user_id, weeks=12):
     start_date = current_week_monday - timedelta(weeks=weeks - 1)
 
     # Query decisions by week for this user
-    decisions_by_week = Decision.objects.filter(
-        journal_contact__journal__owner_id=user_id,
-        created_at__gte=start_date
-    ).annotate(
-        week=TruncWeek('created_at')
-    ).values('week').annotate(
-        count=Count('id')
-    ).order_by('week')
+    decisions_by_week = (
+        Decision.objects.filter(
+            journal_contact__journal__owner_id=user_id, created_at__gte=start_date
+        )
+        .annotate(week=TruncWeek("created_at"))
+        .values("week")
+        .annotate(count=Count("id"))
+        .order_by("week")
+    )
 
     # Query gifts by week for this user
-    gifts_by_week = Gift.objects.filter(
-        donor_contact__owner_id=user_id,
-        gift_date__gte=start_date
-    ).annotate(
-        week=TruncWeek('gift_date')
-    ).values('week').annotate(
-        count=Count('id')
-    ).order_by('week')
+    gifts_by_week = (
+        Gift.objects.filter(donor_contact__owner_id=user_id, gift_date__gte=start_date)
+        .annotate(week=TruncWeek("gift_date"))
+        .values("week")
+        .annotate(count=Count("id"))
+        .order_by("week")
+    )
 
     # Query stage progressions by week for this user
-    stage_events_by_week = JournalStageEvent.objects.filter(
-        journal_contact__journal__owner_id=user_id,
-        created_at__gte=start_date
-    ).annotate(
-        week=TruncWeek('created_at')
-    ).values('week').annotate(
-        count=Count('id')
-    ).order_by('week')
+    stage_events_by_week = (
+        JournalStageEvent.objects.filter(
+            journal_contact__journal__owner_id=user_id, created_at__gte=start_date
+        )
+        .annotate(week=TruncWeek("created_at"))
+        .values("week")
+        .annotate(count=Count("id"))
+        .order_by("week")
+    )
 
     # Build maps for quick lookup
     # Note: TruncWeek on DateTimeField returns datetime, on DateField returns date
     def normalize_to_date(dt):
         """Convert datetime or date to date object."""
-        return dt.date() if hasattr(dt, 'date') and callable(dt.date) else dt
+        return dt.date() if hasattr(dt, "date") and callable(dt.date) else dt
 
-    decisions_map = {normalize_to_date(item['week']): item['count'] for item in decisions_by_week}
-    gifts_map = {normalize_to_date(item['week']): item['count'] for item in gifts_by_week}
-    stage_events_map = {normalize_to_date(item['week']): item['count'] for item in stage_events_by_week}
+    decisions_map = {normalize_to_date(item["week"]): item["count"] for item in decisions_by_week}
+    gifts_map = {normalize_to_date(item["week"]): item["count"] for item in gifts_by_week}
+    stage_events_map = {
+        normalize_to_date(item["week"]): item["count"] for item in stage_events_by_week
+    }
 
     # Build complete week list (fill gaps with 0)
     result = []
     for week_num in range(weeks):
         week_start = start_date + timedelta(weeks=week_num)
         # Format label (e.g., "Feb 3")
-        week_label = week_start.strftime('%b %-d')
+        week_label = week_start.strftime("%b %-d")
 
-        result.append({
-            'week_start': week_start.isoformat(),
-            'week_label': week_label,
-            'decisions_logged': decisions_map.get(week_start, 0),
-            'donations_received': gifts_map.get(week_start, 0),
-            'stage_progressions': stage_events_map.get(week_start, 0),
-        })
+        result.append(
+            {
+                "week_start": week_start.isoformat(),
+                "week_label": week_label,
+                "decisions_logged": decisions_map.get(week_start, 0),
+                "donations_received": gifts_map.get(week_start, 0),
+                "stage_progressions": stage_events_map.get(week_start, 0),
+            }
+        )
 
     return {
-        'trends': result,
-        'weeks': weeks,
+        "trends": result,
+        "weeks": weeks,
     }
 
 
@@ -947,28 +981,29 @@ def get_user_journals(user_id):
     Returns:
         Dictionary with 'journals' list
     """
-    journals = Journal.objects.filter(
-        owner_id=user_id,
-        is_archived=False
-    ).annotate(
-        member_count=Count('journal_contacts', distinct=True),
-        decision_count=Count('journal_contacts__decisions', distinct=True),
-        active_member_count=Count(
-            'journal_contacts',
-            filter=Q(journal_contacts__decisions__isnull=False),
-            distinct=True
+    journals = (
+        Journal.objects.filter(owner_id=user_id, is_archived=False)
+        .annotate(
+            member_count=Count("journal_contacts", distinct=True),
+            decision_count=Count("journal_contacts__decisions", distinct=True),
+            active_member_count=Count(
+                "journal_contacts",
+                filter=Q(journal_contacts__decisions__isnull=False),
+                distinct=True,
+            ),
         )
-    ).order_by('-created_at')
+        .order_by("-created_at")
+    )
 
     return {
-        'journals': [
+        "journals": [
             {
-                'id': str(j.id),
-                'name': j.name,
-                'member_count': j.member_count,
-                'decision_count': j.decision_count,
-                'active_member_count': j.active_member_count,
-                'created_at': j.created_at.isoformat(),
+                "id": str(j.id),
+                "name": j.name,
+                "member_count": j.member_count,
+                "decision_count": j.decision_count,
+                "active_member_count": j.active_member_count,
+                "created_at": j.created_at.isoformat(),
             }
             for j in journals
         ]
@@ -990,14 +1025,18 @@ def get_stage_contacts(stage, limit=100):
         Dictionary with 'contacts' list and 'total_count'
     """
     # Subquery to get most recent stage per journal_contact
-    latest_stage = JournalStageEvent.objects.filter(
-        journal_contact=OuterRef('pk')
-    ).order_by('-created_at').values('stage')[:1]
+    latest_stage = (
+        JournalStageEvent.objects.filter(journal_contact=OuterRef("pk"))
+        .order_by("-created_at")
+        .values("stage")[:1]
+    )
 
     # Subquery for last activity date (most recent stage event)
-    last_activity = JournalStageEvent.objects.filter(
-        journal_contact__contact=OuterRef('pk')
-    ).order_by('-created_at').values('created_at')[:1]
+    last_activity = (
+        JournalStageEvent.objects.filter(journal_contact__contact=OuterRef("pk"))
+        .order_by("-created_at")
+        .values("created_at")[:1]
+    )
 
     # Get JournalContacts with current stage annotation
     journal_contacts_qs = JournalContact.objects.annotate(
@@ -1005,7 +1044,7 @@ def get_stage_contacts(stage, limit=100):
     )
 
     # Filter by stage (handle None for "No Activity")
-    if stage is None or stage == 'none':
+    if stage is None or stage == "none":
         # Contacts with no stage events
         journal_contacts_qs = journal_contacts_qs.filter(current_stage__isnull=True)
     else:
@@ -1013,31 +1052,33 @@ def get_stage_contacts(stage, limit=100):
         journal_contacts_qs = journal_contacts_qs.filter(current_stage=stage)
 
     # Get distinct contact IDs from matching JournalContacts
-    contact_ids = journal_contacts_qs.values_list('contact_id', flat=True).distinct()
+    contact_ids = journal_contacts_qs.values_list("contact_id", flat=True).distinct()
 
     # Count total before applying limit
     total_count = contact_ids.count()
 
     # Get Contact objects with owner and last activity
-    contacts = Contact.active.filter(
-        id__in=contact_ids[:limit]
-    ).annotate(
-        last_activity_date=Subquery(last_activity)
-    ).select_related('owner')
+    contacts = (
+        Contact.active.filter(id__in=contact_ids[:limit])
+        .annotate(last_activity_date=Subquery(last_activity))
+        .select_related("owner")
+    )
 
     return {
-        'contacts': [
+        "contacts": [
             {
-                'id': str(c.id),
-                'full_name': c.full_name,
-                'email': c.email,
-                'owner_name': f'{c.owner.first_name} {c.owner.last_name}'.strip(),
-                'last_activity_date': c.last_activity_date.isoformat() if c.last_activity_date else None,
+                "id": str(c.id),
+                "full_name": c.full_name,
+                "email": c.email,
+                "owner_name": f"{c.owner.first_name} {c.owner.last_name}".strip(),
+                "last_activity_date": c.last_activity_date.isoformat()
+                if c.last_activity_date
+                else None,
             }
             for c in contacts
         ],
-        'total_count': total_count,
-        'stage': stage or 'none',
+        "total_count": total_count,
+        "stage": stage or "none",
     }
 
 
@@ -1059,69 +1100,74 @@ def get_user_drilldown(user_id):
     # to keep metric definitions (conversion rate, decisions_logged, etc.) in
     # lockstep between the dashboard table and the drilldown panel.
     user = _annotate_user_performance(
-        User.objects.filter(id=user_id, role__in=['missionary', 'admin', 'supervisor'])
+        User.objects.filter(id=user_id, role__in=["missionary", "admin", "supervisor"])
     ).first()
     if user is None:
-        return {'detail': 'User not found'}
+        return {"detail": "User not found"}
 
     performance = _serialize_user_performance(user)
 
     # Stalled contact count for this user (last journal activity >14 days ago)
     cutoff_date = timezone.now() - timedelta(days=14)
-    last_activity = JournalStageEvent.objects.filter(
-        journal_contact__contact=OuterRef('pk')
-    ).order_by('-created_at').values('created_at')[:1]
+    last_activity = (
+        JournalStageEvent.objects.filter(journal_contact__contact=OuterRef("pk"))
+        .order_by("-created_at")
+        .values("created_at")[:1]
+    )
 
-    stalled_count = Contact.active.filter(
-        owner_id=user_id
-    ).annotate(
-        last_activity_date=Subquery(last_activity)
-    ).filter(
-        Q(last_activity_date__lt=cutoff_date) | Q(last_activity_date__isnull=True),
-        journal_memberships__isnull=False
-    ).distinct().count()
+    stalled_count = (
+        Contact.active.filter(owner_id=user_id)
+        .annotate(last_activity_date=Subquery(last_activity))
+        .filter(
+            Q(last_activity_date__lt=cutoff_date) | Q(last_activity_date__isnull=True),
+            journal_memberships__isnull=False,
+        )
+        .distinct()
+        .count()
+    )
 
     # Recent journals (top 5, non-archived) with annotations
-    recent_journals = Journal.objects.filter(
-        owner_id=user_id,
-        is_archived=False
-    ).annotate(
-        member_count=Count('journal_contacts', distinct=True),
-        decision_count=Count('journal_contacts__decisions', distinct=True),
-        active_member_count=Count(
-            'journal_contacts',
-            filter=Q(journal_contacts__decisions__isnull=False),
-            distinct=True
+    recent_journals = (
+        Journal.objects.filter(owner_id=user_id, is_archived=False)
+        .annotate(
+            member_count=Count("journal_contacts", distinct=True),
+            decision_count=Count("journal_contacts__decisions", distinct=True),
+            active_member_count=Count(
+                "journal_contacts",
+                filter=Q(journal_contacts__decisions__isnull=False),
+                distinct=True,
+            ),
         )
-    ).order_by('-created_at')[:5]
+        .order_by("-created_at")[:5]
+    )
 
     return {
-        'user': {
-            'id': performance['id'],
-            'name': performance['name'],
-            'email': performance['email'],
-            'role': performance['role'],
+        "user": {
+            "id": performance["id"],
+            "name": performance["name"],
+            "email": performance["email"],
+            "role": performance["role"],
         },
-        'stats': {
-            'total_contacts': performance['total_contacts'],
-            'active_journals': performance['active_journals'],
-            'decisions_logged': performance['decisions_logged'],
-            'conversion_rate': performance['conversion_rate'],
-            'total_donations': performance['total_donations'],
-            'donation_count': performance['donation_count'],
-            'stalled_contacts': stalled_count,
+        "stats": {
+            "total_contacts": performance["total_contacts"],
+            "active_journals": performance["active_journals"],
+            "decisions_logged": performance["decisions_logged"],
+            "conversion_rate": performance["conversion_rate"],
+            "total_donations": performance["total_donations"],
+            "donation_count": performance["donation_count"],
+            "stalled_contacts": stalled_count,
         },
-        'journals': [
+        "journals": [
             {
-                'id': str(j.id),
-                'name': j.name,
-                'member_count': j.member_count,
-                'decision_count': j.decision_count,
-                'active_member_count': j.active_member_count,
-                'created_at': j.created_at.isoformat(),
+                "id": str(j.id),
+                "name": j.name,
+                "member_count": j.member_count,
+                "decision_count": j.decision_count,
+                "active_member_count": j.active_member_count,
+                "created_at": j.created_at.isoformat(),
             }
             for j in recent_journals
-        ]
+        ],
     }
 
 
@@ -1148,9 +1194,9 @@ def get_pace_calculation(date_from=None, date_to=None):
         stage_events_qs = stage_events_qs.filter(created_at__lt=dt_to)
 
     # Get all stage events ordered by journal_contact and created_at
-    stage_events = stage_events_qs.order_by(
-        'journal_contact_id', 'created_at'
-    ).values('journal_contact_id', 'created_at')
+    stage_events = stage_events_qs.order_by("journal_contact_id", "created_at").values(
+        "journal_contact_id", "created_at"
+    )
 
     # Calculate intervals between consecutive events for each contact
     intervals = []
@@ -1158,8 +1204,8 @@ def get_pace_calculation(date_from=None, date_to=None):
     prev_time = None
 
     for event in stage_events:
-        contact_id = event['journal_contact_id']
-        created_at = event['created_at']
+        contact_id = event["journal_contact_id"]
+        created_at = event["created_at"]
 
         if contact_id == prev_contact_id and prev_time:
             # Calculate interval in days
@@ -1174,11 +1220,11 @@ def get_pace_calculation(date_from=None, date_to=None):
     if intervals:
         average_pace = sum(intervals) / len(intervals)
         return {
-            'average_days_between_stages': round(average_pace, 1),
-            'total_intervals': len(intervals),
+            "average_days_between_stages": round(average_pace, 1),
+            "total_intervals": len(intervals),
         }
     else:
         return {
-            'average_days_between_stages': None,
-            'total_intervals': 0,
+            "average_days_between_stages": None,
+            "total_intervals": 0,
         }

--- a/apps/insights/services.py
+++ b/apps/insights/services.py
@@ -1018,7 +1018,8 @@ def get_stage_contacts(stage, limit=100):
     Target: <5 queries.
 
     Args:
-        stage: PipelineStage value (string) or None for "No Activity" (contacts with no stage events)
+        stage: PipelineStage value (string) or None for "No Activity"
+            (contacts with no stage events)
         limit: Max results to return (default 100)
 
     Returns:

--- a/apps/insights/tests/test_csv_export.py
+++ b/apps/insights/tests/test_csv_export.py
@@ -9,7 +9,6 @@ from io import StringIO
 from django.utils import timezone
 
 from rest_framework import status
-from rest_framework.test import APIClient
 
 import pytest
 
@@ -108,7 +107,8 @@ class TestStalledContactsCSVExport:
         date_from = "2025-01-01"
         date_to = "2025-01-31"
         response = client.get(
-            f"/api/v1/insights/admin/stalled-contacts/export/?date_from={date_from}&date_to={date_to}"
+            "/api/v1/insights/admin/stalled-contacts/export/"
+            f"?date_from={date_from}&date_to={date_to}"
         )
         assert response.status_code == status.HTTP_200_OK
         assert f"{date_from}_to_{date_to}" in response["Content-Disposition"]
@@ -159,7 +159,6 @@ class TestStalledContactsCSVExport:
         rows = list(csv_reader)
 
         # Should only have contact2 (recent event is within date range)
-        contact_names = [row[0] for row in rows]
         # Note: with date_from filter, we filter contacts that have activity >= date_from
         # So contact2 (15 days ago) should be included, contact1 (30 days ago) should be excluded
         # Actually, the date_from filter in stalled contacts filters by last_activity_date

--- a/apps/insights/tests/test_csv_export.py
+++ b/apps/insights/tests/test_csv_export.py
@@ -1,20 +1,22 @@
 """
 Tests for CSV export endpoints in insights app.
 """
-import pytest
 import csv
-from io import StringIO
 from datetime import timedelta
 from decimal import Decimal
+from io import StringIO
 
 from django.utils import timezone
+
 from rest_framework import status
 from rest_framework.test import APIClient
 
-from apps.users.tests.factories import UserFactory
+import pytest
+
 from apps.contacts.tests.factories import ContactFactory
-from apps.journals.models import Journal, JournalContact, JournalStageEvent, PipelineStage
 from apps.events.models import Event
+from apps.journals.models import Journal, JournalContact, JournalStageEvent, PipelineStage
+from apps.users.tests.factories import UserFactory
 
 
 @pytest.mark.django_db
@@ -24,47 +26,47 @@ class TestStalledContactsCSVExport:
     def test_admin_can_download_csv(self, admin_client):
         """Verify admin can download stalled contacts CSV."""
         client, admin_user = admin_client
-        response = client.get('/api/v1/insights/admin/stalled-contacts/export/')
+        response = client.get("/api/v1/insights/admin/stalled-contacts/export/")
         assert response.status_code == status.HTTP_200_OK
-        assert response['Content-Type'] == 'text/csv'
+        assert response["Content-Type"] == "text/csv"
 
     def test_staff_cannot_access(self, authenticated_client):
         """Verify staff cannot access CSV export endpoint."""
         client, user = authenticated_client
-        response = client.get('/api/v1/insights/admin/stalled-contacts/export/')
+        response = client.get("/api/v1/insights/admin/stalled-contacts/export/")
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
     def test_csv_contains_correct_headers(self, admin_client):
         """Verify CSV has the correct header row."""
         client, admin_user = admin_client
-        response = client.get('/api/v1/insights/admin/stalled-contacts/export/')
+        response = client.get("/api/v1/insights/admin/stalled-contacts/export/")
         assert response.status_code == status.HTTP_200_OK
 
         # Parse CSV content
-        content = b''.join(response.streaming_content).decode('utf-8')
+        content = b"".join(response.streaming_content).decode("utf-8")
         csv_reader = csv.reader(StringIO(content))
         header = next(csv_reader)
 
         assert header == [
-            'Contact Name',
-            'Email',
-            'Owner',
-            'Last Activity Date',
-            'Days Stalled',
-            'Status'
+            "Contact Name",
+            "Email",
+            "Owner",
+            "Last Activity Date",
+            "Days Stalled",
+            "Status",
         ]
 
     def test_csv_contains_data_rows(self, admin_client):
         """Create stalled contacts and verify they appear in CSV."""
         client, admin_user = admin_client
-        staff = UserFactory(role='missionary')
+        staff = UserFactory(role="missionary")
         contact = ContactFactory(owner=staff)
 
         # Create journal and add contact
         journal = Journal.objects.create(
-            name='Test Journal',
+            name="Test Journal",
             owner=staff,
-            goal_amount=Decimal('5000.00'),
+            goal_amount=Decimal("5000.00"),
         )
         jc = JournalContact.objects.create(journal=journal, contact=contact)
 
@@ -78,11 +80,11 @@ class TestStalledContactsCSVExport:
         stage_event.save()
 
         # Download CSV
-        response = client.get('/api/v1/insights/admin/stalled-contacts/export/')
+        response = client.get("/api/v1/insights/admin/stalled-contacts/export/")
         assert response.status_code == status.HTTP_200_OK
 
         # Parse CSV and check for data rows
-        content = b''.join(response.streaming_content).decode('utf-8')
+        content = b"".join(response.streaming_content).decode("utf-8")
         csv_reader = csv.reader(StringIO(content))
         next(csv_reader)  # Skip header
         rows = list(csv_reader)
@@ -94,34 +96,36 @@ class TestStalledContactsCSVExport:
     def test_content_disposition_header(self, admin_client):
         """Verify Content-Disposition header triggers browser download."""
         client, admin_user = admin_client
-        response = client.get('/api/v1/insights/admin/stalled-contacts/export/')
+        response = client.get("/api/v1/insights/admin/stalled-contacts/export/")
         assert response.status_code == status.HTTP_200_OK
-        assert 'Content-Disposition' in response
-        assert 'attachment' in response['Content-Disposition']
-        assert '.csv' in response['Content-Disposition']
+        assert "Content-Disposition" in response
+        assert "attachment" in response["Content-Disposition"]
+        assert ".csv" in response["Content-Disposition"]
 
     def test_date_range_in_filename(self, admin_client):
         """Verify date range is included in filename when provided."""
         client, admin_user = admin_client
-        date_from = '2025-01-01'
-        date_to = '2025-01-31'
-        response = client.get(f'/api/v1/insights/admin/stalled-contacts/export/?date_from={date_from}&date_to={date_to}')
+        date_from = "2025-01-01"
+        date_to = "2025-01-31"
+        response = client.get(
+            f"/api/v1/insights/admin/stalled-contacts/export/?date_from={date_from}&date_to={date_to}"
+        )
         assert response.status_code == status.HTTP_200_OK
-        assert f'{date_from}_to_{date_to}' in response['Content-Disposition']
+        assert f"{date_from}_to_{date_to}" in response["Content-Disposition"]
 
     def test_date_range_filters_csv_data(self, admin_client):
         """Verify date range parameters filter CSV data."""
         client, admin_user = admin_client
-        staff = UserFactory(role='missionary')
+        staff = UserFactory(role="missionary")
 
         # Create two contacts with different activity dates
         contact1 = ContactFactory(owner=staff)
         contact2 = ContactFactory(owner=staff)
 
         journal = Journal.objects.create(
-            name='Test Journal',
+            name="Test Journal",
             owner=staff,
-            goal_amount=Decimal('5000.00'),
+            goal_amount=Decimal("5000.00"),
         )
         jc1 = JournalContact.objects.create(journal=journal, contact=contact1)
         jc2 = JournalContact.objects.create(journal=journal, contact=contact2)
@@ -144,10 +148,12 @@ class TestStalledContactsCSVExport:
 
         # Export with date_from=20 days ago (should only include contact1)
         date_from = (timezone.now() - timedelta(days=20)).date().isoformat()
-        response = client.get(f'/api/v1/insights/admin/stalled-contacts/export/?date_from={date_from}')
+        response = client.get(
+            f"/api/v1/insights/admin/stalled-contacts/export/?date_from={date_from}"
+        )
         assert response.status_code == status.HTTP_200_OK
 
-        content = b''.join(response.streaming_content).decode('utf-8')
+        content = b"".join(response.streaming_content).decode("utf-8")
         csv_reader = csv.reader(StringIO(content))
         next(csv_reader)  # Skip header
         rows = list(csv_reader)
@@ -171,54 +177,48 @@ class TestTeamActivityCSVExport:
     def test_admin_can_download_csv(self, admin_client):
         """Verify admin can download team activity CSV."""
         client, admin_user = admin_client
-        response = client.get('/api/v1/insights/admin/team-activity/export/')
+        response = client.get("/api/v1/insights/admin/team-activity/export/")
         assert response.status_code == status.HTTP_200_OK
-        assert response['Content-Type'] == 'text/csv'
+        assert response["Content-Type"] == "text/csv"
 
     def test_staff_cannot_access(self, authenticated_client):
         """Verify staff cannot access CSV export endpoint."""
         client, user = authenticated_client
-        response = client.get('/api/v1/insights/admin/team-activity/export/')
+        response = client.get("/api/v1/insights/admin/team-activity/export/")
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
     def test_csv_contains_correct_headers(self, admin_client):
         """Verify CSV has the correct header row."""
         client, admin_user = admin_client
-        response = client.get('/api/v1/insights/admin/team-activity/export/')
+        response = client.get("/api/v1/insights/admin/team-activity/export/")
         assert response.status_code == status.HTTP_200_OK
 
         # Parse CSV content
-        content = b''.join(response.streaming_content).decode('utf-8')
+        content = b"".join(response.streaming_content).decode("utf-8")
         csv_reader = csv.reader(StringIO(content))
         header = next(csv_reader)
 
-        assert header == [
-            'Date',
-            'User',
-            'Event Type',
-            'Title',
-            'Contact Name'
-        ]
+        assert header == ["Date", "User", "Event Type", "Title", "Contact Name"]
 
     def test_csv_contains_data_rows(self, admin_client):
         """Create events and verify they appear in CSV."""
         client, admin_user = admin_client
-        staff = UserFactory(role='missionary')
+        staff = UserFactory(role="missionary")
 
         # Create an event
         Event.objects.create(
             user=staff,
-            event_type='journal_created',
-            title='Test Event',
-            severity='info',
+            event_type="journal_created",
+            title="Test Event",
+            severity="info",
         )
 
         # Download CSV
-        response = client.get('/api/v1/insights/admin/team-activity/export/')
+        response = client.get("/api/v1/insights/admin/team-activity/export/")
         assert response.status_code == status.HTTP_200_OK
 
         # Parse CSV and check for data rows
-        content = b''.join(response.streaming_content).decode('utf-8')
+        content = b"".join(response.streaming_content).decode("utf-8")
         csv_reader = csv.reader(StringIO(content))
         next(csv_reader)  # Skip header
         rows = list(csv_reader)
@@ -226,44 +226,44 @@ class TestTeamActivityCSVExport:
         assert len(rows) >= 1
         # Verify event title appears in CSV
         titles = [row[3] for row in rows]
-        assert 'Test Event' in titles
+        assert "Test Event" in titles
 
     def test_content_disposition_header(self, admin_client):
         """Verify Content-Disposition header triggers browser download."""
         client, admin_user = admin_client
-        response = client.get('/api/v1/insights/admin/team-activity/export/')
+        response = client.get("/api/v1/insights/admin/team-activity/export/")
         assert response.status_code == status.HTTP_200_OK
-        assert 'Content-Disposition' in response
-        assert 'attachment' in response['Content-Disposition']
-        assert '.csv' in response['Content-Disposition']
+        assert "Content-Disposition" in response
+        assert "attachment" in response["Content-Disposition"]
+        assert ".csv" in response["Content-Disposition"]
 
     def test_invalid_date_returns_400(self, admin_client):
         """Verify invalid date format returns 400 error."""
         client, admin_user = admin_client
-        response = client.get('/api/v1/insights/admin/team-activity/export/?date_from=bad-date')
+        response = client.get("/api/v1/insights/admin/team-activity/export/?date_from=bad-date")
         assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert 'detail' in response.data
+        assert "detail" in response.data
 
     def test_limit_parameter_works(self, admin_client):
         """Verify limit parameter restricts number of rows."""
         client, admin_user = admin_client
-        staff = UserFactory(role='missionary')
+        staff = UserFactory(role="missionary")
 
         # Create multiple events
         for i in range(10):
             Event.objects.create(
                 user=staff,
-                event_type='journal_created',
-                title=f'Test Event {i}',
-                severity='info',
+                event_type="journal_created",
+                title=f"Test Event {i}",
+                severity="info",
             )
 
         # Download CSV with limit=5
-        response = client.get('/api/v1/insights/admin/team-activity/export/?limit=5')
+        response = client.get("/api/v1/insights/admin/team-activity/export/?limit=5")
         assert response.status_code == status.HTTP_200_OK
 
         # Parse CSV and verify row count
-        content = b''.join(response.streaming_content).decode('utf-8')
+        content = b"".join(response.streaming_content).decode("utf-8")
         csv_reader = csv.reader(StringIO(content))
         next(csv_reader)  # Skip header
         rows = list(csv_reader)

--- a/apps/insights/tests/test_date_filtering.py
+++ b/apps/insights/tests/test_date_filtering.py
@@ -7,7 +7,6 @@ from decimal import Decimal
 from django.utils import timezone
 
 from rest_framework import status
-from rest_framework.test import APIClient
 
 import pytest
 

--- a/apps/insights/tests/test_date_filtering.py
+++ b/apps/insights/tests/test_date_filtering.py
@@ -1,19 +1,21 @@
 """
 Tests for date range filtering on admin analytics endpoints.
 """
-import pytest
 from datetime import date, timedelta
 from decimal import Decimal
 
 from django.utils import timezone
+
 from rest_framework import status
 from rest_framework.test import APIClient
 
-from apps.users.tests.factories import UserFactory
+import pytest
+
 from apps.contacts.tests.factories import ContactFactory
-from apps.gifts.tests.factories import GiftFactory
-from apps.journals.models import Journal, JournalContact, Decision, JournalStageEvent, PipelineStage
 from apps.events.models import Event
+from apps.gifts.tests.factories import GiftFactory
+from apps.journals.models import Decision, Journal, JournalContact, JournalStageEvent, PipelineStage
+from apps.users.tests.factories import UserFactory
 
 
 @pytest.mark.django_db
@@ -23,7 +25,7 @@ class TestDashboardOverviewDateFiltering:
     def test_date_from_filters_contacts(self, admin_client):
         """Create contacts on different dates, verify date_from filters correctly."""
         client, admin_user = admin_client
-        staff = UserFactory(role='missionary')
+        staff = UserFactory(role="missionary")
 
         # Create old contact (10 days ago)
         old_date = timezone.now() - timedelta(days=10)
@@ -39,14 +41,14 @@ class TestDashboardOverviewDateFiltering:
 
         # Query with date_from=5 days ago (should only count new contact)
         date_from = (timezone.now() - timedelta(days=5)).date().isoformat()
-        response = client.get(f'/api/v1/insights/admin/dashboard-overview/?date_from={date_from}')
+        response = client.get(f"/api/v1/insights/admin/dashboard-overview/?date_from={date_from}")
         assert response.status_code == status.HTTP_200_OK
-        assert response.data['total_contacts'] == 1
+        assert response.data["total_contacts"] == 1
 
     def test_date_to_filters_contacts(self, admin_client):
         """Create contacts on different dates, verify date_to filters correctly."""
         client, admin_user = admin_client
-        staff = UserFactory(role='missionary')
+        staff = UserFactory(role="missionary")
 
         # Create old contact (10 days ago)
         old_date = timezone.now() - timedelta(days=10)
@@ -62,14 +64,14 @@ class TestDashboardOverviewDateFiltering:
 
         # Query with date_to=5 days ago (should only count old contact)
         date_to = (timezone.now() - timedelta(days=5)).date().isoformat()
-        response = client.get(f'/api/v1/insights/admin/dashboard-overview/?date_to={date_to}')
+        response = client.get(f"/api/v1/insights/admin/dashboard-overview/?date_to={date_to}")
         assert response.status_code == status.HTTP_200_OK
-        assert response.data['total_contacts'] == 1
+        assert response.data["total_contacts"] == 1
 
     def test_date_range_filters_donations(self, admin_client):
         """Create gifts on different dates, verify date range filters correctly."""
         client, admin_user = admin_client
-        staff = UserFactory(role='missionary')
+        staff = UserFactory(role="missionary")
         contact = ContactFactory(owner=staff)
 
         # Create old gift (20 days ago)
@@ -82,34 +84,34 @@ class TestDashboardOverviewDateFiltering:
 
         # Query with date_from=10 days ago (should only count new gift)
         date_from = (date.today() - timedelta(days=10)).isoformat()
-        response = client.get(f'/api/v1/insights/admin/dashboard-overview/?date_from={date_from}')
+        response = client.get(f"/api/v1/insights/admin/dashboard-overview/?date_from={date_from}")
         assert response.status_code == status.HTTP_200_OK
-        assert response.data['donations_12m']['total_count'] == 1
-        assert response.data['donations_12m']['total_amount'] == 200.0
+        assert response.data["donations_12m"]["total_count"] == 1
+        assert response.data["donations_12m"]["total_amount"] == 200.0
 
     def test_invalid_date_format_returns_400(self, admin_client):
         """Send invalid date format, verify 400 error."""
         client, admin_user = admin_client
-        response = client.get('/api/v1/insights/admin/dashboard-overview/?date_from=invalid-date')
+        response = client.get("/api/v1/insights/admin/dashboard-overview/?date_from=invalid-date")
         assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert 'detail' in response.data
-        assert 'date_from' in response.data['detail']
+        assert "detail" in response.data
+        assert "date_from" in response.data["detail"]
 
     def test_date_from_without_date_to_works(self, admin_client):
         """Send only date_from, verify it works (open-ended range)."""
         client, admin_user = admin_client
         date_from = (timezone.now() - timedelta(days=30)).date().isoformat()
-        response = client.get(f'/api/v1/insights/admin/dashboard-overview/?date_from={date_from}')
+        response = client.get(f"/api/v1/insights/admin/dashboard-overview/?date_from={date_from}")
         assert response.status_code == status.HTTP_200_OK
-        assert 'total_contacts' in response.data
+        assert "total_contacts" in response.data
 
     def test_date_to_without_date_from_works(self, admin_client):
         """Send only date_to, verify it works."""
         client, admin_user = admin_client
         date_to = timezone.now().date().isoformat()
-        response = client.get(f'/api/v1/insights/admin/dashboard-overview/?date_to={date_to}')
+        response = client.get(f"/api/v1/insights/admin/dashboard-overview/?date_to={date_to}")
         assert response.status_code == status.HTTP_200_OK
-        assert 'total_contacts' in response.data
+        assert "total_contacts" in response.data
 
 
 @pytest.mark.django_db
@@ -119,14 +121,14 @@ class TestStalledContactsDateFiltering:
     def test_date_to_affects_stalled_calculation(self, admin_client):
         """Verify that date_to is used as 'now' for stalled calculation."""
         client, admin_user = admin_client
-        staff = UserFactory(role='missionary')
+        staff = UserFactory(role="missionary")
         contact = ContactFactory(owner=staff)
 
         # Create journal and add contact
         journal = Journal.objects.create(
-            name='Test Journal',
+            name="Test Journal",
             owner=staff,
-            goal_amount=Decimal('5000.00'),
+            goal_amount=Decimal("5000.00"),
         )
         jc = JournalContact.objects.create(journal=journal, contact=contact)
 
@@ -141,17 +143,17 @@ class TestStalledContactsDateFiltering:
 
         # Query with date_to=5 days ago (10 days - 5 days = 5 days old, not stalled yet)
         date_to = (timezone.now() - timedelta(days=5)).date().isoformat()
-        response = client.get(f'/api/v1/insights/admin/stalled-contacts/?date_to={date_to}')
+        response = client.get(f"/api/v1/insights/admin/stalled-contacts/?date_to={date_to}")
         assert response.status_code == status.HTTP_200_OK
         # With cutoff at 14 days and event 5 days old relative to date_to, shouldn't be stalled
-        assert response.data['total_count'] == 0
+        assert response.data["total_count"] == 0
 
     def test_invalid_date_returns_400(self, admin_client):
         """Send invalid date format, verify 400 error."""
         client, admin_user = admin_client
-        response = client.get('/api/v1/insights/admin/stalled-contacts/?date_from=bad-date')
+        response = client.get("/api/v1/insights/admin/stalled-contacts/?date_from=bad-date")
         assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert 'detail' in response.data
+        assert "detail" in response.data
 
 
 @pytest.mark.django_db
@@ -161,13 +163,13 @@ class TestDashboardOverviewConversionRateDateFiltering:
     def test_date_range_filters_conversion_rate(self, admin_client):
         """Create decisions in two date ranges, verify conversion rate changes with date filter."""
         client, admin_user = admin_client
-        staff = UserFactory(role='missionary')
+        staff = UserFactory(role="missionary")
 
         # Create journal with 2 contacts
         journal = Journal.objects.create(
-            name='Test Journal',
+            name="Test Journal",
             owner=staff,
-            goal_amount=Decimal('10000.00'),
+            goal_amount=Decimal("10000.00"),
         )
         contact1 = ContactFactory(owner=staff)
         contact2 = ContactFactory(owner=staff)
@@ -178,9 +180,9 @@ class TestDashboardOverviewConversionRateDateFiltering:
         old_date = timezone.now() - timedelta(days=30)
         d1 = Decision.objects.create(
             journal_contact=jc1,
-            amount=Decimal('100.00'),
-            cadence='monthly',
-            status='active',
+            amount=Decimal("100.00"),
+            cadence="monthly",
+            status="active",
         )
         d1.created_at = old_date
         d1.save()
@@ -191,9 +193,9 @@ class TestDashboardOverviewConversionRateDateFiltering:
         new_date = timezone.now() - timedelta(days=5)
         d2 = Decision.objects.create(
             journal_contact=jc2,
-            amount=Decimal('50.00'),
-            cadence='monthly',
-            status='active',
+            amount=Decimal("50.00"),
+            cadence="monthly",
+            status="active",
         )
         d2.created_at = new_date
         d2.save()
@@ -201,24 +203,24 @@ class TestDashboardOverviewConversionRateDateFiltering:
         jc2.save()
 
         # Without date filter: 2 contacts with decisions / 2 contacts in journals = 100%
-        response = client.get('/api/v1/insights/admin/dashboard-overview/')
+        response = client.get("/api/v1/insights/admin/dashboard-overview/")
         assert response.status_code == status.HTTP_200_OK
-        assert response.data['conversion_rate'] == 100.0
+        assert response.data["conversion_rate"] == 100.0
 
         # With date_from=10 days ago: only jc2/d2 in range → 1/1 = 100%
         date_from = (timezone.now() - timedelta(days=10)).date().isoformat()
-        response = client.get(f'/api/v1/insights/admin/dashboard-overview/?date_from={date_from}')
+        response = client.get(f"/api/v1/insights/admin/dashboard-overview/?date_from={date_from}")
         assert response.status_code == status.HTTP_200_OK
-        assert response.data['conversion_rate'] == 100.0
+        assert response.data["conversion_rate"] == 100.0
 
         # With date range covering only the old period: only jc1/d1 → 1/1 = 100%
         old_from = (timezone.now() - timedelta(days=35)).date().isoformat()
         old_to = (timezone.now() - timedelta(days=15)).date().isoformat()
         response = client.get(
-            f'/api/v1/insights/admin/dashboard-overview/?date_from={old_from}&date_to={old_to}'
+            f"/api/v1/insights/admin/dashboard-overview/?date_from={old_from}&date_to={old_to}"
         )
         assert response.status_code == status.HTTP_200_OK
-        assert response.data['conversion_rate'] == 100.0
+        assert response.data["conversion_rate"] == 100.0
 
 
 @pytest.mark.django_db
@@ -228,15 +230,15 @@ class TestTeamActivityDateFiltering:
     def test_date_range_filters_events(self, admin_client):
         """Create events on different dates, verify date range filters correctly."""
         client, admin_user = admin_client
-        staff = UserFactory(role='missionary')
+        staff = UserFactory(role="missionary")
 
         # Create old event (20 days ago)
         old_date = timezone.now() - timedelta(days=20)
         old_event = Event.objects.create(
             user=staff,
-            event_type='journal_created',
-            title='Old Event',
-            severity='info',
+            event_type="journal_created",
+            title="Old Event",
+            severity="info",
         )
         old_event.created_at = old_date
         old_event.save()
@@ -245,18 +247,16 @@ class TestTeamActivityDateFiltering:
         new_date = timezone.now() - timedelta(days=5)
         new_event = Event.objects.create(
             user=staff,
-            event_type='journal_created',
-            title='New Event',
-            severity='info',
+            event_type="journal_created",
+            title="New Event",
+            severity="info",
         )
         new_event.created_at = new_date
         new_event.save()
 
         # Query with date_from=10 days ago (should only show new event)
         date_from = (timezone.now() - timedelta(days=10)).date().isoformat()
-        response = client.get(f'/api/v1/insights/admin/team-activity/?date_from={date_from}')
+        response = client.get(f"/api/v1/insights/admin/team-activity/?date_from={date_from}")
         assert response.status_code == status.HTTP_200_OK
-        assert len(response.data['activities']) == 1
-        assert response.data['activities'][0]['title'] == 'New Event'
-
-
+        assert len(response.data["activities"]) == 1
+        assert response.data["activities"][0]["title"] == "New Event"

--- a/apps/insights/tests/test_late_donations.py
+++ b/apps/insights/tests/test_late_donations.py
@@ -19,7 +19,7 @@ def test_late_donations_returns_overdue_pledge():
     """A monthly pledge with no gifts in 60+ days must show up."""
     from rest_framework.test import APIClient
 
-    user = UserFactory(role='missionary')
+    user = UserFactory(role="missionary")
     contact = ContactFactory(
         owner=user,
         last_gift_date=date.today() - timedelta(days=60),
@@ -27,23 +27,23 @@ def test_late_donations_returns_overdue_pledge():
     RecurringGiftFactory(
         donor_contact=contact,
         amount_cents=10000,
-        frequency='monthly',
+        frequency="monthly",
         start_date=date.today() - timedelta(days=120),
     )
 
     client = APIClient()
     client.force_authenticate(user=user)
-    response = client.get('/api/v1/insights/late-donations/')
+    response = client.get("/api/v1/insights/late-donations/")
 
     assert response.status_code == 200
     body = response.json()
-    assert body['total_count'] == 1
-    assert len(body['late_donations']) == 1
-    item = body['late_donations'][0]
-    assert item['contact_id'] == str(contact.id)
-    assert item['days_late'] > 0
-    assert isinstance(item['amount'], (int, float))
-    assert isinstance(item['monthly_equivalent'], (int, float))
+    assert body["total_count"] == 1
+    assert len(body["late_donations"]) == 1
+    item = body["late_donations"][0]
+    assert item["contact_id"] == str(contact.id)
+    assert item["days_late"] > 0
+    assert isinstance(item["amount"], (int, float))
+    assert isinstance(item["monthly_equivalent"], (int, float))
 
 
 @pytest.mark.django_db
@@ -51,7 +51,7 @@ def test_late_donations_empty_when_on_track():
     """No late pledges => empty list."""
     from rest_framework.test import APIClient
 
-    user = UserFactory(role='missionary')
+    user = UserFactory(role="missionary")
     contact = ContactFactory(
         owner=user,
         last_gift_date=date.today() - timedelta(days=10),
@@ -59,18 +59,18 @@ def test_late_donations_empty_when_on_track():
     RecurringGiftFactory(
         donor_contact=contact,
         amount_cents=10000,
-        frequency='monthly',
+        frequency="monthly",
         start_date=date.today() - timedelta(days=120),
     )
 
     client = APIClient()
     client.force_authenticate(user=user)
-    response = client.get('/api/v1/insights/late-donations/')
+    response = client.get("/api/v1/insights/late-donations/")
 
     assert response.status_code == 200
     body = response.json()
-    assert body['total_count'] == 0
-    assert body['late_donations'] == []
+    assert body["total_count"] == 0
+    assert body["late_donations"] == []
 
 
 @pytest.mark.django_db
@@ -83,7 +83,7 @@ def test_count_late_donations_matches_full_list():
         count_late_donations,
     )
 
-    user = UserFactory(role='missionary')
+    user = UserFactory(role="missionary")
     # 3 late pledges
     for _ in range(3):
         contact = ContactFactory(
@@ -93,7 +93,7 @@ def test_count_late_donations_matches_full_list():
         RecurringGiftFactory(
             donor_contact=contact,
             amount_cents=10000,
-            frequency='monthly',
+            frequency="monthly",
             start_date=date.today() - timedelta(days=120),
         )
     # 1 on-track pledge — must NOT be counted
@@ -104,7 +104,7 @@ def test_count_late_donations_matches_full_list():
     RecurringGiftFactory(
         donor_contact=on_track,
         amount_cents=10000,
-        frequency='monthly',
+        frequency="monthly",
         start_date=date.today() - timedelta(days=120),
     )
 
@@ -118,8 +118,8 @@ def test_late_donations_no_cross_user_leakage():
     """Missionary A must not see missionary B's late pledges."""
     from rest_framework.test import APIClient
 
-    user_a = UserFactory(role='missionary')
-    user_b = UserFactory(role='missionary')
+    user_a = UserFactory(role="missionary")
+    user_b = UserFactory(role="missionary")
 
     contact_b = ContactFactory(
         owner=user_b,
@@ -128,13 +128,13 @@ def test_late_donations_no_cross_user_leakage():
     RecurringGiftFactory(
         donor_contact=contact_b,
         amount_cents=10000,
-        frequency='monthly',
+        frequency="monthly",
         start_date=date.today() - timedelta(days=120),
     )
 
     client = APIClient()
     client.force_authenticate(user=user_a)
-    response = client.get('/api/v1/insights/late-donations/')
+    response = client.get("/api/v1/insights/late-donations/")
 
     assert response.status_code == 200
-    assert response.json()['total_count'] == 0
+    assert response.json()["total_count"] == 0

--- a/apps/insights/tests/test_monthly_commitments.py
+++ b/apps/insights/tests/test_monthly_commitments.py
@@ -15,54 +15,73 @@ from apps.users.tests.factories import UserFactory
 @pytest.mark.django_db
 def test_last_fulfilled_date_uses_latest_gift_for_pledge():
     """last_fulfilled_date is MAX(gift_date) for gifts linked to the pledge."""
-    user = UserFactory(role='missionary')
+    user = UserFactory(role="missionary")
     contact = ContactFactory(owner=user)
     pledge = RecurringGiftFactory(
-        donor_contact=contact, amount_cents=10000, frequency='monthly',
+        donor_contact=contact,
+        amount_cents=10000,
+        frequency="monthly",
     )
-    GiftFactory(donor_contact=contact, amount_cents=10000,
-                gift_date=date(2026, 1, 15), recurring_gift=pledge)
-    GiftFactory(donor_contact=contact, amount_cents=10000,
-                gift_date=date(2026, 3, 15), recurring_gift=pledge)
+    GiftFactory(
+        donor_contact=contact,
+        amount_cents=10000,
+        gift_date=date(2026, 1, 15),
+        recurring_gift=pledge,
+    )
+    GiftFactory(
+        donor_contact=contact,
+        amount_cents=10000,
+        gift_date=date(2026, 3, 15),
+        recurring_gift=pledge,
+    )
 
     result = get_monthly_commitments(user)
 
-    assert len(result['pledges']) == 1
-    assert result['pledges'][0]['last_fulfilled_date'] == '2026-03-15'
+    assert len(result["pledges"]) == 1
+    assert result["pledges"][0]["last_fulfilled_date"] == "2026-03-15"
 
 
 @pytest.mark.django_db
 def test_last_fulfilled_date_null_when_never_paid():
     """A pledge with no linked gifts surfaces last_fulfilled_date = None."""
-    user = UserFactory(role='missionary')
+    user = UserFactory(role="missionary")
     contact = ContactFactory(owner=user)
     RecurringGiftFactory(
-        donor_contact=contact, amount_cents=10000, frequency='monthly',
+        donor_contact=contact,
+        amount_cents=10000,
+        frequency="monthly",
         start_date=date.today() - timedelta(days=10),
     )
 
     result = get_monthly_commitments(user)
 
-    assert len(result['pledges']) == 1
-    assert result['pledges'][0]['last_fulfilled_date'] is None
+    assert len(result["pledges"]) == 1
+    assert result["pledges"][0]["last_fulfilled_date"] is None
 
 
 @pytest.mark.django_db
 def test_last_fulfilled_date_ignores_unrelated_gifts():
     """A standalone gift on the same contact (not linked to the pledge) does
     NOT count as a fulfillment."""
-    user = UserFactory(role='missionary')
+    user = UserFactory(role="missionary")
     contact = ContactFactory(owner=user)
     pledge = RecurringGiftFactory(
-        donor_contact=contact, amount_cents=10000, frequency='monthly',
+        donor_contact=contact,
+        amount_cents=10000,
+        frequency="monthly",
     )
     # Linked gift
-    GiftFactory(donor_contact=contact, amount_cents=10000,
-                gift_date=date(2026, 1, 15), recurring_gift=pledge)
+    GiftFactory(
+        donor_contact=contact,
+        amount_cents=10000,
+        gift_date=date(2026, 1, 15),
+        recurring_gift=pledge,
+    )
     # Unlinked one-time gift on same contact, more recent — must NOT win
-    GiftFactory(donor_contact=contact, amount_cents=50000,
-                gift_date=date(2026, 4, 1), recurring_gift=None)
+    GiftFactory(
+        donor_contact=contact, amount_cents=50000, gift_date=date(2026, 4, 1), recurring_gift=None
+    )
 
     result = get_monthly_commitments(user)
 
-    assert result['pledges'][0]['last_fulfilled_date'] == '2026-01-15'
+    assert result["pledges"][0]["last_fulfilled_date"] == "2026-01-15"

--- a/apps/insights/tests/test_org_settings.py
+++ b/apps/insights/tests/test_org_settings.py
@@ -2,8 +2,9 @@
 Tests for the org-wide annual goal setting and its effect on the
 Fiscal Year Pace tile.
 """
-import pytest
 from rest_framework.test import APIClient
+
+import pytest
 
 from apps.contacts.tests.factories import ContactFactory
 from apps.core.models import OrgSettings
@@ -61,11 +62,14 @@ def test_org_settings_admin_only():
     client.force_authenticate(user=user)
 
     assert client.get("/api/v1/insights/admin/org-settings/").status_code == 403
-    assert client.patch(
-        "/api/v1/insights/admin/org-settings/",
-        {"annual_goal_cents": 1},
-        format="json",
-    ).status_code == 403
+    assert (
+        client.patch(
+            "/api/v1/insights/admin/org-settings/",
+            {"annual_goal_cents": 1},
+            format="json",
+        ).status_code
+        == 403
+    )
 
 
 @pytest.mark.django_db

--- a/apps/insights/tests/test_stage_contacts.py
+++ b/apps/insights/tests/test_stage_contacts.py
@@ -3,6 +3,7 @@ Tests for stage contacts endpoint.
 """
 from django.test import TestCase
 from django.urls import reverse
+
 from rest_framework.test import APIClient
 
 from apps.contacts.models import Contact
@@ -19,166 +20,150 @@ class TestStageContacts(TestCase):
 
         # Create admin user
         self.admin = User.objects.create_user(
-            email='admin@test.com',
-            password='testpass123',
-            first_name='Admin',
-            last_name='User',
-            role='admin'
+            email="admin@test.com",
+            password="testpass123",
+            first_name="Admin",
+            last_name="User",
+            role="admin",
         )
 
         # Create non-admin user
         self.staff = User.objects.create_user(
-            email='staff@test.com',
-            password='testpass123',
-            first_name='Staff',
-            last_name='User',
-            role='missionary'
+            email="staff@test.com",
+            password="testpass123",
+            first_name="Staff",
+            last_name="User",
+            role="missionary",
         )
 
         # Create contacts
         self.contact1 = Contact.objects.create(
-            first_name='Alice',
-            last_name='Contact',
-            email='alice@test.com',
+            first_name="Alice",
+            last_name="Contact",
+            email="alice@test.com",
             owner=self.staff,
-            status='active'
+            status="active",
         )
 
         self.contact2 = Contact.objects.create(
-            first_name='Bob',
-            last_name='Contact',
-            email='bob@test.com',
+            first_name="Bob",
+            last_name="Contact",
+            email="bob@test.com",
             owner=self.staff,
-            status='active'
+            status="active",
         )
 
         self.contact3 = Contact.objects.create(
-            first_name='Charlie',
-            last_name='Contact',
-            email='charlie@test.com',
+            first_name="Charlie",
+            last_name="Contact",
+            email="charlie@test.com",
             owner=self.staff,
-            status='active'
+            status="active",
         )
 
         # Create journal
         self.journal = Journal.objects.create(
-            name='Test Journal',
-            owner=self.staff,
-            goal_amount=10000.00
+            name="Test Journal", owner=self.staff, goal_amount=10000.00
         )
 
         # Add contacts to journal
-        self.jc1 = JournalContact.objects.create(
-            journal=self.journal,
-            contact=self.contact1
-        )
+        self.jc1 = JournalContact.objects.create(journal=self.journal, contact=self.contact1)
 
-        self.jc2 = JournalContact.objects.create(
-            journal=self.journal,
-            contact=self.contact2
-        )
+        self.jc2 = JournalContact.objects.create(journal=self.journal, contact=self.contact2)
 
-        self.jc3 = JournalContact.objects.create(
-            journal=self.journal,
-            contact=self.contact3
-        )
+        self.jc3 = JournalContact.objects.create(journal=self.journal, contact=self.contact3)
 
         # Create stage events - contact1 in "contact" stage
         JournalStageEvent.objects.create(
-            journal_contact=self.jc1,
-            stage=PipelineStage.CONTACT.value
+            journal_contact=self.jc1, stage=PipelineStage.CONTACT.value
         )
 
         # Contact2 in "meet" stage
         JournalStageEvent.objects.create(
-            journal_contact=self.jc2,
-            stage=PipelineStage.CONTACT.value
+            journal_contact=self.jc2, stage=PipelineStage.CONTACT.value
         )
-        JournalStageEvent.objects.create(
-            journal_contact=self.jc2,
-            stage=PipelineStage.MEET.value
-        )
+        JournalStageEvent.objects.create(journal_contact=self.jc2, stage=PipelineStage.MEET.value)
 
         # Contact3 has no stage events (No Activity)
 
     def test_admin_can_access_endpoint(self):
         """Test that admin can access the stage contacts endpoint."""
         self.client.force_authenticate(user=self.admin)
-        url = reverse('insights:admin-stage-contacts')
-        response = self.client.get(url, {'stage': 'contact'})
+        url = reverse("insights:admin-stage-contacts")
+        response = self.client.get(url, {"stage": "contact"})
         self.assertEqual(response.status_code, 200)
-        self.assertIn('contacts', response.data)
-        self.assertIn('total_count', response.data)
-        self.assertIn('stage', response.data)
+        self.assertIn("contacts", response.data)
+        self.assertIn("total_count", response.data)
+        self.assertIn("stage", response.data)
 
     def test_non_admin_gets_403(self):
         """Test that non-admin user gets 403 Forbidden."""
         self.client.force_authenticate(user=self.staff)
-        url = reverse('insights:admin-stage-contacts')
-        response = self.client.get(url, {'stage': 'contact'})
+        url = reverse("insights:admin-stage-contacts")
+        response = self.client.get(url, {"stage": "contact"})
         self.assertEqual(response.status_code, 403)
 
     def test_stage_parameter_is_required(self):
         """Test that stage parameter is required."""
         self.client.force_authenticate(user=self.admin)
-        url = reverse('insights:admin-stage-contacts')
+        url = reverse("insights:admin-stage-contacts")
         response = self.client.get(url)
         self.assertEqual(response.status_code, 400)
-        self.assertIn('detail', response.data)
-        self.assertIn('stage', response.data['detail'])
+        self.assertIn("detail", response.data)
+        self.assertIn("stage", response.data["detail"])
 
     def test_returns_contacts_in_correct_stage(self):
         """Test that endpoint returns contacts in the correct stage."""
         self.client.force_authenticate(user=self.admin)
-        url = reverse('insights:admin-stage-contacts')
+        url = reverse("insights:admin-stage-contacts")
 
         # Test "contact" stage - should return contact1
-        response = self.client.get(url, {'stage': 'contact'})
+        response = self.client.get(url, {"stage": "contact"})
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.data['total_count'], 1)
-        self.assertEqual(len(response.data['contacts']), 1)
-        self.assertEqual(response.data['contacts'][0]['full_name'], 'Alice Contact')
+        self.assertEqual(response.data["total_count"], 1)
+        self.assertEqual(len(response.data["contacts"]), 1)
+        self.assertEqual(response.data["contacts"][0]["full_name"], "Alice Contact")
 
         # Test "meet" stage - should return contact2
-        response = self.client.get(url, {'stage': 'meet'})
+        response = self.client.get(url, {"stage": "meet"})
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.data['total_count'], 1)
-        self.assertEqual(len(response.data['contacts']), 1)
-        self.assertEqual(response.data['contacts'][0]['full_name'], 'Bob Contact')
+        self.assertEqual(response.data["total_count"], 1)
+        self.assertEqual(len(response.data["contacts"]), 1)
+        self.assertEqual(response.data["contacts"][0]["full_name"], "Bob Contact")
 
     def test_returns_empty_list_for_stage_with_no_contacts(self):
         """Test that endpoint returns empty list for stage with no contacts."""
         self.client.force_authenticate(user=self.admin)
-        url = reverse('insights:admin-stage-contacts')
-        response = self.client.get(url, {'stage': 'close'})
+        url = reverse("insights:admin-stage-contacts")
+        response = self.client.get(url, {"stage": "close"})
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.data['total_count'], 0)
-        self.assertEqual(len(response.data['contacts']), 0)
+        self.assertEqual(response.data["total_count"], 0)
+        self.assertEqual(len(response.data["contacts"]), 0)
 
     def test_none_stage_parameter_returns_contacts_with_no_stage_events(self):
         """Test that "none" stage parameter returns contacts with no stage events."""
         self.client.force_authenticate(user=self.admin)
-        url = reverse('insights:admin-stage-contacts')
-        response = self.client.get(url, {'stage': 'none'})
+        url = reverse("insights:admin-stage-contacts")
+        response = self.client.get(url, {"stage": "none"})
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.data['total_count'], 1)
-        self.assertEqual(len(response.data['contacts']), 1)
-        self.assertEqual(response.data['contacts'][0]['full_name'], 'Charlie Contact')
+        self.assertEqual(response.data["total_count"], 1)
+        self.assertEqual(len(response.data["contacts"]), 1)
+        self.assertEqual(response.data["contacts"][0]["full_name"], "Charlie Contact")
 
     def test_contact_data_structure(self):
         """Test that contact data includes required fields."""
         self.client.force_authenticate(user=self.admin)
-        url = reverse('insights:admin-stage-contacts')
-        response = self.client.get(url, {'stage': 'contact'})
+        url = reverse("insights:admin-stage-contacts")
+        response = self.client.get(url, {"stage": "contact"})
         self.assertEqual(response.status_code, 200)
 
-        contact = response.data['contacts'][0]
-        self.assertIn('id', contact)
-        self.assertIn('full_name', contact)
-        self.assertIn('email', contact)
-        self.assertIn('owner_name', contact)
-        self.assertIn('last_activity_date', contact)
-        self.assertEqual(contact['owner_name'], 'Staff User')
+        contact = response.data["contacts"][0]
+        self.assertIn("id", contact)
+        self.assertIn("full_name", contact)
+        self.assertIn("email", contact)
+        self.assertIn("owner_name", contact)
+        self.assertIn("last_activity_date", contact)
+        self.assertEqual(contact["owner_name"], "Staff User")
 
     def test_limit_parameter(self):
         """Test that limit parameter restricts results."""
@@ -187,23 +172,17 @@ class TestStageContacts(TestCase):
         # Create more contacts in "contact" stage
         for i in range(5):
             contact = Contact.objects.create(
-                first_name=f'Test{i}',
-                last_name='Contact',
-                email=f'test{i}@test.com',
+                first_name=f"Test{i}",
+                last_name="Contact",
+                email=f"test{i}@test.com",
                 owner=self.staff,
-                status='active'
+                status="active",
             )
-            jc = JournalContact.objects.create(
-                journal=self.journal,
-                contact=contact
-            )
-            JournalStageEvent.objects.create(
-                journal_contact=jc,
-                stage=PipelineStage.CONTACT.value
-            )
+            jc = JournalContact.objects.create(journal=self.journal, contact=contact)
+            JournalStageEvent.objects.create(journal_contact=jc, stage=PipelineStage.CONTACT.value)
 
-        url = reverse('insights:admin-stage-contacts')
-        response = self.client.get(url, {'stage': 'contact', 'limit': 3})
+        url = reverse("insights:admin-stage-contacts")
+        response = self.client.get(url, {"stage": "contact", "limit": 3})
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.data['total_count'], 6)  # 1 original + 5 new
-        self.assertEqual(len(response.data['contacts']), 3)  # Limited to 3
+        self.assertEqual(response.data["total_count"], 6)  # 1 original + 5 new
+        self.assertEqual(len(response.data["contacts"]), 3)  # Limited to 3

--- a/apps/insights/tests/test_team_trends.py
+++ b/apps/insights/tests/test_team_trends.py
@@ -1,18 +1,20 @@
 """
 Tests for team trends endpoint.
 """
-import pytest
 from datetime import timedelta
 from decimal import Decimal
 
 from django.utils import timezone
+
 from rest_framework import status
 from rest_framework.test import APIClient
 
-from apps.users.tests.factories import UserFactory
+import pytest
+
 from apps.contacts.tests.factories import ContactFactory
 from apps.gifts.tests.factories import GiftFactory
-from apps.journals.models import Journal, JournalContact, Decision, JournalStageEvent, PipelineStage
+from apps.journals.models import Decision, Journal, JournalContact, JournalStageEvent, PipelineStage
+from apps.users.tests.factories import UserFactory
 
 
 @pytest.mark.django_db
@@ -22,93 +24,93 @@ class TestTeamTrendsView:
     def test_admin_can_access(self, admin_client):
         """Admin user gets 200 response."""
         client, user = admin_client
-        response = client.get('/api/v1/insights/admin/team-trends/')
+        response = client.get("/api/v1/insights/admin/team-trends/")
         assert response.status_code == status.HTTP_200_OK
-        assert 'trends' in response.data
-        assert 'weeks' in response.data
+        assert "trends" in response.data
+        assert "weeks" in response.data
 
     def test_staff_cannot_access(self, authenticated_client):
         """Non-admin user gets 403 response."""
         client, user = authenticated_client
-        response = client.get('/api/v1/insights/admin/team-trends/')
+        response = client.get("/api/v1/insights/admin/team-trends/")
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
     def test_unauthenticated_cannot_access(self):
         """Unauthenticated request gets 401 response."""
         client = APIClient()
-        response = client.get('/api/v1/insights/admin/team-trends/')
+        response = client.get("/api/v1/insights/admin/team-trends/")
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
     def test_returns_12_data_points_by_default(self, admin_client):
         """Default response contains 12 weekly data points."""
         client, user = admin_client
-        response = client.get('/api/v1/insights/admin/team-trends/')
+        response = client.get("/api/v1/insights/admin/team-trends/")
         assert response.status_code == status.HTTP_200_OK
-        assert response.data['weeks'] == 12
-        assert len(response.data['trends']) == 12
+        assert response.data["weeks"] == 12
+        assert len(response.data["trends"]) == 12
 
     def test_data_structure(self, admin_client):
         """Each trend data point has required fields."""
         client, user = admin_client
-        response = client.get('/api/v1/insights/admin/team-trends/')
+        response = client.get("/api/v1/insights/admin/team-trends/")
         assert response.status_code == status.HTTP_200_OK
 
         # Check first data point has all fields
-        first_point = response.data['trends'][0]
-        assert 'week_start' in first_point
-        assert 'week_label' in first_point
-        assert 'decisions_logged' in first_point
-        assert 'donations_received' in first_point
-        assert 'stage_progressions' in first_point
+        first_point = response.data["trends"][0]
+        assert "week_start" in first_point
+        assert "week_label" in first_point
+        assert "decisions_logged" in first_point
+        assert "donations_received" in first_point
+        assert "stage_progressions" in first_point
 
         # Verify types
-        assert isinstance(first_point['week_start'], str)
-        assert isinstance(first_point['week_label'], str)
-        assert isinstance(first_point['decisions_logged'], int)
-        assert isinstance(first_point['donations_received'], int)
-        assert isinstance(first_point['stage_progressions'], int)
+        assert isinstance(first_point["week_start"], str)
+        assert isinstance(first_point["week_label"], str)
+        assert isinstance(first_point["decisions_logged"], int)
+        assert isinstance(first_point["donations_received"], int)
+        assert isinstance(first_point["stage_progressions"], int)
 
     def test_custom_weeks_param(self, admin_client):
         """weeks parameter controls number of data points returned."""
         client, user = admin_client
 
         # Test 4 weeks
-        response = client.get('/api/v1/insights/admin/team-trends/?weeks=4')
+        response = client.get("/api/v1/insights/admin/team-trends/?weeks=4")
         assert response.status_code == status.HTTP_200_OK
-        assert response.data['weeks'] == 4
-        assert len(response.data['trends']) == 4
+        assert response.data["weeks"] == 4
+        assert len(response.data["trends"]) == 4
 
         # Test 26 weeks
-        response = client.get('/api/v1/insights/admin/team-trends/?weeks=26')
+        response = client.get("/api/v1/insights/admin/team-trends/?weeks=26")
         assert response.status_code == status.HTTP_200_OK
-        assert response.data['weeks'] == 26
-        assert len(response.data['trends']) == 26
+        assert response.data["weeks"] == 26
+        assert len(response.data["trends"]) == 26
 
     def test_empty_database_returns_zero_filled_weeks(self, admin_client):
         """Empty database returns 12 weeks with all counts at 0."""
         client, user = admin_client
-        response = client.get('/api/v1/insights/admin/team-trends/')
+        response = client.get("/api/v1/insights/admin/team-trends/")
         assert response.status_code == status.HTTP_200_OK
-        assert len(response.data['trends']) == 12
+        assert len(response.data["trends"]) == 12
 
         # All counts should be 0
-        for point in response.data['trends']:
-            assert point['decisions_logged'] == 0
-            assert point['donations_received'] == 0
-            assert point['stage_progressions'] == 0
+        for point in response.data["trends"]:
+            assert point["decisions_logged"] == 0
+            assert point["donations_received"] == 0
+            assert point["stage_progressions"] == 0
 
     def test_counts_decisions_by_week(self, admin_client):
         """Decisions are counted in the correct week."""
         client, admin_user = admin_client
-        staff = UserFactory(role='missionary')
+        staff = UserFactory(role="missionary")
         contact = ContactFactory(owner=staff)
         contact2 = ContactFactory(owner=staff)
 
         # Create journal and journal_contacts
         journal = Journal.objects.create(
-            name='Test Journal',
+            name="Test Journal",
             owner=staff,
-            goal_amount=Decimal('5000.00'),
+            goal_amount=Decimal("5000.00"),
         )
         journal_contact1 = JournalContact.objects.create(
             journal=journal,
@@ -123,33 +125,35 @@ class TestTeamTrendsView:
         now = timezone.now()
         Decision.objects.create(
             journal_contact=journal_contact1,
-            amount=Decimal('100.00'),
-            cadence='monthly',
-            status='active',
+            amount=Decimal("100.00"),
+            cadence="monthly",
+            status="active",
         )
         # Update created_at to current week
         Decision.objects.filter(journal_contact=journal_contact1).update(created_at=now)
 
         Decision.objects.create(
             journal_contact=journal_contact2,
-            amount=Decimal('50.00'),
-            cadence='one_time',
-            status='pending',
+            amount=Decimal("50.00"),
+            cadence="one_time",
+            status="pending",
         )
         # Update created_at to current week
-        Decision.objects.filter(journal_contact=journal_contact2).update(created_at=now - timedelta(days=1))
+        Decision.objects.filter(journal_contact=journal_contact2).update(
+            created_at=now - timedelta(days=1)
+        )
 
-        response = client.get('/api/v1/insights/admin/team-trends/')
+        response = client.get("/api/v1/insights/admin/team-trends/")
         assert response.status_code == status.HTTP_200_OK
 
         # Last week (most recent) should have 2 decisions
-        last_week = response.data['trends'][-1]
-        assert last_week['decisions_logged'] == 2
+        last_week = response.data["trends"][-1]
+        assert last_week["decisions_logged"] == 2
 
     def test_counts_donations_by_week(self, admin_client):
         """Gifts are counted in the correct week."""
         client, admin_user = admin_client
-        staff = UserFactory(role='missionary')
+        staff = UserFactory(role="missionary")
         contact = ContactFactory(owner=staff)
 
         # Create gifts in current week (use same day to avoid week-boundary issues)
@@ -157,24 +161,24 @@ class TestTeamTrendsView:
         GiftFactory(donor_contact=contact, gift_date=today, amount_cents=10000)
         GiftFactory(donor_contact=contact, gift_date=today, amount_cents=5000)
 
-        response = client.get('/api/v1/insights/admin/team-trends/')
+        response = client.get("/api/v1/insights/admin/team-trends/")
         assert response.status_code == status.HTTP_200_OK
 
         # Last week should have 2 donations
-        last_week = response.data['trends'][-1]
-        assert last_week['donations_received'] == 2
+        last_week = response.data["trends"][-1]
+        assert last_week["donations_received"] == 2
 
     def test_counts_stage_progressions_by_week(self, admin_client):
         """JournalStageEvents are counted in the correct week."""
         client, admin_user = admin_client
-        staff = UserFactory(role='missionary')
+        staff = UserFactory(role="missionary")
         contact = ContactFactory(owner=staff)
 
         # Create journal and journal_contact
         journal = Journal.objects.create(
-            name='Test Journal',
+            name="Test Journal",
             owner=staff,
-            goal_amount=Decimal('5000.00'),
+            goal_amount=Decimal("5000.00"),
         )
         journal_contact = JournalContact.objects.create(
             journal=journal,
@@ -199,34 +203,34 @@ class TestTeamTrendsView:
             created_at=now - timedelta(days=3),
         )
 
-        response = client.get('/api/v1/insights/admin/team-trends/')
+        response = client.get("/api/v1/insights/admin/team-trends/")
         assert response.status_code == status.HTTP_200_OK
 
         # Last week should have 3 stage progressions
-        last_week = response.data['trends'][-1]
-        assert last_week['stage_progressions'] == 3
+        last_week = response.data["trends"][-1]
+        assert last_week["stage_progressions"] == 3
 
     def test_invalid_weeks_param_returns_default(self, admin_client):
         """Invalid weeks parameter returns default (12)."""
         client, user = admin_client
 
         # Test non-numeric
-        response = client.get('/api/v1/insights/admin/team-trends/?weeks=abc')
+        response = client.get("/api/v1/insights/admin/team-trends/?weeks=abc")
         assert response.status_code == status.HTTP_200_OK
-        assert response.data['weeks'] == 12
+        assert response.data["weeks"] == 12
 
     def test_weeks_param_respects_min_max_bounds(self, admin_client):
         """weeks parameter is bounded between 1 and 52."""
         client, user = admin_client
 
         # Test below min (should return 1)
-        response = client.get('/api/v1/insights/admin/team-trends/?weeks=0')
+        response = client.get("/api/v1/insights/admin/team-trends/?weeks=0")
         assert response.status_code == status.HTTP_200_OK
-        assert response.data['weeks'] == 1
-        assert len(response.data['trends']) == 1
+        assert response.data["weeks"] == 1
+        assert len(response.data["trends"]) == 1
 
         # Test above max (should return 52)
-        response = client.get('/api/v1/insights/admin/team-trends/?weeks=100')
+        response = client.get("/api/v1/insights/admin/team-trends/?weeks=100")
         assert response.status_code == status.HTTP_200_OK
-        assert response.data['weeks'] == 52
-        assert len(response.data['trends']) == 52
+        assert response.data["weeks"] == 52
+        assert len(response.data["trends"]) == 52

--- a/apps/insights/tests/test_user_detail.py
+++ b/apps/insights/tests/test_user_detail.py
@@ -1,18 +1,13 @@
 """
 Tests for user detail endpoints in insights app.
 """
-from datetime import timedelta
 from decimal import Decimal
 
-from django.utils import timezone
-
 from rest_framework import status
-from rest_framework.test import APIClient
 
 import pytest
 
 from apps.contacts.tests.factories import ContactFactory
-from apps.gifts.tests.factories import GiftFactory
 from apps.journals.models import Decision, Journal, JournalContact
 from apps.users.tests.factories import UserFactory
 
@@ -111,7 +106,7 @@ class TestUserJournals:
         contact1 = ContactFactory(owner=staff)
         contact2 = ContactFactory(owner=staff)
         jc1 = JournalContact.objects.create(journal=journal, contact=contact1)
-        jc2 = JournalContact.objects.create(journal=journal, contact=contact2)
+        JournalContact.objects.create(journal=journal, contact=contact2)
 
         # Create a decision for one contact
         Decision.objects.create(journal_contact=jc1, amount=Decimal("100.00"), cadence="monthly")

--- a/apps/insights/tests/test_user_detail.py
+++ b/apps/insights/tests/test_user_detail.py
@@ -1,18 +1,20 @@
 """
 Tests for user detail endpoints in insights app.
 """
-import pytest
-from decimal import Decimal
 from datetime import timedelta
+from decimal import Decimal
 
 from django.utils import timezone
+
 from rest_framework import status
 from rest_framework.test import APIClient
 
-from apps.users.tests.factories import UserFactory
+import pytest
+
 from apps.contacts.tests.factories import ContactFactory
 from apps.gifts.tests.factories import GiftFactory
-from apps.journals.models import Journal, JournalContact, Decision
+from apps.journals.models import Decision, Journal, JournalContact
+from apps.users.tests.factories import UserFactory
 
 
 @pytest.mark.django_db
@@ -22,50 +24,50 @@ class TestUserTrends:
     def test_admin_can_access(self, admin_client):
         """Admin can access user trends endpoint."""
         client, admin_user = admin_client
-        staff = UserFactory(role='missionary')
-        response = client.get(f'/api/v1/insights/admin/user-trends/?user_id={staff.id}')
+        staff = UserFactory(role="missionary")
+        response = client.get(f"/api/v1/insights/admin/user-trends/?user_id={staff.id}")
         assert response.status_code == status.HTTP_200_OK
-        assert 'trends' in response.data
-        assert 'weeks' in response.data
+        assert "trends" in response.data
+        assert "weeks" in response.data
 
     def test_staff_cannot_access(self, authenticated_client):
         """Staff cannot access admin endpoint."""
         client, staff_user = authenticated_client
-        response = client.get(f'/api/v1/insights/admin/user-trends/?user_id={staff_user.id}')
+        response = client.get(f"/api/v1/insights/admin/user-trends/?user_id={staff_user.id}")
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
     def test_missing_user_id_returns_400(self, admin_client):
         """Request without user_id parameter returns 400."""
         client, admin_user = admin_client
-        response = client.get('/api/v1/insights/admin/user-trends/')
+        response = client.get("/api/v1/insights/admin/user-trends/")
         assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert 'detail' in response.data
+        assert "detail" in response.data
 
     def test_returns_trend_data_structure(self, admin_client):
         """Verify trend data structure is correct."""
         client, admin_user = admin_client
-        staff = UserFactory(role='missionary')
-        response = client.get(f'/api/v1/insights/admin/user-trends/?user_id={staff.id}')
+        staff = UserFactory(role="missionary")
+        response = client.get(f"/api/v1/insights/admin/user-trends/?user_id={staff.id}")
         assert response.status_code == status.HTTP_200_OK
-        assert response.data['weeks'] == 12  # default
-        assert isinstance(response.data['trends'], list)
+        assert response.data["weeks"] == 12  # default
+        assert isinstance(response.data["trends"], list)
 
         # Check structure of trend items
-        if response.data['trends']:
-            trend = response.data['trends'][0]
-            assert 'week_start' in trend
-            assert 'week_label' in trend
-            assert 'decisions_logged' in trend
-            assert 'donations_received' in trend
-            assert 'stage_progressions' in trend
+        if response.data["trends"]:
+            trend = response.data["trends"][0]
+            assert "week_start" in trend
+            assert "week_label" in trend
+            assert "decisions_logged" in trend
+            assert "donations_received" in trend
+            assert "stage_progressions" in trend
 
     def test_custom_weeks_parameter(self, admin_client):
         """Test custom weeks parameter."""
         client, admin_user = admin_client
-        staff = UserFactory(role='missionary')
-        response = client.get(f'/api/v1/insights/admin/user-trends/?user_id={staff.id}&weeks=8')
+        staff = UserFactory(role="missionary")
+        response = client.get(f"/api/v1/insights/admin/user-trends/?user_id={staff.id}&weeks=8")
         assert response.status_code == status.HTTP_200_OK
-        assert response.data['weeks'] == 8
+        assert response.data["weeks"] == 8
 
 
 @pytest.mark.django_db
@@ -75,34 +77,34 @@ class TestUserJournals:
     def test_admin_can_access(self, admin_client):
         """Admin can access user journals endpoint."""
         client, admin_user = admin_client
-        staff = UserFactory(role='missionary')
-        response = client.get(f'/api/v1/insights/admin/user-journals/?user_id={staff.id}')
+        staff = UserFactory(role="missionary")
+        response = client.get(f"/api/v1/insights/admin/user-journals/?user_id={staff.id}")
         assert response.status_code == status.HTTP_200_OK
-        assert 'journals' in response.data
+        assert "journals" in response.data
 
     def test_staff_cannot_access(self, authenticated_client):
         """Staff cannot access admin endpoint."""
         client, staff_user = authenticated_client
-        response = client.get(f'/api/v1/insights/admin/user-journals/?user_id={staff_user.id}')
+        response = client.get(f"/api/v1/insights/admin/user-journals/?user_id={staff_user.id}")
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
     def test_missing_user_id_returns_400(self, admin_client):
         """Request without user_id parameter returns 400."""
         client, admin_user = admin_client
-        response = client.get('/api/v1/insights/admin/user-journals/')
+        response = client.get("/api/v1/insights/admin/user-journals/")
         assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert 'detail' in response.data
+        assert "detail" in response.data
 
     def test_returns_journals_for_user(self, admin_client):
         """Create a journal owned by a staff user, verify it appears in response."""
         client, admin_user = admin_client
-        staff = UserFactory(role='missionary')
+        staff = UserFactory(role="missionary")
 
         # Create a journal for the staff user
         journal = Journal.objects.create(
-            name='Test Journal',
+            name="Test Journal",
             owner=staff,
-            goal_amount=Decimal('5000.00'),
+            goal_amount=Decimal("5000.00"),
         )
 
         # Add some contacts to the journal
@@ -112,25 +114,21 @@ class TestUserJournals:
         jc2 = JournalContact.objects.create(journal=journal, contact=contact2)
 
         # Create a decision for one contact
-        Decision.objects.create(
-            journal_contact=jc1,
-            amount=Decimal('100.00'),
-            cadence='monthly'
-        )
+        Decision.objects.create(journal_contact=jc1, amount=Decimal("100.00"), cadence="monthly")
 
-        response = client.get(f'/api/v1/insights/admin/user-journals/?user_id={staff.id}')
+        response = client.get(f"/api/v1/insights/admin/user-journals/?user_id={staff.id}")
         assert response.status_code == status.HTTP_200_OK
-        assert len(response.data['journals']) == 1
+        assert len(response.data["journals"]) == 1
 
-        journal_data = response.data['journals'][0]
-        assert journal_data['id'] == str(journal.id)
-        assert journal_data['name'] == 'Test Journal'
-        assert 'member_count' in journal_data
-        assert 'decision_count' in journal_data
-        assert 'active_member_count' in journal_data
-        assert 'created_at' in journal_data
+        journal_data = response.data["journals"][0]
+        assert journal_data["id"] == str(journal.id)
+        assert journal_data["name"] == "Test Journal"
+        assert "member_count" in journal_data
+        assert "decision_count" in journal_data
+        assert "active_member_count" in journal_data
+        assert "created_at" in journal_data
 
         # Verify counts
-        assert journal_data['member_count'] == 2
-        assert journal_data['decision_count'] == 1
-        assert journal_data['active_member_count'] == 1
+        assert journal_data["member_count"] == 2
+        assert journal_data["decision_count"] == 1
+        assert journal_data["active_member_count"] == 1

--- a/apps/insights/tests/test_user_drilldown.py
+++ b/apps/insights/tests/test_user_drilldown.py
@@ -7,12 +7,13 @@ from decimal import Decimal
 from django.test import TestCase
 from django.urls import reverse
 from django.utils import timezone
+
 from rest_framework import status
 from rest_framework.test import APIClient
 
 from apps.contacts.models import Contact
 from apps.gifts.models import Gift
-from apps.journals.models import Journal, JournalContact, Decision, JournalStageEvent, PipelineStage
+from apps.journals.models import Decision, Journal, JournalContact, JournalStageEvent, PipelineStage
 from apps.users.models import User
 
 
@@ -22,71 +23,71 @@ class UserDrilldownViewTest(TestCase):
     def setUp(self):
         # Create admin user
         self.admin = User.objects.create_user(
-            email='admin@test.com',
-            password='testpass123',
-            role='admin',
-            first_name='Admin',
-            last_name='User',
+            email="admin@test.com",
+            password="testpass123",
+            role="admin",
+            first_name="Admin",
+            last_name="User",
         )
 
         # Create staff user (missionary)
         self.missionary = User.objects.create_user(
-            email='missionary@test.com',
-            password='testpass123',
-            role='missionary',
-            first_name='Missionary',
-            last_name='Smith',
+            email="missionary@test.com",
+            password="testpass123",
+            role="missionary",
+            first_name="Missionary",
+            last_name="Smith",
         )
 
         # Create non-admin staff user
         self.staff = User.objects.create_user(
-            email='staff@test.com',
-            password='testpass123',
-            role='missionary',
-            first_name='Staff',
-            last_name='Member',
+            email="staff@test.com",
+            password="testpass123",
+            role="missionary",
+            first_name="Staff",
+            last_name="Member",
         )
 
         # Create contacts owned by missionary
         self.contact1 = Contact.objects.create(
             owner=self.missionary,
-            first_name='John',
-            last_name='Doe',
-            email='john@test.com',
-            status='active',
+            first_name="John",
+            last_name="Doe",
+            email="john@test.com",
+            status="active",
         )
         self.contact2 = Contact.objects.create(
             owner=self.missionary,
-            first_name='Jane',
-            last_name='Smith',
-            email='jane@test.com',
-            status='active',
+            first_name="Jane",
+            last_name="Smith",
+            email="jane@test.com",
+            status="active",
         )
         self.contact3 = Contact.objects.create(
             owner=self.missionary,
-            first_name='Bob',
-            last_name='Johnson',
-            email='bob@test.com',
-            status='active',
+            first_name="Bob",
+            last_name="Johnson",
+            email="bob@test.com",
+            status="active",
         )
 
         # Create journals
         self.journal1 = Journal.objects.create(
             owner=self.missionary,
-            name='Journal 1',
-            goal_amount=Decimal('50000.00'),
+            name="Journal 1",
+            goal_amount=Decimal("50000.00"),
             is_archived=False,
         )
         self.journal2 = Journal.objects.create(
             owner=self.missionary,
-            name='Journal 2',
-            goal_amount=Decimal('30000.00'),
+            name="Journal 2",
+            goal_amount=Decimal("30000.00"),
             is_archived=False,
         )
         self.journal3 = Journal.objects.create(
             owner=self.missionary,
-            name='Journal 3 (archived)',
-            goal_amount=Decimal('20000.00'),
+            name="Journal 3 (archived)",
+            goal_amount=Decimal("20000.00"),
             is_archived=True,
         )
 
@@ -113,15 +114,15 @@ class UserDrilldownViewTest(TestCase):
         # Create decisions
         Decision.objects.create(
             journal_contact=self.jc1,
-            amount=Decimal('100.00'),
-            cadence='monthly',
-            status='active',
+            amount=Decimal("100.00"),
+            cadence="monthly",
+            status="active",
         )
         Decision.objects.create(
             journal_contact=self.jc2,
-            amount=Decimal('50.00'),
-            cadence='monthly',
-            status='active',
+            amount=Decimal("50.00"),
+            cadence="monthly",
+            status="active",
         )
 
         # Create gifts
@@ -137,18 +138,18 @@ class UserDrilldownViewTest(TestCase):
         )
 
         self.client = APIClient()
-        self.url = reverse('insights:admin-user-drilldown')
+        self.url = reverse("insights:admin-user-drilldown")
 
     def test_admin_can_access_endpoint(self):
         """Admin user can access user drilldown endpoint."""
         self.client.force_authenticate(user=self.admin)
-        response = self.client.get(self.url, {'user_id': str(self.missionary.id)})
+        response = self.client.get(self.url, {"user_id": str(self.missionary.id)})
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_non_admin_gets_403(self):
         """Non-admin user gets 403 Forbidden."""
         self.client.force_authenticate(user=self.staff)
-        response = self.client.get(self.url, {'user_id': str(self.missionary.id)})
+        response = self.client.get(self.url, {"user_id": str(self.missionary.id)})
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_user_id_parameter_required(self):
@@ -156,76 +157,78 @@ class UserDrilldownViewTest(TestCase):
         self.client.force_authenticate(user=self.admin)
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertIn('detail', response.data)
+        self.assertIn("detail", response.data)
 
     def test_returns_correct_stats(self):
         """Returns correct stats for the user."""
         self.client.force_authenticate(user=self.admin)
-        response = self.client.get(self.url, {'user_id': str(self.missionary.id)})
+        response = self.client.get(self.url, {"user_id": str(self.missionary.id)})
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         # Check user info
-        self.assertEqual(response.data['user']['id'], str(self.missionary.id))
-        self.assertEqual(response.data['user']['name'], 'Missionary Smith')
-        self.assertEqual(response.data['user']['email'], 'missionary@test.com')
-        self.assertEqual(response.data['user']['role'], 'missionary')
+        self.assertEqual(response.data["user"]["id"], str(self.missionary.id))
+        self.assertEqual(response.data["user"]["name"], "Missionary Smith")
+        self.assertEqual(response.data["user"]["email"], "missionary@test.com")
+        self.assertEqual(response.data["user"]["role"], "missionary")
 
         # Check stats
-        self.assertEqual(response.data['stats']['total_contacts'], 3)
-        self.assertEqual(response.data['stats']['active_journals'], 2)
-        self.assertEqual(response.data['stats']['decisions_logged'], 2)
-        self.assertEqual(response.data['stats']['conversion_rate'], 66.7)  # 2/3 * 100
-        self.assertEqual(response.data['stats']['total_donations'], 150.0)  # $150.00 (10000 + 5000 cents converted to dollars)
-        self.assertEqual(response.data['stats']['donation_count'], 2)
+        self.assertEqual(response.data["stats"]["total_contacts"], 3)
+        self.assertEqual(response.data["stats"]["active_journals"], 2)
+        self.assertEqual(response.data["stats"]["decisions_logged"], 2)
+        self.assertEqual(response.data["stats"]["conversion_rate"], 66.7)  # 2/3 * 100
+        self.assertEqual(
+            response.data["stats"]["total_donations"], 150.0
+        )  # $150.00 (10000 + 5000 cents converted to dollars)
+        self.assertEqual(response.data["stats"]["donation_count"], 2)
 
     def test_returns_stalled_contact_count(self):
         """Returns correct stalled contact count."""
         self.client.force_authenticate(user=self.admin)
-        response = self.client.get(self.url, {'user_id': str(self.missionary.id)})
+        response = self.client.get(self.url, {"user_id": str(self.missionary.id)})
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         # 1 stalled contact: contact2 (20 days old activity)
         # contact3 has no activity but was just added, so it's not >14 days stalled yet
         # (The stalled logic uses journal_membership_date as fallback, which is recent)
-        self.assertEqual(response.data['stats']['stalled_contacts'], 1)
+        self.assertEqual(response.data["stats"]["stalled_contacts"], 1)
 
     def test_returns_recent_journals(self):
         """Returns recent journals with progress indicators."""
         self.client.force_authenticate(user=self.admin)
-        response = self.client.get(self.url, {'user_id': str(self.missionary.id)})
+        response = self.client.get(self.url, {"user_id": str(self.missionary.id)})
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         # Should return 2 non-archived journals
-        self.assertEqual(len(response.data['journals']), 2)
+        self.assertEqual(len(response.data["journals"]), 2)
 
         # Check journal structure
-        journal = response.data['journals'][0]
-        self.assertIn('id', journal)
-        self.assertIn('name', journal)
-        self.assertIn('member_count', journal)
-        self.assertIn('decision_count', journal)
-        self.assertIn('active_member_count', journal)
-        self.assertIn('created_at', journal)
+        journal = response.data["journals"][0]
+        self.assertIn("id", journal)
+        self.assertIn("name", journal)
+        self.assertIn("member_count", journal)
+        self.assertIn("decision_count", journal)
+        self.assertIn("active_member_count", journal)
+        self.assertIn("created_at", journal)
 
         # Check journal1 has 2 members, 2 decisions, 2 active
-        journal1_data = next(j for j in response.data['journals'] if j['name'] == 'Journal 1')
-        self.assertEqual(journal1_data['member_count'], 2)
-        self.assertEqual(journal1_data['decision_count'], 2)
-        self.assertEqual(journal1_data['active_member_count'], 2)
+        journal1_data = next(j for j in response.data["journals"] if j["name"] == "Journal 1")
+        self.assertEqual(journal1_data["member_count"], 2)
+        self.assertEqual(journal1_data["decision_count"], 2)
+        self.assertEqual(journal1_data["active_member_count"], 2)
 
         # Check journal2 has 1 member, 0 decisions, 0 active
-        journal2_data = next(j for j in response.data['journals'] if j['name'] == 'Journal 2')
-        self.assertEqual(journal2_data['member_count'], 1)
-        self.assertEqual(journal2_data['decision_count'], 0)
-        self.assertEqual(journal2_data['active_member_count'], 0)
+        journal2_data = next(j for j in response.data["journals"] if j["name"] == "Journal 2")
+        self.assertEqual(journal2_data["member_count"], 1)
+        self.assertEqual(journal2_data["decision_count"], 0)
+        self.assertEqual(journal2_data["active_member_count"], 0)
 
     def test_returns_404_for_nonexistent_user(self):
         """Returns 404 for non-existent user."""
         self.client.force_authenticate(user=self.admin)
-        fake_uuid = '00000000-0000-0000-0000-000000000000'
-        response = self.client.get(self.url, {'user_id': fake_uuid})
+        fake_uuid = "00000000-0000-0000-0000-000000000000"
+        response = self.client.get(self.url, {"user_id": fake_uuid})
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
-        self.assertIn('detail', response.data)
+        self.assertIn("detail", response.data)
 
     def test_conversion_rate_uses_journal_contacts_denominator(self):
         """Verify conversion rate uses contacts-in-journals, not all contacts."""
@@ -233,27 +236,27 @@ class UserDrilldownViewTest(TestCase):
 
         # Create a new missionary with 4 contacts but only 2 in a journal
         missionary2 = User.objects.create_user(
-            email='missionary2@test.com',
-            password='testpass123',
-            role='missionary',
-            first_name='Test',
-            last_name='Missionary',
+            email="missionary2@test.com",
+            password="testpass123",
+            role="missionary",
+            first_name="Test",
+            last_name="Missionary",
         )
         contacts = [
             Contact.objects.create(
                 owner=missionary2,
-                first_name=f'Contact{i}',
-                last_name='Test',
-                email=f'c{i}@test.com',
-                status='active',
+                first_name=f"Contact{i}",
+                last_name="Test",
+                email=f"c{i}@test.com",
+                status="active",
             )
             for i in range(4)
         ]
 
         journal = Journal.objects.create(
             owner=missionary2,
-            name='Test Journal',
-            goal_amount=Decimal('10000.00'),
+            name="Test Journal",
+            goal_amount=Decimal("10000.00"),
             is_archived=False,
         )
         # Only 2 contacts in the journal
@@ -263,13 +266,13 @@ class UserDrilldownViewTest(TestCase):
         # 1 decision (for contacts[0])
         Decision.objects.create(
             journal_contact=jc1,
-            amount=Decimal('100.00'),
-            cadence='monthly',
-            status='active',
+            amount=Decimal("100.00"),
+            cadence="monthly",
+            status="active",
         )
 
-        response = self.client.get(self.url, {'user_id': str(missionary2.id)})
+        response = self.client.get(self.url, {"user_id": str(missionary2.id)})
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         # Denominator should be 2 (contacts in journals), not 4 (total contacts)
         # So conversion rate = 1/2 * 100 = 50.0, not 1/4 * 100 = 25.0
-        self.assertEqual(response.data['stats']['conversion_rate'], 50.0)
+        self.assertEqual(response.data["stats"]["conversion_rate"], 50.0)

--- a/apps/insights/tests/test_user_performance_perf.py
+++ b/apps/insights/tests/test_user_performance_perf.py
@@ -12,9 +12,9 @@ Covers:
 """
 from decimal import Decimal
 
+from django.db import connection
 from django.test import TestCase
 from django.test.utils import CaptureQueriesContext
-from django.db import connection
 
 from apps.contacts.models import Contact
 from apps.gifts.models import Gift
@@ -36,52 +36,51 @@ class UserPerformanceQueryBudgetTest(TestCase):
 
     def setUp(self):
         self.user = User.objects.create_user(
-            email='perf@test.com',
-            password='testpass123',
-            role='missionary',
-            first_name='Perf',
-            last_name='Tester',
+            email="perf@test.com",
+            password="testpass123",
+            role="missionary",
+            first_name="Perf",
+            last_name="Tester",
         )
 
         contacts = [
             Contact.objects.create(
                 owner=self.user,
-                first_name=f'C{i}',
-                last_name='Test',
-                email=f'c{i}@test.com',
-                status='active',
+                first_name=f"C{i}",
+                last_name="Test",
+                email=f"c{i}@test.com",
+                status="active",
             )
             for i in range(5)
         ]
 
         journal = Journal.objects.create(
             owner=self.user,
-            name='Perf Journal',
-            goal_amount=Decimal('10000.00'),
+            name="Perf Journal",
+            goal_amount=Decimal("10000.00"),
             is_archived=False,
         )
 
         # Put 4 contacts in a journal; mark 2 with decisions (50% conversion).
         journal_contacts = [
-            JournalContact.objects.create(journal=journal, contact=c)
-            for c in contacts[:4]
+            JournalContact.objects.create(journal=journal, contact=c) for c in contacts[:4]
         ]
         for jc in journal_contacts[:2]:
             Decision.objects.create(
                 journal_contact=jc,
-                amount=Decimal('100.00'),
+                amount=Decimal("100.00"),
             )
 
         # Two gifts totaling $150.00.
         Gift.objects.create(
             donor_contact=contacts[0],
             amount_cents=10000,
-            gift_date='2026-01-01',
+            gift_date="2026-01-01",
         )
         Gift.objects.create(
             donor_contact=contacts[1],
             amount_cents=5000,
-            gift_date='2026-01-02',
+            gift_date="2026-01-02",
         )
 
     def test_get_user_performance_within_query_budget(self):
@@ -91,18 +90,18 @@ class UserPerformanceQueryBudgetTest(TestCase):
         self.assertLessEqual(
             len(ctx.captured_queries),
             self.PERFORMANCE_QUERY_BUDGET,
-            f'get_user_performance used {len(ctx.captured_queries)} queries, '
-            f'budget is {self.PERFORMANCE_QUERY_BUDGET}',
+            f"get_user_performance used {len(ctx.captured_queries)} queries, "
+            f"budget is {self.PERFORMANCE_QUERY_BUDGET}",
         )
 
-        rows = {row['email']: row for row in result['users']}
-        row = rows['perf@test.com']
-        self.assertEqual(row['total_contacts'], 5)
-        self.assertEqual(row['active_journals'], 1)
-        self.assertEqual(row['decisions_logged'], 2)
-        self.assertEqual(row['conversion_rate'], 50.0)
-        self.assertEqual(row['total_donations'], 150.0)
-        self.assertEqual(row['donation_count'], 2)
+        rows = {row["email"]: row for row in result["users"]}
+        row = rows["perf@test.com"]
+        self.assertEqual(row["total_contacts"], 5)
+        self.assertEqual(row["active_journals"], 1)
+        self.assertEqual(row["decisions_logged"], 2)
+        self.assertEqual(row["conversion_rate"], 50.0)
+        self.assertEqual(row["total_donations"], 150.0)
+        self.assertEqual(row["donation_count"], 2)
 
     def test_get_user_drilldown_within_query_budget(self):
         with CaptureQueriesContext(connection) as ctx:
@@ -111,87 +110,86 @@ class UserPerformanceQueryBudgetTest(TestCase):
         self.assertLessEqual(
             len(ctx.captured_queries),
             self.DRILLDOWN_QUERY_BUDGET,
-            f'get_user_drilldown used {len(ctx.captured_queries)} queries, '
-            f'budget is {self.DRILLDOWN_QUERY_BUDGET}',
+            f"get_user_drilldown used {len(ctx.captured_queries)} queries, "
+            f"budget is {self.DRILLDOWN_QUERY_BUDGET}",
         )
 
-        stats = result['stats']
-        self.assertEqual(stats['total_contacts'], 5)
-        self.assertEqual(stats['active_journals'], 1)
-        self.assertEqual(stats['decisions_logged'], 2)
-        self.assertEqual(stats['conversion_rate'], 50.0)
-        self.assertEqual(stats['total_donations'], 150.0)
-        self.assertEqual(stats['donation_count'], 2)
+        stats = result["stats"]
+        self.assertEqual(stats["total_contacts"], 5)
+        self.assertEqual(stats["active_journals"], 1)
+        self.assertEqual(stats["decisions_logged"], 2)
+        self.assertEqual(stats["conversion_rate"], 50.0)
+        self.assertEqual(stats["total_donations"], 150.0)
+        self.assertEqual(stats["donation_count"], 2)
 
     def test_drilldown_matches_performance_row(self):
         """Drilldown and table must report identical metrics for the same user."""
         perf_row = next(
-            row for row in get_user_performance()['users']
-            if row['email'] == 'perf@test.com'
+            row for row in get_user_performance()["users"] if row["email"] == "perf@test.com"
         )
-        drilldown = get_user_drilldown(str(self.user.id))['stats']
+        drilldown = get_user_drilldown(str(self.user.id))["stats"]
 
         for key in (
-            'total_contacts',
-            'active_journals',
-            'decisions_logged',
-            'conversion_rate',
-            'total_donations',
-            'donation_count',
+            "total_contacts",
+            "active_journals",
+            "decisions_logged",
+            "conversion_rate",
+            "total_donations",
+            "donation_count",
         ):
             self.assertEqual(
                 perf_row[key],
                 drilldown[key],
-                f'Mismatch on {key}: table={perf_row[key]} drilldown={drilldown[key]}',
+                f"Mismatch on {key}: table={perf_row[key]} drilldown={drilldown[key]}",
             )
 
     def test_contacts_with_decisions_deduplicates_across_journals(self):
         """One contact in two journals must count as 1, not 2."""
         contact = Contact.objects.create(
             owner=self.user,
-            first_name='Shared',
-            last_name='Contact',
-            email='shared@test.com',
-            status='active',
+            first_name="Shared",
+            last_name="Contact",
+            email="shared@test.com",
+            status="active",
         )
 
         journal2 = Journal.objects.create(
             owner=self.user,
-            name='Second Journal',
-            goal_amount=Decimal('5000.00'),
+            name="Second Journal",
+            goal_amount=Decimal("5000.00"),
             is_archived=False,
         )
 
         jc2 = JournalContact.objects.create(journal=journal2, contact=contact)
-        Decision.objects.create(journal_contact=jc2, amount=Decimal('50.00'))
+        Decision.objects.create(journal_contact=jc2, amount=Decimal("50.00"))
 
         # The shared contact also appears in the first journal (from setUp) via
         # journal_contacts[0] which already has a Decision. Adding it to a second
         # journal should not inflate contacts_with_decisions.
         result = get_user_performance()
-        row = next(r for r in result['users'] if r['email'] == 'perf@test.com')
+        row = next(r for r in result["users"] if r["email"] == "perf@test.com")
 
         # decisions_logged grows by 1 (the new Decision above)
-        self.assertEqual(row['decisions_logged'], 3)
+        self.assertEqual(row["decisions_logged"], 3)
         # Verify deduplication via conversion_rate.
         # contacts_in_journals = 5: setUp journal has 4 contacts; journal2 adds
         # 1 new contact (shared), deduplicated across both journals = 5 unique.
         # contacts_with_decisions = 3: setUp's contacts[0] and contacts[1], plus shared.
         # Expected conversion_rate = 3/5 * 100 = 60.0%
-        self.assertAlmostEqual(row['conversion_rate'], 60.0, places=1)
+        self.assertAlmostEqual(row["conversion_rate"], 60.0, places=1)
 
     def test_user_not_found_returns_detail(self):
-        result = get_user_drilldown('00000000-0000-0000-0000-000000000000')
-        self.assertEqual(result, {'detail': 'User not found'})
+        result = get_user_drilldown("00000000-0000-0000-0000-000000000000")
+        self.assertEqual(result, {"detail": "User not found"})
 
     def test_coach_user_drilldown_returns_not_found(self):
         """get_user_drilldown must return not-found for coach users (role not in allowed set)."""
         coach = User.objects.create_user(
-            email='coach@test.com',
-            password='testpass123',
-            role='coach',
-            first_name='Coach',
-            last_name='User',
+            email="coach@test.com",
+            password="testpass123",
+            role="coach",
+            first_name="Coach",
+            last_name="User",
         )
         result = get_user_drilldown(str(coach.id))
-        self.assertEqual(result, {'detail': 'User not found'})
+        self.assertEqual(result, {"detail": "User not found"})

--- a/apps/insights/tests/test_views.py
+++ b/apps/insights/tests/test_views.py
@@ -1,10 +1,7 @@
 """
 Tests for admin analytics endpoints in insights app.
 """
-from datetime import timedelta
 from decimal import Decimal
-
-from django.utils import timezone
 
 from rest_framework import status
 from rest_framework.test import APIClient
@@ -391,7 +388,7 @@ class TestConversionFunnelBugFixes:
             goal_amount=Decimal("10000.00"),
         )
         jc1 = JournalContact.objects.create(journal=journal, contact=contact1)
-        jc2 = JournalContact.objects.create(journal=journal, contact=contact2)
+        JournalContact.objects.create(journal=journal, contact=contact2)
 
         # Only jc1 gets a stage event; jc2 has no activity
         from apps.journals.models import JournalStageEvent, PipelineStage

--- a/apps/insights/tests/test_views.py
+++ b/apps/insights/tests/test_views.py
@@ -1,18 +1,20 @@
 """
 Tests for admin analytics endpoints in insights app.
 """
-import pytest
-from decimal import Decimal
 from datetime import timedelta
+from decimal import Decimal
 
 from django.utils import timezone
+
 from rest_framework import status
 from rest_framework.test import APIClient
 
-from apps.users.tests.factories import UserFactory
+import pytest
+
 from apps.contacts.tests.factories import ContactFactory
 from apps.gifts.tests.factories import GiftFactory
-from apps.journals.models import Journal, JournalContact, Decision
+from apps.journals.models import Decision, Journal, JournalContact
+from apps.users.tests.factories import UserFactory
 
 
 @pytest.mark.django_db
@@ -21,32 +23,32 @@ class TestAdminDashboardOverview:
 
     def test_admin_can_access(self, admin_client):
         client, user = admin_client
-        response = client.get('/api/v1/insights/admin/dashboard-overview/')
+        response = client.get("/api/v1/insights/admin/dashboard-overview/")
         assert response.status_code == status.HTTP_200_OK
-        assert 'total_contacts' in response.data
-        assert 'active_journals' in response.data
-        assert 'stalled_contacts' in response.data
-        assert 'conversion_rate' in response.data
-        assert 'donations_12m' in response.data
+        assert "total_contacts" in response.data
+        assert "active_journals" in response.data
+        assert "stalled_contacts" in response.data
+        assert "conversion_rate" in response.data
+        assert "donations_12m" in response.data
 
     def test_staff_cannot_access(self, authenticated_client):
         client, user = authenticated_client
-        response = client.get('/api/v1/insights/admin/dashboard-overview/')
+        response = client.get("/api/v1/insights/admin/dashboard-overview/")
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
     def test_unauthenticated_cannot_access(self):
         client = APIClient()
-        response = client.get('/api/v1/insights/admin/dashboard-overview/')
+        response = client.get("/api/v1/insights/admin/dashboard-overview/")
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
     def test_returns_correct_counts(self, admin_client):
         client, admin_user = admin_client
-        staff = UserFactory(role='missionary')
+        staff = UserFactory(role="missionary")
         ContactFactory.create_batch(3, owner=staff)
         ContactFactory.create_batch(2, owner=admin_user)
 
-        response = client.get('/api/v1/insights/admin/dashboard-overview/')
-        assert response.data['total_contacts'] == 5
+        response = client.get("/api/v1/insights/admin/dashboard-overview/")
+        assert response.data["total_contacts"] == 5
 
 
 @pytest.mark.django_db
@@ -55,81 +57,80 @@ class TestStalledContacts:
 
     def test_admin_can_access(self, admin_client):
         client, user = admin_client
-        response = client.get('/api/v1/insights/admin/stalled-contacts/')
+        response = client.get("/api/v1/insights/admin/stalled-contacts/")
         assert response.status_code == status.HTTP_200_OK
-        assert 'stalled_contacts' in response.data
-        assert 'total_count' in response.data
+        assert "stalled_contacts" in response.data
+        assert "total_count" in response.data
 
     def test_staff_cannot_access(self, authenticated_client):
         client, user = authenticated_client
-        response = client.get('/api/v1/insights/admin/stalled-contacts/')
+        response = client.get("/api/v1/insights/admin/stalled-contacts/")
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
     def test_pagination_params(self, admin_client):
         client, user = admin_client
-        response = client.get('/api/v1/insights/admin/stalled-contacts/?limit=10&offset=0')
+        response = client.get("/api/v1/insights/admin/stalled-contacts/?limit=10&offset=0")
         assert response.status_code == status.HTTP_200_OK
-        assert response.data['limit'] == 10
-        assert response.data['offset'] == 0
+        assert response.data["limit"] == 10
+        assert response.data["offset"] == 0
 
     def test_invalid_limit_returns_default(self, admin_client):
         """Send ?limit=abc, verify 200 response (not 500) with default limit of 50."""
         client, user = admin_client
-        response = client.get('/api/v1/insights/admin/stalled-contacts/?limit=abc')
+        response = client.get("/api/v1/insights/admin/stalled-contacts/?limit=abc")
         assert response.status_code == status.HTTP_200_OK
-        assert response.data['limit'] == 50  # default
+        assert response.data["limit"] == 50  # default
 
     def test_invalid_offset_returns_default(self, admin_client):
         """Send ?offset=xyz, verify 200 response with default offset of 0."""
         client, user = admin_client
-        response = client.get('/api/v1/insights/admin/stalled-contacts/?offset=xyz')
+        response = client.get("/api/v1/insights/admin/stalled-contacts/?offset=xyz")
         assert response.status_code == status.HTTP_200_OK
-        assert response.data['offset'] == 0  # default
+        assert response.data["offset"] == 0  # default
 
     def test_zero_activity_contact_has_days_stalled(self, admin_client):
         """Create a contact, add to a journal (JournalContact), do NOT create any JournalStageEvent.
         Verify days_stalled is an integer >= 0, not None."""
         client, admin_user = admin_client
-        staff = UserFactory(role='missionary')
+        staff = UserFactory(role="missionary")
         contact = ContactFactory(owner=staff)
         # Add to journal but create no stage events
         journal = Journal.objects.create(
-            name='Test Journal',
+            name="Test Journal",
             owner=staff,
-            goal_amount=Decimal('5000.00'),
+            goal_amount=Decimal("5000.00"),
         )
         JournalContact.objects.create(journal=journal, contact=contact)
 
-        response = client.get('/api/v1/insights/admin/stalled-contacts/')
+        response = client.get("/api/v1/insights/admin/stalled-contacts/")
         assert response.status_code == status.HTTP_200_OK
         # Should have at least 1 stalled contact (the one we just created)
-        if response.data['total_count'] > 0:
+        if response.data["total_count"] > 0:
             # Find our contact in results
             contact_data = next(
-                (c for c in response.data['stalled_contacts'] if c['id'] == str(contact.id)),
-                None
+                (c for c in response.data["stalled_contacts"] if c["id"] == str(contact.id)), None
             )
             if contact_data:
-                assert contact_data['days_stalled'] is not None
-                assert isinstance(contact_data['days_stalled'], int)
-                assert contact_data['days_stalled'] >= 0
+                assert contact_data["days_stalled"] is not None
+                assert isinstance(contact_data["days_stalled"], int)
+                assert contact_data["days_stalled"] >= 0
 
     def test_sort_by_days_stalled(self, admin_client):
         """Verify ?sort_by=days_stalled returns 200."""
         client, user = admin_client
-        response = client.get('/api/v1/insights/admin/stalled-contacts/?sort_by=days_stalled')
+        response = client.get("/api/v1/insights/admin/stalled-contacts/?sort_by=days_stalled")
         assert response.status_code == status.HTTP_200_OK
 
     def test_sort_by_full_name(self, admin_client):
         """Verify ?sort_by=full_name returns 200."""
         client, user = admin_client
-        response = client.get('/api/v1/insights/admin/stalled-contacts/?sort_by=full_name')
+        response = client.get("/api/v1/insights/admin/stalled-contacts/?sort_by=full_name")
         assert response.status_code == status.HTTP_200_OK
 
     def test_invalid_sort_by_uses_default(self, admin_client):
         """Verify ?sort_by=hackme returns 200 (falls back to days_stalled default, not error)."""
         client, user = admin_client
-        response = client.get('/api/v1/insights/admin/stalled-contacts/?sort_by=hackme')
+        response = client.get("/api/v1/insights/admin/stalled-contacts/?sort_by=hackme")
         assert response.status_code == status.HTTP_200_OK
 
 
@@ -139,59 +140,59 @@ class TestUserPerformance:
 
     def test_admin_can_access(self, admin_client):
         client, user = admin_client
-        response = client.get('/api/v1/insights/admin/user-performance/')
+        response = client.get("/api/v1/insights/admin/user-performance/")
         assert response.status_code == status.HTTP_200_OK
-        assert 'users' in response.data
+        assert "users" in response.data
 
     def test_staff_cannot_access(self, authenticated_client):
         client, user = authenticated_client
-        response = client.get('/api/v1/insights/admin/user-performance/')
+        response = client.get("/api/v1/insights/admin/user-performance/")
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
     def test_returns_user_metrics(self, admin_client):
         client, admin_user = admin_client
-        staff = UserFactory(role='missionary')
+        staff = UserFactory(role="missionary")
         ContactFactory.create_batch(3, owner=staff)
 
-        response = client.get('/api/v1/insights/admin/user-performance/')
+        response = client.get("/api/v1/insights/admin/user-performance/")
         assert response.status_code == status.HTTP_200_OK
-        users = response.data['users']
+        users = response.data["users"]
         # Should include both admin and staff users
         assert len(users) >= 2
         # Verify structure
         user_data = users[0]
-        assert 'id' in user_data
-        assert 'email' in user_data
-        assert 'total_contacts' in user_data
-        assert 'active_journals' in user_data
-        assert 'decisions_logged' in user_data
-        assert 'total_donations' in user_data
+        assert "id" in user_data
+        assert "email" in user_data
+        assert "total_contacts" in user_data
+        assert "active_journals" in user_data
+        assert "decisions_logged" in user_data
+        assert "total_donations" in user_data
 
     def test_includes_conversion_rate(self, admin_client):
         """conversion_rate is returned per user (Phase 14 success criteria #3)."""
         client, admin_user = admin_client
-        staff = UserFactory(role='missionary')
+        staff = UserFactory(role="missionary")
         contact = ContactFactory(owner=staff)
         # Create journal, journal_contact, and decision to get non-zero conversion rate
         journal = Journal.objects.create(
-            name='Test Journal',
+            name="Test Journal",
             owner=staff,
-            goal_amount=Decimal('10000.00'),
+            goal_amount=Decimal("10000.00"),
         )
         jc = JournalContact.objects.create(journal=journal, contact=contact)
         Decision.objects.create(
             journal_contact=jc,
             amount=10000,  # $100.00
-            cadence='monthly',
-            status='active',
+            cadence="monthly",
+            status="active",
         )
 
-        response = client.get('/api/v1/insights/admin/user-performance/')
+        response = client.get("/api/v1/insights/admin/user-performance/")
         assert response.status_code == status.HTTP_200_OK
-        staff_data = next(u for u in response.data['users'] if u['email'] == staff.email)
-        assert 'conversion_rate' in staff_data
-        assert isinstance(staff_data['conversion_rate'], (int, float))
-        assert staff_data['conversion_rate'] > 0  # 1 contact with decision / 1 total contact
+        staff_data = next(u for u in response.data["users"] if u["email"] == staff.email)
+        assert "conversion_rate" in staff_data
+        assert isinstance(staff_data["conversion_rate"], (int, float))
+        assert staff_data["conversion_rate"] > 0  # 1 contact with decision / 1 total contact
 
 
 @pytest.mark.django_db
@@ -200,23 +201,23 @@ class TestConversionFunnel:
 
     def test_admin_can_access(self, admin_client):
         client, user = admin_client
-        response = client.get('/api/v1/insights/admin/conversion-funnel/')
+        response = client.get("/api/v1/insights/admin/conversion-funnel/")
         assert response.status_code == status.HTTP_200_OK
-        assert 'funnel' in response.data
-        assert 'total_contacts_in_pipeline' in response.data
+        assert "funnel" in response.data
+        assert "total_contacts_in_pipeline" in response.data
 
     def test_staff_cannot_access(self, authenticated_client):
         client, user = authenticated_client
-        response = client.get('/api/v1/insights/admin/conversion-funnel/')
+        response = client.get("/api/v1/insights/admin/conversion-funnel/")
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
     def test_funnel_uses_pipeline_stages(self, admin_client):
         client, user = admin_client
-        response = client.get('/api/v1/insights/admin/conversion-funnel/')
-        funnel = response.data['funnel']
+        response = client.get("/api/v1/insights/admin/conversion-funnel/")
+        funnel = response.data["funnel"]
         # Should have entries for pipeline stages (even if 0 count)
-        stage_names = [f['stage'] for f in funnel if f['stage'] is not None]
-        expected_stages = ['contact', 'meet', 'close', 'decision', 'thank', 'next_steps']
+        stage_names = [f["stage"] for f in funnel if f["stage"] is not None]
+        expected_stages = ["contact", "meet", "close", "decision", "thank", "next_steps"]
         for expected in expected_stages:
             assert expected in stage_names, f"Missing stage: {expected}"
 
@@ -227,25 +228,25 @@ class TestTeamActivity:
 
     def test_admin_can_access(self, admin_client):
         client, user = admin_client
-        response = client.get('/api/v1/insights/admin/team-activity/')
+        response = client.get("/api/v1/insights/admin/team-activity/")
         assert response.status_code == status.HTTP_200_OK
-        assert 'activities' in response.data
-        assert 'total_count' in response.data
+        assert "activities" in response.data
+        assert "total_count" in response.data
 
     def test_staff_cannot_access(self, authenticated_client):
         client, user = authenticated_client
-        response = client.get('/api/v1/insights/admin/team-activity/')
+        response = client.get("/api/v1/insights/admin/team-activity/")
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
     def test_limit_param(self, admin_client):
         client, user = admin_client
-        response = client.get('/api/v1/insights/admin/team-activity/?limit=10')
+        response = client.get("/api/v1/insights/admin/team-activity/?limit=10")
         assert response.status_code == status.HTTP_200_OK
 
     def test_invalid_limit_returns_default(self, admin_client):
         """Send ?limit=abc, verify 200 (not 500)."""
         client, user = admin_client
-        response = client.get('/api/v1/insights/admin/team-activity/?limit=abc')
+        response = client.get("/api/v1/insights/admin/team-activity/?limit=abc")
         assert response.status_code == status.HTTP_200_OK
 
 
@@ -254,30 +255,32 @@ class TestAdminEndpointPermissions:
     """Cross-cutting permission tests for all 5 admin endpoints."""
 
     ADMIN_ENDPOINTS = [
-        '/api/v1/insights/admin/dashboard-overview/',
-        '/api/v1/insights/admin/stalled-contacts/',
-        '/api/v1/insights/admin/user-performance/',
-        '/api/v1/insights/admin/conversion-funnel/',
-        '/api/v1/insights/admin/team-activity/',
+        "/api/v1/insights/admin/dashboard-overview/",
+        "/api/v1/insights/admin/stalled-contacts/",
+        "/api/v1/insights/admin/user-performance/",
+        "/api/v1/insights/admin/conversion-funnel/",
+        "/api/v1/insights/admin/team-activity/",
     ]
 
     def test_coach_cannot_access(self):
-        user = UserFactory(role='coach')
+        user = UserFactory(role="coach")
         client = APIClient()
         client.force_authenticate(user=user)
         for endpoint in self.ADMIN_ENDPOINTS:
             response = client.get(endpoint)
-            assert response.status_code == status.HTTP_403_FORBIDDEN, \
-                f"Coach user should get 403 from {endpoint}"
+            assert (
+                response.status_code == status.HTTP_403_FORBIDDEN
+            ), f"Coach user should get 403 from {endpoint}"
 
     def test_missionary_cannot_access(self):
-        user = UserFactory(role='missionary')
+        user = UserFactory(role="missionary")
         client = APIClient()
         client.force_authenticate(user=user)
         for endpoint in self.ADMIN_ENDPOINTS:
             response = client.get(endpoint)
-            assert response.status_code == status.HTTP_403_FORBIDDEN, \
-                f"Missionary user should get 403 from {endpoint}"
+            assert (
+                response.status_code == status.HTTP_403_FORBIDDEN
+            ), f"Missionary user should get 403 from {endpoint}"
 
 
 @pytest.mark.django_db
@@ -287,22 +290,23 @@ class TestDashboardOverviewDonationAmounts:
     def test_donation_amount_is_dollars(self, admin_client):
         """Verify donations_12m.total_amount is in dollars, not cents."""
         client, admin_user = admin_client
-        staff = UserFactory(role='missionary')
+        staff = UserFactory(role="missionary")
         contact = ContactFactory(owner=staff)
 
         # Create gift of $250.00 (25000 cents)
         from datetime import date, timedelta
+
         GiftFactory(
             donor_contact=contact,
             amount_cents=25000,
             gift_date=date.today() - timedelta(days=5),
         )
 
-        response = client.get('/api/v1/insights/admin/dashboard-overview/')
+        response = client.get("/api/v1/insights/admin/dashboard-overview/")
         assert response.status_code == status.HTTP_200_OK
         # Backend should return 250.0 (dollars), not 25000 (cents)
-        assert response.data['donations_12m']['total_amount'] == 250.0
-        assert response.data['donations_12m']['total_count'] == 1
+        assert response.data["donations_12m"]["total_amount"] == 250.0
+        assert response.data["donations_12m"]["total_count"] == 1
 
 
 @pytest.mark.django_db
@@ -312,25 +316,25 @@ class TestUserPerformanceBugFixes:
     def test_supervisor_users_included(self, admin_client):
         """Verify supervisor role users appear in user performance results."""
         client, admin_user = admin_client
-        supervisor = UserFactory(role='supervisor')
+        supervisor = UserFactory(role="supervisor")
         ContactFactory.create_batch(2, owner=supervisor)
 
-        response = client.get('/api/v1/insights/admin/user-performance/')
+        response = client.get("/api/v1/insights/admin/user-performance/")
         assert response.status_code == status.HTTP_200_OK
-        user_emails = [u['email'] for u in response.data['users']]
+        user_emails = [u["email"] for u in response.data["users"]]
         assert supervisor.email in user_emails
 
     def test_conversion_rate_uses_journal_contacts_denominator(self, admin_client):
         """Verify conversion rate denominator is contacts-in-journals, not all contacts."""
         client, admin_user = admin_client
-        staff = UserFactory(role='missionary')
+        staff = UserFactory(role="missionary")
 
         # Create 5 contacts, but only 2 in journals
         contacts = ContactFactory.create_batch(5, owner=staff)
         journal = Journal.objects.create(
-            name='Test Journal',
+            name="Test Journal",
             owner=staff,
-            goal_amount=Decimal('10000.00'),
+            goal_amount=Decimal("10000.00"),
         )
         jc1 = JournalContact.objects.create(journal=journal, contact=contacts[0])
         JournalContact.objects.create(journal=journal, contact=contacts[1])
@@ -338,35 +342,36 @@ class TestUserPerformanceBugFixes:
         # Add decision for 1 of the 2 journal contacts
         Decision.objects.create(
             journal_contact=jc1,
-            amount=Decimal('100.00'),
-            cadence='monthly',
-            status='active',
+            amount=Decimal("100.00"),
+            cadence="monthly",
+            status="active",
         )
 
-        response = client.get('/api/v1/insights/admin/user-performance/')
+        response = client.get("/api/v1/insights/admin/user-performance/")
         assert response.status_code == status.HTTP_200_OK
-        staff_data = next(u for u in response.data['users'] if u['email'] == staff.email)
+        staff_data = next(u for u in response.data["users"] if u["email"] == staff.email)
 
         # Conversion rate should be 1/2 = 50.0%, not 1/5 = 20.0%
-        assert staff_data['conversion_rate'] == 50.0
+        assert staff_data["conversion_rate"] == 50.0
 
     def test_donation_total_is_dollars(self, admin_client):
         """Verify total_donations in user performance is in dollars."""
         client, admin_user = admin_client
-        staff = UserFactory(role='missionary')
+        staff = UserFactory(role="missionary")
         contact = ContactFactory(owner=staff)
 
         from datetime import date, timedelta
+
         GiftFactory(
             donor_contact=contact,
             amount_cents=50000,  # $500.00
             gift_date=date.today() - timedelta(days=5),
         )
 
-        response = client.get('/api/v1/insights/admin/user-performance/')
+        response = client.get("/api/v1/insights/admin/user-performance/")
         assert response.status_code == status.HTTP_200_OK
-        staff_data = next(u for u in response.data['users'] if u['email'] == staff.email)
-        assert staff_data['total_donations'] == 500.0
+        staff_data = next(u for u in response.data["users"] if u["email"] == staff.email)
+        assert staff_data["total_donations"] == 500.0
 
 
 @pytest.mark.django_db
@@ -376,41 +381,42 @@ class TestConversionFunnelBugFixes:
     def test_no_activity_contacts_excluded_from_total(self, admin_client):
         """Verify contacts with no stage events don't inflate total_contacts_in_pipeline."""
         client, admin_user = admin_client
-        staff = UserFactory(role='missionary')
+        staff = UserFactory(role="missionary")
         contact1 = ContactFactory(owner=staff)
         contact2 = ContactFactory(owner=staff)
 
         journal = Journal.objects.create(
-            name='Test Journal',
+            name="Test Journal",
             owner=staff,
-            goal_amount=Decimal('10000.00'),
+            goal_amount=Decimal("10000.00"),
         )
         jc1 = JournalContact.objects.create(journal=journal, contact=contact1)
         jc2 = JournalContact.objects.create(journal=journal, contact=contact2)
 
         # Only jc1 gets a stage event; jc2 has no activity
         from apps.journals.models import JournalStageEvent, PipelineStage
+
         JournalStageEvent.objects.create(
             journal_contact=jc1,
             stage=PipelineStage.CONTACT,
         )
 
-        response = client.get('/api/v1/insights/admin/conversion-funnel/')
+        response = client.get("/api/v1/insights/admin/conversion-funnel/")
         assert response.status_code == status.HTTP_200_OK
         # total should be 1 (only jc1 with a stage event), not 2
-        assert response.data['total_contacts_in_pipeline'] == 1
+        assert response.data["total_contacts_in_pipeline"] == 1
         # no_activity_count should be 1 (jc2)
-        assert response.data['no_activity_count'] == 1
+        assert response.data["no_activity_count"] == 1
 
     def test_funnel_percentages_sum_to_100(self, admin_client):
         """Verify funnel stage percentages sum to approximately 100%."""
         client, admin_user = admin_client
-        staff = UserFactory(role='missionary')
+        staff = UserFactory(role="missionary")
 
         journal = Journal.objects.create(
-            name='Test Journal',
+            name="Test Journal",
             owner=staff,
-            goal_amount=Decimal('10000.00'),
+            goal_amount=Decimal("10000.00"),
         )
         from apps.journals.models import JournalStageEvent, PipelineStage
 
@@ -420,7 +426,7 @@ class TestConversionFunnelBugFixes:
             jc = JournalContact.objects.create(journal=journal, contact=contact)
             JournalStageEvent.objects.create(journal_contact=jc, stage=stage)
 
-        response = client.get('/api/v1/insights/admin/conversion-funnel/')
+        response = client.get("/api/v1/insights/admin/conversion-funnel/")
         assert response.status_code == status.HTTP_200_OK
-        total_pct = sum(f['percentage'] for f in response.data['funnel'])
+        total_pct = sum(f["percentage"] for f in response.data["funnel"])
         assert abs(total_pct - 100.0) < 1.0  # Allow for rounding

--- a/apps/insights/views.py
+++ b/apps/insights/views.py
@@ -47,12 +47,12 @@ from apps.insights.services import (
     get_follow_ups,
     get_late_donations,
     get_monthly_commitments,
+    get_single_user_performance,
     get_stage_contacts,
     get_stalled_contacts,
     get_team_activity,
     get_team_trends,
     get_transactions,
-    get_single_user_performance,
     get_user_drilldown,
     get_user_journals,
     get_user_performance,
@@ -613,9 +613,7 @@ class OrgSettingsView(APIView):
         # update; the lock cost is bounded by how long the write takes.
         with transaction.atomic():
             OrgSettings.get_solo()  # ensure row exists before locking it
-            instance = OrgSettings.objects.select_for_update().get(
-                pk=OrgSettings._solo_uuid()
-            )
+            instance = OrgSettings.objects.select_for_update().get(pk=OrgSettings._solo_uuid())
             if "annual_goal_cents" in serializer.validated_data:
                 instance.annual_goal_cents = serializer.validated_data["annual_goal_cents"]
                 instance.save(update_fields=["annual_goal_cents", "updated_at"])

--- a/apps/insights/views.py
+++ b/apps/insights/views.py
@@ -219,7 +219,10 @@ class DashboardOverviewView(APIView):
     @extend_schema(
         tags=["insights"],
         summary="Get dashboard overview (admin only)",
-        description="Cross-user aggregation for admin dashboard: total contacts, active journals, stalled count, conversion rate, donation summary.",
+        description=(
+            "Cross-user aggregation for admin dashboard: total contacts, "
+            "active journals, stalled count, conversion rate, donation summary."
+        ),
         parameters=[
             OpenApiParameter(
                 name="date_from", description="Filter start date (YYYY-MM-DD)", type=str
@@ -313,7 +316,9 @@ class UserPerformanceView(APIView):
     @extend_schema(
         tags=["insights"],
         summary="Get user performance metrics (admin only)",
-        description="Per-missionary: total contacts, active journals, decisions logged, donation totals.",
+        description=(
+            "Per-missionary: total contacts, active journals, decisions logged, " "donation totals."
+        ),
         responses={200: UserPerformanceResponseSerializer},
     )
     def get(self, request):
@@ -353,7 +358,10 @@ class ConversionFunnelView(APIView):
     @extend_schema(
         tags=["insights"],
         summary="Get conversion funnel (admin only)",
-        description="Pipeline stage distribution with counts and percentages using Journal 6-stage pipeline.",
+        description=(
+            "Pipeline stage distribution with counts and percentages "
+            "using Journal 6-stage pipeline."
+        ),
         parameters=[
             OpenApiParameter(
                 name="date_from", description="Filter start date (YYYY-MM-DD)", type=str
@@ -421,7 +429,10 @@ class TeamTrendsView(APIView):
     @extend_schema(
         tags=["insights"],
         summary="Get team trends (admin only)",
-        description="Weekly aggregated metrics: decisions logged, donations received, stage progressions.",
+        description=(
+            "Weekly aggregated metrics: decisions logged, donations received, "
+            "stage progressions."
+        ),
         parameters=[
             OpenApiParameter(
                 name="weeks", description="Number of weeks (default: 12, min: 1, max: 52)", type=int
@@ -459,7 +470,10 @@ class UserTrendsView(APIView):
     @extend_schema(
         tags=["insights"],
         summary="Get user trends (admin only)",
-        description="Weekly aggregated metrics for a specific user: decisions logged, donations received, stage progressions.",
+        description=(
+            "Weekly aggregated metrics for a specific user: decisions logged, "
+            "donations received, stage progressions."
+        ),
         parameters=[
             OpenApiParameter(
                 name="user_id", description="User ID (required)", type=str, required=True
@@ -492,7 +506,10 @@ class UserJournalsView(APIView):
     @extend_schema(
         tags=["insights"],
         summary="Get user journals (admin only)",
-        description="Journal list with member count, decision count, and active member count for a specific user.",
+        description=(
+            "Journal list with member count, decision count, and active member "
+            "count for a specific user."
+        ),
         parameters=[
             OpenApiParameter(
                 name="user_id", description="User ID (required)", type=str, required=True
@@ -521,7 +538,11 @@ class StageContactsView(APIView):
     @extend_schema(
         tags=["insights"],
         summary="Get stage contacts (admin only)",
-        description='Contacts currently in a specific pipeline stage. Pass stage parameter (contact, meet, close, decision, thank, next_steps) or "none" for no activity.',
+        description=(
+            "Contacts currently in a specific pipeline stage. Pass stage parameter "
+            '(contact, meet, close, decision, thank, next_steps) or "none" '
+            "for no activity."
+        ),
         parameters=[
             OpenApiParameter(
                 name="stage", description="Pipeline stage (required)", type=str, required=True
@@ -559,7 +580,10 @@ class UserDrilldownView(APIView):
     @extend_schema(
         tags=["insights"],
         summary="Get user drilldown (admin only)",
-        description="Combined user summary with key stats, stalled count, and recent journals for quick inspection.",
+        description=(
+            "Combined user summary with key stats, stalled count, and recent "
+            "journals for quick inspection."
+        ),
         parameters=[
             OpenApiParameter(
                 name="user_id", description="User ID (required)", type=str, required=True

--- a/apps/journals/admin.py
+++ b/apps/journals/admin.py
@@ -8,19 +8,19 @@ from apps.journals.models import Journal, JournalContact, JournalStageEvent
 
 @admin.register(Journal)
 class JournalAdmin(admin.ModelAdmin):
-    list_display = ['name', 'owner', 'goal_amount', 'deadline', 'is_archived', 'created_at']
-    list_filter = ['is_archived', 'created_at']
-    search_fields = ['name', 'owner__email']
-    readonly_fields = ['id', 'created_at', 'updated_at']
+    list_display = ["name", "owner", "goal_amount", "deadline", "is_archived", "created_at"]
+    list_filter = ["is_archived", "created_at"]
+    search_fields = ["name", "owner__email"]
+    readonly_fields = ["id", "created_at", "updated_at"]
 
 
 @admin.register(JournalContact)
 class JournalContactAdmin(admin.ModelAdmin):
-    list_display = ['journal', 'contact', 'created_at']
-    list_filter = ['created_at']
+    list_display = ["journal", "contact", "created_at"]
+    list_filter = ["created_at"]
 
 
 @admin.register(JournalStageEvent)
 class JournalStageEventAdmin(admin.ModelAdmin):
-    list_display = ['journal_contact', 'stage', 'event_type', 'created_at']
-    list_filter = ['stage', 'event_type', 'created_at']
+    list_display = ["journal_contact", "stage", "event_type", "created_at"]
+    list_filter = ["stage", "event_type", "created_at"]

--- a/apps/journals/apps.py
+++ b/apps/journals/apps.py
@@ -5,8 +5,8 @@ from django.apps import AppConfig
 
 
 class JournalsConfig(AppConfig):
-    name = 'apps.journals'
-    verbose_name = 'Journals'
+    name = "apps.journals"
+    verbose_name = "Journals"
 
     def ready(self):
         import apps.journals.signals  # noqa: F401

--- a/apps/journals/export_views.py
+++ b/apps/journals/export_views.py
@@ -4,9 +4,10 @@ CSV export view for journals with FilterSet-based filtering.
 import csv
 from datetime import datetime
 
+from django.http import StreamingHttpResponse
+
 from rest_framework import permissions
 from rest_framework.views import APIView
-from django.http import StreamingHttpResponse
 
 from apps.core.permissions import get_visible_user_ids
 from apps.imports.services import sanitize_csv_value
@@ -16,6 +17,7 @@ from apps.journals.models import Journal
 
 class Echo:
     """Pseudo-buffer for csv.writer to write to StreamingHttpResponse."""
+
     def write(self, value):
         return value
 
@@ -25,6 +27,7 @@ class JournalExportCSVView(APIView):
     GET: Export journals as filtered CSV file.
     Applies the same JournalFilterSet as the list endpoint.
     """
+
     permission_classes = [permissions.IsAuthenticated]
 
     def get(self, request):
@@ -35,44 +38,48 @@ class JournalExportCSVView(APIView):
         queryset = Journal.objects.filter(owner_id__in=visible)
 
         # Exclude archived by default unless is_archived filter present
-        if 'is_archived' not in request.query_params:
+        if "is_archived" not in request.query_params:
             queryset = queryset.filter(is_archived=False)
 
         # Apply FilterSet (same as list endpoint)
         filterset = JournalFilterSet(request.query_params, queryset=queryset)
-        filtered_qs = filterset.qs.select_related('owner')[:10000]
+        filtered_qs = filterset.qs.select_related("owner")[:10000]
 
-        filename = f'journals_{datetime.now().date().isoformat()}.csv'
+        filename = f"journals_{datetime.now().date().isoformat()}.csv"
 
         def generate_csv():
             pseudo_buffer = Echo()
             writer = csv.writer(pseudo_buffer)
 
             # Header
-            yield writer.writerow([
-                'Name',
-                'Goal Amount',
-                'Deadline',
-                'Archived',
-                'Owner',
-                'Created',
-            ])
+            yield writer.writerow(
+                [
+                    "Name",
+                    "Goal Amount",
+                    "Deadline",
+                    "Archived",
+                    "Owner",
+                    "Created",
+                ]
+            )
 
             # Data rows
             for journal in filtered_qs:
-                owner_name = ''
+                owner_name = ""
                 if journal.owner:
                     owner_name = journal.owner.full_name
 
-                yield writer.writerow([
-                    sanitize_csv_value(journal.name),
-                    str(journal.goal_amount or 0),
-                    journal.deadline or '',
-                    'Yes' if journal.is_archived else 'No',
-                    sanitize_csv_value(owner_name),
-                    journal.created_at.date().isoformat() if journal.created_at else '',
-                ])
+                yield writer.writerow(
+                    [
+                        sanitize_csv_value(journal.name),
+                        str(journal.goal_amount or 0),
+                        journal.deadline or "",
+                        "Yes" if journal.is_archived else "No",
+                        sanitize_csv_value(owner_name),
+                        journal.created_at.date().isoformat() if journal.created_at else "",
+                    ]
+                )
 
-        response = StreamingHttpResponse(generate_csv(), content_type='text/csv')
-        response['Content-Disposition'] = f'attachment; filename="{filename}"'
+        response = StreamingHttpResponse(generate_csv(), content_type="text/csv")
+        response["Content-Disposition"] = f'attachment; filename="{filename}"'
         return response

--- a/apps/journals/filters.py
+++ b/apps/journals/filters.py
@@ -5,11 +5,11 @@ from apps.journals.models import Journal
 
 
 class JournalFilterSet(django_filters.FilterSet):
-    deadline_after = django_filters.DateFilter(field_name='deadline', lookup_expr='gte')
-    deadline_before = django_filters.DateFilter(field_name='deadline', lookup_expr='lte')
-    owner = django_filters.UUIDFilter(field_name='owner_id')
+    deadline_after = django_filters.DateFilter(field_name="deadline", lookup_expr="gte")
+    deadline_before = django_filters.DateFilter(field_name="deadline", lookup_expr="lte")
+    owner = django_filters.UUIDFilter(field_name="owner_id")
 
     class Meta:
         model = Journal
-        fields = ['deadline_after', 'deadline_before', 'owner']
+        fields = ["deadline_after", "deadline_before", "owner"]
         # NOTE: is_archived is handled in get_queryset(), NOT here — preserves archived-by-default behavior

--- a/apps/journals/filters.py
+++ b/apps/journals/filters.py
@@ -12,4 +12,5 @@ class JournalFilterSet(django_filters.FilterSet):
     class Meta:
         model = Journal
         fields = ["deadline_after", "deadline_before", "owner"]
-        # NOTE: is_archived is handled in get_queryset(), NOT here — preserves archived-by-default behavior
+        # NOTE: is_archived is handled in get_queryset(), NOT here —
+        # preserves archived-by-default behavior

--- a/apps/journals/serializers.py
+++ b/apps/journals/serializers.py
@@ -4,6 +4,7 @@ Serializers for Journal models.
 from decimal import Decimal
 
 from django.db import IntegrityError, transaction
+
 from rest_framework import serializers
 
 from apps.journals.models import (
@@ -20,50 +21,63 @@ class JournalListSerializer(serializers.ModelSerializer):
     """
     Serializer for journal list view (minimal fields).
     """
-    owner_name = serializers.CharField(source='owner.full_name', read_only=True)
+
+    owner_name = serializers.CharField(source="owner.full_name", read_only=True)
 
     class Meta:
         model = Journal
         fields = [
-            'id', 'owner', 'owner_name', 'name', 'goal_amount', 'deadline',
-            'is_archived', 'created_at', 'updated_at'
+            "id",
+            "owner",
+            "owner_name",
+            "name",
+            "goal_amount",
+            "deadline",
+            "is_archived",
+            "created_at",
+            "updated_at",
         ]
-        read_only_fields = ['id', 'owner', 'created_at', 'updated_at', 'is_archived']
+        read_only_fields = ["id", "owner", "created_at", "updated_at", "is_archived"]
 
 
 class JournalDetailSerializer(serializers.ModelSerializer):
     """
     Serializer for journal detail view (all fields).
     """
+
     owner = serializers.PrimaryKeyRelatedField(read_only=True)
 
     class Meta:
         model = Journal
         fields = [
-            'id', 'name', 'goal_amount', 'deadline',
-            'is_archived', 'archived_at', 'owner',
-            'created_at', 'updated_at'
+            "id",
+            "name",
+            "goal_amount",
+            "deadline",
+            "is_archived",
+            "archived_at",
+            "owner",
+            "created_at",
+            "updated_at",
         ]
-        read_only_fields = [
-            'id', 'owner', 'is_archived', 'archived_at',
-            'created_at', 'updated_at'
-        ]
+        read_only_fields = ["id", "owner", "is_archived", "archived_at", "created_at", "updated_at"]
 
 
 class JournalCreateSerializer(serializers.ModelSerializer):
     """
     Serializer for creating journals.
     """
+
     class Meta:
         model = Journal
-        fields = ['id', 'name', 'goal_amount', 'deadline']
-        read_only_fields = ['id']
+        fields = ["id", "name", "goal_amount", "deadline"]
+        read_only_fields = ["id"]
 
     def create(self, validated_data):
         # Set owner to current user
-        request = self.context.get('request')
+        request = self.context.get("request")
         if request and request.user.is_authenticated:
-            validated_data['owner'] = request.user
+            validated_data["owner"] = request.user
 
         journal = Journal.objects.create(**validated_data)
         return journal
@@ -74,20 +88,27 @@ class JournalContactSerializer(serializers.ModelSerializer):
     Serializer for journal contact membership with ownership validation.
     Includes stage_events summary for grid display.
     """
-    contact_name = serializers.CharField(source='contact.full_name', read_only=True)
-    contact_email = serializers.EmailField(source='contact.email', read_only=True)
-    contact_status = serializers.CharField(source='contact.status', read_only=True)
+
+    contact_name = serializers.CharField(source="contact.full_name", read_only=True)
+    contact_email = serializers.EmailField(source="contact.email", read_only=True)
+    contact_status = serializers.CharField(source="contact.status", read_only=True)
     stage_events = serializers.SerializerMethodField()
     decision = serializers.SerializerMethodField()
 
     class Meta:
         model = JournalContact
         fields = [
-            'id', 'journal', 'contact', 'contact_name',
-            'contact_email', 'contact_status', 'stage_events',
-            'decision', 'created_at'
+            "id",
+            "journal",
+            "contact",
+            "contact_name",
+            "contact_email",
+            "contact_status",
+            "stage_events",
+            "decision",
+            "created_at",
         ]
-        read_only_fields = ['id', 'created_at']
+        read_only_fields = ["id", "created_at"]
 
     def get_stage_events(self, obj):
         """
@@ -96,10 +117,10 @@ class JournalContactSerializer(serializers.ModelSerializer):
         """
         from apps.journals.models import PipelineStage
 
-        events = getattr(obj, 'prefetched_stage_events', None)
+        events = getattr(obj, "prefetched_stage_events", None)
         if events is None:
             # Fallback if prefetch not available (e.g., single object retrieval)
-            events = list(obj.stage_events.order_by('-created_at'))
+            events = list(obj.stage_events.order_by("-created_at"))
 
         # Group by stage in Python
         by_stage = {}
@@ -115,27 +136,27 @@ class JournalContactSerializer(serializers.ModelSerializer):
             if stage_events:
                 last = stage_events[0]  # Already ordered by -created_at from prefetch
                 summaries[stage] = {
-                    'has_events': True,
-                    'event_count': len(stage_events),
-                    'last_event_date': last.created_at.isoformat(),
-                    'last_event_type': last.event_type,
-                    'last_event_notes': last.notes[:100] if last.notes else None,
+                    "has_events": True,
+                    "event_count": len(stage_events),
+                    "last_event_date": last.created_at.isoformat(),
+                    "last_event_type": last.event_type,
+                    "last_event_notes": last.notes[:100] if last.notes else None,
                 }
             else:
                 summaries[stage] = {
-                    'has_events': False,
-                    'event_count': 0,
-                    'last_event_date': None,
-                    'last_event_type': None,
-                    'last_event_notes': None,
+                    "has_events": False,
+                    "event_count": 0,
+                    "last_event_date": None,
+                    "last_event_type": None,
+                    "last_event_notes": None,
                 }
 
             # Enrich scheduled stage summary with scheduled_date from metadata
-            if stage == 'scheduled' and stage_events:
+            if stage == "scheduled" and stage_events:
                 last_metadata = stage_events[0].metadata or {}
-                summaries[stage]['scheduled_date'] = last_metadata.get('scheduled_date')
-            elif stage == 'scheduled':
-                summaries[stage]['scheduled_date'] = None
+                summaries[stage]["scheduled_date"] = last_metadata.get("scheduled_date")
+            elif stage == "scheduled":
+                summaries[stage]["scheduled_date"] = None
 
         return summaries
 
@@ -144,7 +165,7 @@ class JournalContactSerializer(serializers.ModelSerializer):
         Get current decision summary for grid display.
         Uses prefetched data from view queryset to avoid N+1 queries (QAL-05).
         """
-        decisions = getattr(obj, 'prefetched_decisions', None)
+        decisions = getattr(obj, "prefetched_decisions", None)
         if decisions is None:
             # Fallback if prefetch not available
             decision = obj.decisions.first()
@@ -153,11 +174,11 @@ class JournalContactSerializer(serializers.ModelSerializer):
 
         if decision:
             return {
-                'id': str(decision.id),
-                'amount': str(decision.amount),
-                'cadence': decision.cadence,
-                'status': decision.status,
-                'monthly_equivalent': str(decision.monthly_equivalent),
+                "id": str(decision.id),
+                "amount": str(decision.amount),
+                "cadence": decision.cadence,
+                "status": decision.status,
+                "monthly_equivalent": str(decision.monthly_equivalent),
             }
         return None
 
@@ -165,25 +186,25 @@ class JournalContactSerializer(serializers.ModelSerializer):
         """
         Validate that the user owns both the journal and contact.
         """
-        request = self.context.get('request')
+        request = self.context.get("request")
         if not request or not request.user.is_authenticated:
-            raise serializers.ValidationError('Authentication required')
+            raise serializers.ValidationError("Authentication required")
 
         user = request.user
-        journal = attrs.get('journal')
-        contact = attrs.get('contact')
+        journal = attrs.get("journal")
+        contact = attrs.get("contact")
 
         # Check journal ownership (unless admin)
-        if user.role != 'admin' and journal.owner != user:
-            raise serializers.ValidationError({
-                'journal': 'You do not have permission to add contacts to this journal.'
-            })
+        if user.role != "admin" and journal.owner != user:
+            raise serializers.ValidationError(
+                {"journal": "You do not have permission to add contacts to this journal."}
+            )
 
         # Check contact ownership (unless admin)
-        if user.role != 'admin' and contact.owner != user:
-            raise serializers.ValidationError({
-                'contact': 'You do not have permission to use this contact.'
-            })
+        if user.role != "admin" and contact.owner != user:
+            raise serializers.ValidationError(
+                {"contact": "You do not have permission to use this contact."}
+            )
 
         return attrs
 
@@ -195,48 +216,54 @@ class JournalStageEventSerializer(serializers.ModelSerializer):
     Accepts either `journal_contact` (existing membership) or `contact_id`
     (auto-resolves/creates membership in the user's first active journal).
     """
+
     contact_id = serializers.UUIDField(write_only=True, required=False)
 
     class Meta:
         model = JournalStageEvent
         fields = [
-            'id', 'journal_contact', 'contact_id', 'stage', 'event_type',
-            'notes', 'metadata', 'triggered_by', 'created_at'
+            "id",
+            "journal_contact",
+            "contact_id",
+            "stage",
+            "event_type",
+            "notes",
+            "metadata",
+            "triggered_by",
+            "created_at",
         ]
-        read_only_fields = ['id', 'triggered_by', 'created_at']
+        read_only_fields = ["id", "triggered_by", "created_at"]
         extra_kwargs = {
-            'journal_contact': {'required': False},
+            "journal_contact": {"required": False},
         }
 
     def validate(self, attrs):
-        if not attrs.get('journal_contact') and not attrs.get('contact_id'):
-            raise serializers.ValidationError(
-                "Either journal_contact or contact_id is required."
-            )
+        if not attrs.get("journal_contact") and not attrs.get("contact_id"):
+            raise serializers.ValidationError("Either journal_contact or contact_id is required.")
 
         # Validate scheduled stage requires scheduled_date in metadata
-        if attrs.get('stage') == 'scheduled':
-            metadata = attrs.get('metadata') or {}
-            if not metadata.get('scheduled_date'):
-                raise serializers.ValidationError({
-                    'metadata': 'scheduled_date is required when stage is scheduled.'
-                })
+        if attrs.get("stage") == "scheduled":
+            metadata = attrs.get("metadata") or {}
+            if not metadata.get("scheduled_date"):
+                raise serializers.ValidationError(
+                    {"metadata": "scheduled_date is required when stage is scheduled."}
+                )
 
         return attrs
 
     def create(self, validated_data):
-        request = self.context.get('request')
+        request = self.context.get("request")
         user = request.user if request else None
 
-        contact_id = validated_data.pop('contact_id', None)
+        contact_id = validated_data.pop("contact_id", None)
 
-        if not validated_data.get('journal_contact') and contact_id:
+        if not validated_data.get("journal_contact") and contact_id:
             raise serializers.ValidationError(
                 {"contact_id": "journal_contact is required. Use the journal grid to log events."}
             )
 
         if user and user.is_authenticated:
-            validated_data['triggered_by'] = user
+            validated_data["triggered_by"] = user
 
         return JournalStageEvent.objects.create(**validated_data)
 
@@ -245,35 +272,38 @@ class DecisionSerializer(serializers.ModelSerializer):
     """
     Serializer for decision CRUD with atomic history tracking.
     """
-    monthly_equivalent = serializers.DecimalField(
-        max_digits=10,
-        decimal_places=2,
-        read_only=True
-    )
+
+    monthly_equivalent = serializers.DecimalField(max_digits=10, decimal_places=2, read_only=True)
 
     class Meta:
         model = Decision
         fields = [
-            'id', 'journal_contact', 'amount', 'cadence', 'status',
-            'monthly_equivalent', 'created_at', 'updated_at'
+            "id",
+            "journal_contact",
+            "amount",
+            "cadence",
+            "status",
+            "monthly_equivalent",
+            "created_at",
+            "updated_at",
         ]
-        read_only_fields = ['id', 'monthly_equivalent', 'created_at', 'updated_at']
+        read_only_fields = ["id", "monthly_equivalent", "created_at", "updated_at"]
 
     def validate_journal_contact(self, value):
         """
         Validate that the user owns the journal_contact's journal.
         """
-        request = self.context.get('request')
+        request = self.context.get("request")
         if not request or not request.user.is_authenticated:
-            raise serializers.ValidationError('Authentication required')
+            raise serializers.ValidationError("Authentication required")
 
         user = request.user
         journal = value.journal
 
         # Check journal ownership (unless admin)
-        if user.role != 'admin' and journal.owner != user:
+        if user.role != "admin" and journal.owner != user:
             raise serializers.ValidationError(
-                'You do not have permission to create decisions for this journal contact.'
+                "You do not have permission to create decisions for this journal contact."
             )
 
         return value
@@ -287,9 +317,9 @@ class DecisionSerializer(serializers.ModelSerializer):
                 decision = Decision.objects.create(**validated_data)
                 return decision
         except IntegrityError as e:
-            if 'unique' in str(e).lower():
+            if "unique" in str(e).lower():
                 raise serializers.ValidationError(
-                    'A decision already exists for this contact in this journal.'
+                    "A decision already exists for this contact in this journal."
                 )
             raise
 
@@ -298,13 +328,13 @@ class DecisionSerializer(serializers.ModelSerializer):
         Update decision with atomic history tracking.
         Before updating, create DecisionHistory record with old values.
         """
-        request = self.context.get('request')
+        request = self.context.get("request")
         user = request.user if request and request.user.is_authenticated else None
 
         with transaction.atomic():
             # Build changed_fields dict
             changed_fields = {}
-            for field in ['amount', 'cadence', 'status']:
+            for field in ["amount", "cadence", "status"]:
                 if field in validated_data:
                     old_value = getattr(instance, field)
                     new_value = validated_data[field]
@@ -320,9 +350,7 @@ class DecisionSerializer(serializers.ModelSerializer):
             # Create history record if changes exist
             if changed_fields:
                 DecisionHistory.objects.create(
-                    decision=instance,
-                    changed_fields=changed_fields,
-                    changed_by=user
+                    decision=instance, changed_fields=changed_fields, changed_by=user
                 )
 
             # Update instance fields
@@ -337,16 +365,29 @@ class DecisionHistorySerializer(serializers.ModelSerializer):
     """
     Read-only serializer for decision history records.
     """
+
     changed_by_email = serializers.EmailField(
-        source='changed_by.email',
-        read_only=True,
-        default=None
+        source="changed_by.email", read_only=True, default=None
     )
 
     class Meta:
         model = DecisionHistory
-        fields = ['id', 'decision', 'changed_fields', 'changed_by', 'changed_by_email', 'created_at']
-        read_only_fields = ['id', 'decision', 'changed_fields', 'changed_by', 'changed_by_email', 'created_at']
+        fields = [
+            "id",
+            "decision",
+            "changed_fields",
+            "changed_by",
+            "changed_by_email",
+            "created_at",
+        ]
+        read_only_fields = [
+            "id",
+            "decision",
+            "changed_fields",
+            "changed_by",
+            "changed_by_email",
+            "created_at",
+        ]
 
 
 class NextStepSerializer(serializers.ModelSerializer):
@@ -355,18 +396,25 @@ class NextStepSerializer(serializers.ModelSerializer):
     class Meta:
         model = NextStep
         fields = [
-            'id', 'journal_contact', 'title', 'notes',
-            'due_date', 'completed', 'completed_at', 'order',
-            'created_at', 'updated_at'
+            "id",
+            "journal_contact",
+            "title",
+            "notes",
+            "due_date",
+            "completed",
+            "completed_at",
+            "order",
+            "created_at",
+            "updated_at",
         ]
-        read_only_fields = ['id', 'completed_at', 'created_at', 'updated_at']
+        read_only_fields = ["id", "completed_at", "created_at", "updated_at"]
 
     def validate_journal_contact(self, value):
         """Ensure user owns the journal that contains this contact."""
-        request = self.context.get('request')
+        request = self.context.get("request")
         if request and request.user.is_authenticated:
             user = request.user
-            if user.role != 'admin' and value.journal.owner != user:
+            if user.role != "admin" and value.journal.owner != user:
                 raise serializers.ValidationError(
                     "You don't have permission to add next steps to this journal contact."
                 )
@@ -376,8 +424,8 @@ class NextStepSerializer(serializers.ModelSerializer):
         """Handle completed timestamp when marking complete."""
         from django.utils import timezone
 
-        if validated_data.get('completed') and not instance.completed:
-            validated_data['completed_at'] = timezone.now()
-        elif 'completed' in validated_data and not validated_data['completed']:
-            validated_data['completed_at'] = None
+        if validated_data.get("completed") and not instance.completed:
+            validated_data["completed_at"] = timezone.now()
+        elif "completed" in validated_data and not validated_data["completed"]:
+            validated_data["completed_at"] = None
         return super().update(instance, validated_data)

--- a/apps/journals/signals.py
+++ b/apps/journals/signals.py
@@ -23,16 +23,13 @@ def handle_journal_created(sender, instance, created, **kwargs):
         Event.objects.create(
             user=instance.owner,
             event_type=EventType.JOURNAL_CREATED,
-            title=f'Journal created: {instance.name}',
-            message=f'Goal: ${instance.goal_amount}',
+            title=f"Journal created: {instance.name}",
+            message=f"Goal: ${instance.goal_amount}",
             severity=EventSeverity.INFO,
-            metadata={
-                'journal_id': str(instance.id),
-                'goal_amount': str(instance.goal_amount)
-            }
+            metadata={"journal_id": str(instance.id), "goal_amount": str(instance.goal_amount)},
         )
     except Exception as e:
-        logger.warning(f'Failed to create JOURNAL_CREATED event: {e}')
+        logger.warning(f"Failed to create JOURNAL_CREATED event: {e}")
 
 
 @receiver(post_save, sender=JournalStageEvent)
@@ -49,15 +46,15 @@ def handle_stage_event_created(sender, instance, created, **kwargs):
         Event.objects.create(
             user=journal.owner,
             event_type=EventType.JOURNAL_STAGE_EVENT,
-            title=f'{instance.get_stage_display()}: {instance.get_event_type_display()}',
-            message=instance.notes[:200] if instance.notes else '',
+            title=f"{instance.get_stage_display()}: {instance.get_event_type_display()}",
+            message=instance.notes[:200] if instance.notes else "",
             severity=EventSeverity.INFO,
             metadata={
-                'journal_id': str(journal.id),
-                'stage': instance.stage,
-                'event_type': instance.event_type,
-                'journal_contact_id': str(instance.journal_contact_id)
-            }
+                "journal_id": str(journal.id),
+                "stage": instance.stage,
+                "event_type": instance.event_type,
+                "journal_contact_id": str(instance.journal_contact_id),
+            },
         )
     except Exception as e:
-        logger.warning(f'Failed to create JOURNAL_STAGE_EVENT event: {e}')
+        logger.warning(f"Failed to create JOURNAL_STAGE_EVENT event: {e}")

--- a/apps/journals/tests/test_decisions.py
+++ b/apps/journals/tests/test_decisions.py
@@ -14,6 +14,7 @@ from decimal import Decimal
 
 from django.contrib.auth import get_user_model
 from django.urls import reverse
+
 from rest_framework import status
 from rest_framework.test import APITestCase
 
@@ -30,70 +31,57 @@ class DecisionAPITests(APITestCase):
         """Set up test data: two users, journals, contacts, and journal_contacts."""
         # Create two users
         self.user_a = User.objects.create_user(
-            email='usera@example.com',
-            password='password123',
-            first_name='User',
-            last_name='A',
-            role='missionary'
+            email="usera@example.com",
+            password="password123",
+            first_name="User",
+            last_name="A",
+            role="missionary",
         )
         self.user_b = User.objects.create_user(
-            email='userb@example.com',
-            password='password123',
-            first_name='User',
-            last_name='B',
-            role='missionary'
+            email="userb@example.com",
+            password="password123",
+            first_name="User",
+            last_name="B",
+            role="missionary",
         )
 
         # Create journal owned by user_a
         self.journal = Journal.objects.create(
-            owner=self.user_a,
-            name='Q1 2025 Campaign',
-            goal_amount=50000.00
+            owner=self.user_a, name="Q1 2025 Campaign", goal_amount=50000.00
         )
 
         # Create contacts owned by user_a
         self.contact_a1 = Contact.objects.create(
             owner=self.user_a,
-            first_name='Alice',
-            last_name='Anderson',
-            email='alice.anderson@example.com',
-            status='prospect'
+            first_name="Alice",
+            last_name="Anderson",
+            email="alice.anderson@example.com",
+            status="prospect",
         )
         self.contact_a2 = Contact.objects.create(
             owner=self.user_a,
-            first_name='Bob',
-            last_name='Brown',
-            email='bob.brown@example.com',
-            status='donor'
+            first_name="Bob",
+            last_name="Brown",
+            email="bob.brown@example.com",
+            status="donor",
         )
 
         # Create journal_contacts
-        self.jc1 = JournalContact.objects.create(
-            journal=self.journal,
-            contact=self.contact_a1
-        )
-        self.jc2 = JournalContact.objects.create(
-            journal=self.journal,
-            contact=self.contact_a2
-        )
+        self.jc1 = JournalContact.objects.create(journal=self.journal, contact=self.contact_a1)
+        self.jc2 = JournalContact.objects.create(journal=self.journal, contact=self.contact_a2)
 
         # Create journal and contact for user_b
         self.journal_b = Journal.objects.create(
-            owner=self.user_b,
-            name='User B Journal',
-            goal_amount=30000.00
+            owner=self.user_b, name="User B Journal", goal_amount=30000.00
         )
         self.contact_b = Contact.objects.create(
             owner=self.user_b,
-            first_name='Charlie',
-            last_name='Clark',
-            email='charlie@example.com',
-            status='prospect'
+            first_name="Charlie",
+            last_name="Clark",
+            email="charlie@example.com",
+            status="prospect",
         )
-        self.jc_b = JournalContact.objects.create(
-            journal=self.journal_b,
-            contact=self.contact_b
-        )
+        self.jc_b = JournalContact.objects.create(journal=self.journal_b, contact=self.contact_b)
 
         # Default authentication to user_a
         self.client.force_authenticate(user=self.user_a)
@@ -102,147 +90,137 @@ class DecisionAPITests(APITestCase):
 
     def test_create_decision_success(self):
         """Test successfully creating a decision with all fields."""
-        url = reverse('journals:decision-list')
+        url = reverse("journals:decision-list")
         data = {
-            'journal_contact': str(self.jc1.id),
-            'amount': '100.00',
-            'cadence': 'monthly',
-            'status': 'pending'
+            "journal_contact": str(self.jc1.id),
+            "amount": "100.00",
+            "cadence": "monthly",
+            "status": "pending",
         }
 
-        response = self.client.post(url, data, format='json')
+        response = self.client.post(url, data, format="json")
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        self.assertIn('id', response.data)
-        self.assertEqual(str(response.data['journal_contact']), str(self.jc1.id))
-        self.assertEqual(str(response.data['amount']), '100.00')
-        self.assertEqual(response.data['cadence'], 'monthly')
-        self.assertEqual(response.data['status'], 'pending')
-        self.assertIn('monthly_equivalent', response.data)
+        self.assertIn("id", response.data)
+        self.assertEqual(str(response.data["journal_contact"]), str(self.jc1.id))
+        self.assertEqual(str(response.data["amount"]), "100.00")
+        self.assertEqual(response.data["cadence"], "monthly")
+        self.assertEqual(response.data["status"], "pending")
+        self.assertIn("monthly_equivalent", response.data)
         self.assertEqual(Decision.objects.count(), 1)
 
     def test_create_decision_all_cadences(self):
         """Test creating decisions with each cadence value."""
-        url = reverse('journals:decision-list')
+        url = reverse("journals:decision-list")
 
         # Create separate journal contacts for each test
         contacts = []
         for i in range(4):
             contact = Contact.objects.create(
                 owner=self.user_a,
-                first_name=f'Contact{i}',
-                last_name='Test',
-                email=f'contact{i}@example.com'
+                first_name=f"Contact{i}",
+                last_name="Test",
+                email=f"contact{i}@example.com",
             )
-            jc = JournalContact.objects.create(
-                journal=self.journal,
-                contact=contact
-            )
+            jc = JournalContact.objects.create(journal=self.journal, contact=contact)
             contacts.append(jc)
 
-        cadences = ['one_time', 'monthly', 'quarterly', 'annual']
+        cadences = ["one_time", "monthly", "quarterly", "annual"]
 
         for idx, cadence in enumerate(cadences):
-            response = self.client.post(url, {
-                'journal_contact': str(contacts[idx].id),
-                'amount': '100.00',
-                'cadence': cadence
-            }, format='json')
+            response = self.client.post(
+                url,
+                {"journal_contact": str(contacts[idx].id), "amount": "100.00", "cadence": cadence},
+                format="json",
+            )
 
             self.assertEqual(
                 response.status_code,
                 status.HTTP_201_CREATED,
-                f"Failed to create decision with cadence={cadence}"
+                f"Failed to create decision with cadence={cadence}",
             )
-            self.assertEqual(response.data['cadence'], cadence)
+            self.assertEqual(response.data["cadence"], cadence)
 
     def test_create_decision_all_statuses(self):
         """Test creating decisions with each status value."""
-        url = reverse('journals:decision-list')
+        url = reverse("journals:decision-list")
 
         # Create separate journal contacts for each test
         contacts = []
         for i in range(4):
             contact = Contact.objects.create(
                 owner=self.user_a,
-                first_name=f'StatusContact{i}',
-                last_name='Test',
-                email=f'statuscontact{i}@example.com'
+                first_name=f"StatusContact{i}",
+                last_name="Test",
+                email=f"statuscontact{i}@example.com",
             )
-            jc = JournalContact.objects.create(
-                journal=self.journal,
-                contact=contact
-            )
+            jc = JournalContact.objects.create(journal=self.journal, contact=contact)
             contacts.append(jc)
 
-        statuses = ['pending', 'active', 'paused', 'declined']
+        statuses = ["pending", "active", "paused", "declined"]
 
         for idx, status_value in enumerate(statuses):
-            response = self.client.post(url, {
-                'journal_contact': str(contacts[idx].id),
-                'amount': '100.00',
-                'status': status_value
-            }, format='json')
+            response = self.client.post(
+                url,
+                {
+                    "journal_contact": str(contacts[idx].id),
+                    "amount": "100.00",
+                    "status": status_value,
+                },
+                format="json",
+            )
 
             self.assertEqual(
                 response.status_code,
                 status.HTTP_201_CREATED,
-                f"Failed to create decision with status={status_value}"
+                f"Failed to create decision with status={status_value}",
             )
-            self.assertEqual(response.data['status'], status_value)
+            self.assertEqual(response.data["status"], status_value)
 
     def test_create_decision_without_optional_fields(self):
         """Test creating decision with only required fields, defaults should apply."""
-        url = reverse('journals:decision-list')
-        data = {
-            'journal_contact': str(self.jc1.id),
-            'amount': '100.00'
-        }
+        url = reverse("journals:decision-list")
+        data = {"journal_contact": str(self.jc1.id), "amount": "100.00"}
 
-        response = self.client.post(url, data, format='json')
+        response = self.client.post(url, data, format="json")
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         # Defaults from model: cadence=monthly, status=pending
-        self.assertEqual(response.data['cadence'], 'monthly')
-        self.assertEqual(response.data['status'], 'pending')
+        self.assertEqual(response.data["cadence"], "monthly")
+        self.assertEqual(response.data["status"], "pending")
 
     # Success Criterion 5: Unique constraint
 
     def test_duplicate_decision_returns_400(self):
         """Test that creating a second decision for same journal_contact returns 400."""
-        url = reverse('journals:decision-list')
-        data = {
-            'journal_contact': str(self.jc1.id),
-            'amount': '100.00'
-        }
+        url = reverse("journals:decision-list")
+        data = {"journal_contact": str(self.jc1.id), "amount": "100.00"}
 
         # First POST should succeed
-        response1 = self.client.post(url, data, format='json')
+        response1 = self.client.post(url, data, format="json")
         self.assertEqual(response1.status_code, status.HTTP_201_CREATED)
 
         # Second POST should fail with 400
-        response2 = self.client.post(url, data, format='json')
+        response2 = self.client.post(url, data, format="json")
         self.assertEqual(response2.status_code, status.HTTP_400_BAD_REQUEST)
         # Should contain error message about duplicate/already exists
         response_str = str(response2.data).lower()
-        self.assertTrue('already exists' in response_str or 'duplicate' in response_str)
+        self.assertTrue("already exists" in response_str or "duplicate" in response_str)
 
     def test_different_contacts_can_have_decisions(self):
         """Test that different journal_contacts in same journal can each have decisions."""
-        url = reverse('journals:decision-list')
+        url = reverse("journals:decision-list")
 
         # Create decision for jc1
-        response1 = self.client.post(url, {
-            'journal_contact': str(self.jc1.id),
-            'amount': '100.00'
-        }, format='json')
+        response1 = self.client.post(
+            url, {"journal_contact": str(self.jc1.id), "amount": "100.00"}, format="json"
+        )
         self.assertEqual(response1.status_code, status.HTTP_201_CREATED)
 
         # Create decision for jc2 (different contact, same journal)
-        response2 = self.client.post(url, {
-            'journal_contact': str(self.jc2.id),
-            'amount': '200.00'
-        }, format='json')
+        response2 = self.client.post(
+            url, {"journal_contact": str(self.jc2.id), "amount": "200.00"}, format="json"
+        )
         self.assertEqual(response2.status_code, status.HTTP_201_CREATED)
 
         # Both decisions should exist
@@ -255,49 +233,40 @@ class DecisionAPITests(APITestCase):
         # Authenticate as user_b
         self.client.force_authenticate(user=self.user_b)
 
-        url = reverse('journals:decision-list')
-        data = {
-            'journal_contact': str(self.jc1.id),  # Owned by user_a
-            'amount': '100.00'
-        }
+        url = reverse("journals:decision-list")
+        data = {"journal_contact": str(self.jc1.id), "amount": "100.00"}  # Owned by user_a
 
-        response = self.client.post(url, data, format='json')
+        response = self.client.post(url, data, format="json")
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertIn('journal_contact', response.data)
+        self.assertIn("journal_contact", response.data)
 
     def test_cannot_list_other_users_decisions(self):
         """Test that user_b cannot see user_a's decisions."""
         # Create decision for user_a's journal_contact
-        Decision.objects.create(
-            journal_contact=self.jc1,
-            amount=Decimal('100.00')
-        )
+        Decision.objects.create(journal_contact=self.jc1, amount=Decimal("100.00"))
 
         # Authenticate as user_b
         self.client.force_authenticate(user=self.user_b)
 
-        url = reverse('journals:decision-list')
+        url = reverse("journals:decision-list")
         response = self.client.get(url)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         # user_b should see 0 decisions (user_a's are filtered out)
         # Decision list uses default pagination
-        self.assertEqual(response.data['count'], 0)
+        self.assertEqual(response.data["count"], 0)
 
     def test_cannot_update_other_users_decision(self):
         """Test that user_b cannot update user_a's decision."""
         # Create decision for user_a's journal_contact
-        decision = Decision.objects.create(
-            journal_contact=self.jc1,
-            amount=Decimal('100.00')
-        )
+        decision = Decision.objects.create(journal_contact=self.jc1, amount=Decimal("100.00"))
 
         # Authenticate as user_b
         self.client.force_authenticate(user=self.user_b)
 
-        url = reverse('journals:decision-detail', kwargs={'pk': decision.id})
-        response = self.client.patch(url, {'amount': '200.00'}, format='json')
+        url = reverse("journals:decision-detail", kwargs={"pk": decision.id})
+        response = self.client.patch(url, {"amount": "200.00"}, format="json")
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
@@ -306,27 +275,27 @@ class DecisionAPITests(APITestCase):
     def test_list_decisions_filtered_by_journal_contact_id(self):
         """Test filtering decisions by journal_contact_id."""
         # Create decisions for both journal_contacts
-        Decision.objects.create(journal_contact=self.jc1, amount=Decimal('100.00'))
-        Decision.objects.create(journal_contact=self.jc2, amount=Decimal('200.00'))
+        Decision.objects.create(journal_contact=self.jc1, amount=Decimal("100.00"))
+        Decision.objects.create(journal_contact=self.jc2, amount=Decimal("200.00"))
 
-        url = reverse('journals:decision-list')
-        response = self.client.get(url, {'journal_contact_id': str(self.jc1.id)})
+        url = reverse("journals:decision-list")
+        response = self.client.get(url, {"journal_contact_id": str(self.jc1.id)})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data['count'], 1)
-        self.assertEqual(str(response.data['results'][0]['journal_contact']), str(self.jc1.id))
+        self.assertEqual(response.data["count"], 1)
+        self.assertEqual(str(response.data["results"][0]["journal_contact"]), str(self.jc1.id))
 
     def test_list_decisions_filtered_by_journal_id(self):
         """Test filtering decisions by journal_id."""
         # Create decisions for user_a's journal
-        Decision.objects.create(journal_contact=self.jc1, amount=Decimal('100.00'))
-        Decision.objects.create(journal_contact=self.jc2, amount=Decimal('200.00'))
+        Decision.objects.create(journal_contact=self.jc1, amount=Decimal("100.00"))
+        Decision.objects.create(journal_contact=self.jc2, amount=Decimal("200.00"))
 
-        url = reverse('journals:decision-list')
-        response = self.client.get(url, {'journal_id': str(self.journal.id)})
+        url = reverse("journals:decision-list")
+        response = self.client.get(url, {"journal_id": str(self.journal.id)})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data['count'], 2)
+        self.assertEqual(response.data["count"], 2)
 
 
 class DecisionHistoryTests(APITestCase):
@@ -336,39 +305,31 @@ class DecisionHistoryTests(APITestCase):
         """Set up test data with a decision ready for updates."""
         # Create user
         self.user_a = User.objects.create_user(
-            email='usera@example.com',
-            password='password123',
-            first_name='User',
-            last_name='A',
-            role='missionary'
+            email="usera@example.com",
+            password="password123",
+            first_name="User",
+            last_name="A",
+            role="missionary",
         )
 
         # Create journal owned by user_a
         self.journal = Journal.objects.create(
-            owner=self.user_a,
-            name='Q1 2025 Campaign',
-            goal_amount=50000.00
+            owner=self.user_a, name="Q1 2025 Campaign", goal_amount=50000.00
         )
 
         # Create contact and journal_contact
         self.contact = Contact.objects.create(
             owner=self.user_a,
-            first_name='Alice',
-            last_name='Anderson',
-            email='alice@example.com',
-            status='prospect'
+            first_name="Alice",
+            last_name="Anderson",
+            email="alice@example.com",
+            status="prospect",
         )
-        self.jc = JournalContact.objects.create(
-            journal=self.journal,
-            contact=self.contact
-        )
+        self.jc = JournalContact.objects.create(journal=self.journal, contact=self.contact)
 
         # Create initial decision
         self.decision = Decision.objects.create(
-            journal_contact=self.jc,
-            amount=Decimal('100.00'),
-            cadence='monthly',
-            status='pending'
+            journal_contact=self.jc, amount=Decimal("100.00"), cadence="monthly", status="pending"
         )
 
         # Default authentication
@@ -378,77 +339,76 @@ class DecisionHistoryTests(APITestCase):
 
     def test_update_decision_creates_history(self):
         """Test that updating a decision creates a history record."""
-        url = reverse('journals:decision-detail', kwargs={'pk': self.decision.id})
+        url = reverse("journals:decision-detail", kwargs={"pk": self.decision.id})
 
-        response = self.client.patch(url, {'amount': '200.00'}, format='json')
+        response = self.client.patch(url, {"amount": "200.00"}, format="json")
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(DecisionHistory.objects.count(), 1)
 
         history = DecisionHistory.objects.first()
         self.assertEqual(history.decision, self.decision)
-        self.assertIn('amount', history.changed_fields)
-        self.assertEqual(history.changed_fields['amount'], '100.00')  # Old value
+        self.assertIn("amount", history.changed_fields)
+        self.assertEqual(history.changed_fields["amount"], "100.00")  # Old value
         self.assertEqual(history.changed_by, self.user_a)
 
     def test_update_multiple_fields_creates_single_history(self):
         """Test that updating multiple fields creates one history record with all changes."""
-        url = reverse('journals:decision-detail', kwargs={'pk': self.decision.id})
+        url = reverse("journals:decision-detail", kwargs={"pk": self.decision.id})
 
-        response = self.client.patch(url, {
-            'amount': '200.00',
-            'cadence': 'quarterly'
-        }, format='json')
+        response = self.client.patch(
+            url, {"amount": "200.00", "cadence": "quarterly"}, format="json"
+        )
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(DecisionHistory.objects.count(), 1)
 
         history = DecisionHistory.objects.first()
-        self.assertIn('amount', history.changed_fields)
-        self.assertIn('cadence', history.changed_fields)
-        self.assertEqual(history.changed_fields['amount'], '100.00')
-        self.assertEqual(history.changed_fields['cadence'], 'monthly')
+        self.assertIn("amount", history.changed_fields)
+        self.assertIn("cadence", history.changed_fields)
+        self.assertEqual(history.changed_fields["amount"], "100.00")
+        self.assertEqual(history.changed_fields["cadence"], "monthly")
 
     def test_update_same_value_no_history(self):
         """Test that updating with same value creates no history record."""
-        url = reverse('journals:decision-detail', kwargs={'pk': self.decision.id})
+        url = reverse("journals:decision-detail", kwargs={"pk": self.decision.id})
 
         # PATCH with same amount (use Decimal for exact comparison)
-        response = self.client.patch(url, {'amount': Decimal('100.00')}, format='json')
+        response = self.client.patch(url, {"amount": Decimal("100.00")}, format="json")
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(DecisionHistory.objects.count(), 0)
 
     def test_multiple_updates_create_multiple_history(self):
         """Test that sequential updates create multiple history records."""
-        url = reverse('journals:decision-detail', kwargs={'pk': self.decision.id})
+        url = reverse("journals:decision-detail", kwargs={"pk": self.decision.id})
 
         # First update: change amount
-        self.client.patch(url, {'amount': '200.00'}, format='json')
+        self.client.patch(url, {"amount": "200.00"}, format="json")
 
         # Second update: change cadence
-        self.client.patch(url, {'cadence': 'quarterly'}, format='json')
+        self.client.patch(url, {"cadence": "quarterly"}, format="json")
 
         self.assertEqual(DecisionHistory.objects.count(), 2)
 
         # Should be ordered by -created_at (most recent first)
         histories = DecisionHistory.objects.all()
-        self.assertIn('cadence', histories[0].changed_fields)  # Most recent
-        self.assertIn('amount', histories[1].changed_fields)   # Older
+        self.assertIn("cadence", histories[0].changed_fields)  # Most recent
+        self.assertIn("amount", histories[1].changed_fields)  # Older
 
     def test_history_records_old_value_not_new(self):
         """Test that history records old value, not new value."""
-        url = reverse('journals:decision-detail', kwargs={'pk': self.decision.id})
+        url = reverse("journals:decision-detail", kwargs={"pk": self.decision.id})
 
         # Update from 100 to 200
-        self.client.patch(url, {'amount': '200.00'}, format='json')
+        self.client.patch(url, {"amount": "200.00"}, format="json")
 
         history = DecisionHistory.objects.first()
-        self.assertEqual(history.changed_fields['amount'], '100.00')  # Old value
+        self.assertEqual(history.changed_fields["amount"], "100.00")  # Old value
 
         # Verify decision has new value
         self.decision.refresh_from_db()
-        self.assertEqual(str(self.decision.amount), '200.00')
+        self.assertEqual(str(self.decision.amount), "200.00")
 
     # Success Criterion 3: Monthly equivalent calculation
 
@@ -456,104 +416,87 @@ class DecisionHistoryTests(APITestCase):
         """Test monthly equivalent for monthly cadence."""
         # Create new jc for this test (self.jc already has a decision from setUp)
         contact1 = Contact.objects.create(
-            owner=self.user_a,
-            first_name='Test',
-            last_name='Monthly',
-            email='monthly@example.com'
+            owner=self.user_a, first_name="Test", last_name="Monthly", email="monthly@example.com"
         )
         jc1 = JournalContact.objects.create(journal=self.journal, contact=contact1)
 
-        url = reverse('journals:decision-list')
-        response = self.client.post(url, {
-            'journal_contact': str(jc1.id),
-            'amount': '100.00',
-            'cadence': 'monthly'
-        }, format='json')
+        url = reverse("journals:decision-list")
+        response = self.client.post(
+            url,
+            {"journal_contact": str(jc1.id), "amount": "100.00", "cadence": "monthly"},
+            format="json",
+        )
 
-        self.assertEqual(str(response.data['monthly_equivalent']), '100.00')
+        self.assertEqual(str(response.data["monthly_equivalent"]), "100.00")
 
     def test_monthly_equivalent_quarterly(self):
         """Test monthly equivalent for quarterly cadence."""
         # Create new jc for this test
         contact2 = Contact.objects.create(
-            owner=self.user_a,
-            first_name='Bob',
-            last_name='Brown',
-            email='bob@example.com'
+            owner=self.user_a, first_name="Bob", last_name="Brown", email="bob@example.com"
         )
         jc2 = JournalContact.objects.create(journal=self.journal, contact=contact2)
 
-        url = reverse('journals:decision-list')
-        response = self.client.post(url, {
-            'journal_contact': str(jc2.id),
-            'amount': '300.00',
-            'cadence': 'quarterly'
-        }, format='json')
+        url = reverse("journals:decision-list")
+        response = self.client.post(
+            url,
+            {"journal_contact": str(jc2.id), "amount": "300.00", "cadence": "quarterly"},
+            format="json",
+        )
 
-        self.assertEqual(str(response.data['monthly_equivalent']), '100.00')
+        self.assertEqual(str(response.data["monthly_equivalent"]), "100.00")
 
     def test_monthly_equivalent_annual(self):
         """Test monthly equivalent for annual cadence."""
         # Create new jc for this test
         contact3 = Contact.objects.create(
-            owner=self.user_a,
-            first_name='Charlie',
-            last_name='Clark',
-            email='charlie@example.com'
+            owner=self.user_a, first_name="Charlie", last_name="Clark", email="charlie@example.com"
         )
         jc3 = JournalContact.objects.create(journal=self.journal, contact=contact3)
 
-        url = reverse('journals:decision-list')
-        response = self.client.post(url, {
-            'journal_contact': str(jc3.id),
-            'amount': '1200.00',
-            'cadence': 'annual'
-        }, format='json')
+        url = reverse("journals:decision-list")
+        response = self.client.post(
+            url,
+            {"journal_contact": str(jc3.id), "amount": "1200.00", "cadence": "annual"},
+            format="json",
+        )
 
-        self.assertEqual(str(response.data['monthly_equivalent']), '100.00')
+        self.assertEqual(str(response.data["monthly_equivalent"]), "100.00")
 
     def test_monthly_equivalent_one_time(self):
         """Test monthly equivalent for one_time cadence is amount / 12."""
         # Create new jc for this test
         contact4 = Contact.objects.create(
-            owner=self.user_a,
-            first_name='Diana',
-            last_name='Davis',
-            email='diana@example.com'
+            owner=self.user_a, first_name="Diana", last_name="Davis", email="diana@example.com"
         )
         jc4 = JournalContact.objects.create(journal=self.journal, contact=contact4)
 
-        url = reverse('journals:decision-list')
-        response = self.client.post(url, {
-            'journal_contact': str(jc4.id),
-            'amount': '500.00',
-            'cadence': 'one_time'
-        }, format='json')
+        url = reverse("journals:decision-list")
+        response = self.client.post(
+            url,
+            {"journal_contact": str(jc4.id), "amount": "500.00", "cadence": "one_time"},
+            format="json",
+        )
 
-        self.assertEqual(str(response.data['monthly_equivalent']), '41.67')
+        self.assertEqual(str(response.data["monthly_equivalent"]), "41.67")
 
     def test_monthly_equivalent_updates_after_cadence_change(self):
         """Test that monthly_equivalent recalculates when cadence changes."""
         # Create decision with monthly cadence
         contact5 = Contact.objects.create(
-            owner=self.user_a,
-            first_name='Eve',
-            last_name='Evans',
-            email='eve@example.com'
+            owner=self.user_a, first_name="Eve", last_name="Evans", email="eve@example.com"
         )
         jc5 = JournalContact.objects.create(journal=self.journal, contact=contact5)
         decision = Decision.objects.create(
-            journal_contact=jc5,
-            amount=Decimal('100.00'),
-            cadence='monthly'
+            journal_contact=jc5, amount=Decimal("100.00"), cadence="monthly"
         )
 
         # PATCH to quarterly
-        url = reverse('journals:decision-detail', kwargs={'pk': decision.id})
-        response = self.client.patch(url, {'cadence': 'quarterly'}, format='json')
+        url = reverse("journals:decision-detail", kwargs={"pk": decision.id})
+        response = self.client.patch(url, {"cadence": "quarterly"}, format="json")
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(str(response.data['monthly_equivalent']), '33.33')
+        self.assertEqual(str(response.data["monthly_equivalent"]), "33.33")
 
     # Success Criterion 4: Paginated history
 
@@ -561,104 +504,89 @@ class DecisionHistoryTests(APITestCase):
         """Test that history list defaults to 25 records per page."""
         # Create 30 history records by updating decision 30 times
         # Start from 101 to ensure each update is different from initial 100
-        url = reverse('journals:decision-detail', kwargs={'pk': self.decision.id})
+        url = reverse("journals:decision-detail", kwargs={"pk": self.decision.id})
         for i in range(1, 31):  # 1 to 30 (30 updates)
-            self.client.patch(url, {'amount': str(Decimal('100.00') + i)}, format='json')
+            self.client.patch(url, {"amount": str(Decimal("100.00") + i)}, format="json")
 
         # GET history
-        history_url = reverse('journals:decision-history-list')
-        response = self.client.get(history_url, {'decision_id': str(self.decision.id)})
+        history_url = reverse("journals:decision-history-list")
+        response = self.client.get(history_url, {"decision_id": str(self.decision.id)})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data['count'], 30)  # Total count
-        self.assertEqual(len(response.data['results']), 25)  # Page 1 size
-        self.assertIsNotNone(response.data['next'])  # Has next page
+        self.assertEqual(response.data["count"], 30)  # Total count
+        self.assertEqual(len(response.data["results"]), 25)  # Page 1 size
+        self.assertIsNotNone(response.data["next"])  # Has next page
 
     def test_history_list_page_2(self):
         """Test getting page 2 of history."""
         # Create 30 history records
-        url = reverse('journals:decision-detail', kwargs={'pk': self.decision.id})
+        url = reverse("journals:decision-detail", kwargs={"pk": self.decision.id})
         for i in range(1, 31):  # 1 to 30 (30 updates)
-            self.client.patch(url, {'amount': str(Decimal('100.00') + i)}, format='json')
+            self.client.patch(url, {"amount": str(Decimal("100.00") + i)}, format="json")
 
         # GET page 2
-        history_url = reverse('journals:decision-history-list')
-        response = self.client.get(history_url, {
-            'decision_id': str(self.decision.id),
-            'page': 2
-        })
+        history_url = reverse("journals:decision-history-list")
+        response = self.client.get(history_url, {"decision_id": str(self.decision.id), "page": 2})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(len(response.data['results']), 5)  # Remaining records
-        self.assertIsNone(response.data['next'])  # No more pages
+        self.assertEqual(len(response.data["results"]), 5)  # Remaining records
+        self.assertIsNone(response.data["next"])  # No more pages
 
     def test_history_list_custom_page_size(self):
         """Test custom page_size parameter."""
         # Create 10 history records
-        url = reverse('journals:decision-detail', kwargs={'pk': self.decision.id})
+        url = reverse("journals:decision-detail", kwargs={"pk": self.decision.id})
         for i in range(10):
-            self.client.patch(url, {'amount': str(100 + i)}, format='json')
+            self.client.patch(url, {"amount": str(100 + i)}, format="json")
 
         # GET with page_size=5
-        history_url = reverse('journals:decision-history-list')
-        response = self.client.get(history_url, {
-            'decision_id': str(self.decision.id),
-            'page_size': 5
-        })
+        history_url = reverse("journals:decision-history-list")
+        response = self.client.get(
+            history_url, {"decision_id": str(self.decision.id), "page_size": 5}
+        )
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(len(response.data['results']), 5)
+        self.assertEqual(len(response.data["results"]), 5)
 
     def test_history_filtered_by_journal_contact_id(self):
         """Test filtering history by journal_contact_id."""
         # Create second journal_contact with decision
         contact2 = Contact.objects.create(
-            owner=self.user_a,
-            first_name='Bob',
-            last_name='Brown',
-            email='bob2@example.com'
+            owner=self.user_a, first_name="Bob", last_name="Brown", email="bob2@example.com"
         )
         jc2 = JournalContact.objects.create(journal=self.journal, contact=contact2)
-        decision2 = Decision.objects.create(
-            journal_contact=jc2,
-            amount=Decimal('200.00')
-        )
+        decision2 = Decision.objects.create(journal_contact=jc2, amount=Decimal("200.00"))
 
         # Create history for both decisions
-        url1 = reverse('journals:decision-detail', kwargs={'pk': self.decision.id})
-        self.client.patch(url1, {'amount': '150.00'}, format='json')
+        url1 = reverse("journals:decision-detail", kwargs={"pk": self.decision.id})
+        self.client.patch(url1, {"amount": "150.00"}, format="json")
 
-        url2 = reverse('journals:decision-detail', kwargs={'pk': decision2.id})
-        self.client.patch(url2, {'amount': '250.00'}, format='json')
+        url2 = reverse("journals:decision-detail", kwargs={"pk": decision2.id})
+        self.client.patch(url2, {"amount": "250.00"}, format="json")
 
         # GET history filtered by jc
-        history_url = reverse('journals:decision-history-list')
-        response = self.client.get(history_url, {
-            'journal_contact_id': str(self.jc.id)
-        })
+        history_url = reverse("journals:decision-history-list")
+        response = self.client.get(history_url, {"journal_contact_id": str(self.jc.id)})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data['count'], 1)
+        self.assertEqual(response.data["count"], 1)
         # Verify it's the right decision's history
-        self.assertEqual(
-            str(response.data['results'][0]['decision']),
-            str(self.decision.id)
-        )
+        self.assertEqual(str(response.data["results"][0]["decision"]), str(self.decision.id))
 
     # Atomic transaction integrity
 
     def test_history_and_update_are_atomic(self):
         """Test that decision update and history creation are atomic."""
-        url = reverse('journals:decision-detail', kwargs={'pk': self.decision.id})
+        url = reverse("journals:decision-detail", kwargs={"pk": self.decision.id})
 
-        response = self.client.patch(url, {'amount': '200.00'}, format='json')
+        response = self.client.patch(url, {"amount": "200.00"}, format="json")
 
         # Both should succeed together
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         # Decision updated
         self.decision.refresh_from_db()
-        self.assertEqual(str(self.decision.amount), '200.00')
+        self.assertEqual(str(self.decision.amount), "200.00")
 
         # History created
         self.assertEqual(DecisionHistory.objects.count(), 1)

--- a/apps/journals/tests/test_journal_members.py
+++ b/apps/journals/tests/test_journal_members.py
@@ -199,9 +199,7 @@ class JournalContactTests(APITestCase):
     def test_cannot_add_to_journal_owned_by_other_user(self):
         """Test that user cannot add contacts to another user's journal."""
         # Create journal owned by user_b
-        journal_b = Journal.objects.create(
-            owner=self.user_b, name="User B Journal", goal_amount=30000.00
-        )
+        Journal.objects.create(owner=self.user_b, name="User B Journal", goal_amount=30000.00)
 
         # Authenticate as user_b
         self.client.force_authenticate(user=self.user_b)
@@ -380,8 +378,8 @@ class JournalContactTests(APITestCase):
         )
 
         # Create memberships in both journals
-        jc1 = JournalContact.objects.create(journal=self.journal, contact=self.contact_a1)
-        jc2 = JournalContact.objects.create(journal=journal2, contact=self.contact_a2)
+        JournalContact.objects.create(journal=self.journal, contact=self.contact_a1)
+        JournalContact.objects.create(journal=journal2, contact=self.contact_a2)
 
         url = reverse("journals:journal-member-list")
 

--- a/apps/journals/tests/test_journal_members.py
+++ b/apps/journals/tests/test_journal_members.py
@@ -14,6 +14,7 @@ Tests verify:
 """
 from django.contrib.auth import get_user_model
 from django.urls import reverse
+
 from rest_framework import status
 from rest_framework.test import APITestCase
 

--- a/apps/journals/tests/test_next_steps.py
+++ b/apps/journals/tests/test_next_steps.py
@@ -8,8 +8,6 @@ Tests verify:
 - Ownership validation (only owner can access)
 - Cross-user protection
 """
-from datetime import date
-
 from django.contrib.auth import get_user_model
 from django.urls import reverse
 
@@ -274,9 +272,9 @@ class NextStepAPITests(APITestCase):
     def test_next_steps_ordered_by_order_then_created_at(self):
         """Test that next steps are returned in correct order."""
         # Create next steps with different orders
-        ns3 = NextStep.objects.create(journal_contact=self.jc1, title="Third", order=3)
-        ns1 = NextStep.objects.create(journal_contact=self.jc1, title="First", order=1)
-        ns2 = NextStep.objects.create(journal_contact=self.jc1, title="Second", order=2)
+        NextStep.objects.create(journal_contact=self.jc1, title="Third", order=3)
+        NextStep.objects.create(journal_contact=self.jc1, title="First", order=1)
+        NextStep.objects.create(journal_contact=self.jc1, title="Second", order=2)
 
         url = reverse("journals:nextstep-list")
         response = self.client.get(url, {"journal_contact": str(self.jc1.id)})

--- a/apps/journals/tests/test_next_steps.py
+++ b/apps/journals/tests/test_next_steps.py
@@ -12,6 +12,7 @@ from datetime import date
 
 from django.contrib.auth import get_user_model
 from django.urls import reverse
+
 from rest_framework import status
 from rest_framework.test import APITestCase
 
@@ -28,70 +29,57 @@ class NextStepAPITests(APITestCase):
         """Set up test data: two users, journals, contacts, and journal_contacts."""
         # Create two users
         self.user_a = User.objects.create_user(
-            email='usera@example.com',
-            password='password123',
-            first_name='User',
-            last_name='A',
-            role='missionary'
+            email="usera@example.com",
+            password="password123",
+            first_name="User",
+            last_name="A",
+            role="missionary",
         )
         self.user_b = User.objects.create_user(
-            email='userb@example.com',
-            password='password123',
-            first_name='User',
-            last_name='B',
-            role='missionary'
+            email="userb@example.com",
+            password="password123",
+            first_name="User",
+            last_name="B",
+            role="missionary",
         )
 
         # Create journal owned by user_a
         self.journal = Journal.objects.create(
-            owner=self.user_a,
-            name='Q1 2025 Campaign',
-            goal_amount=50000.00
+            owner=self.user_a, name="Q1 2025 Campaign", goal_amount=50000.00
         )
 
         # Create contacts owned by user_a
         self.contact_a1 = Contact.objects.create(
             owner=self.user_a,
-            first_name='Alice',
-            last_name='Anderson',
-            email='alice.anderson@example.com',
-            status='prospect'
+            first_name="Alice",
+            last_name="Anderson",
+            email="alice.anderson@example.com",
+            status="prospect",
         )
         self.contact_a2 = Contact.objects.create(
             owner=self.user_a,
-            first_name='Bob',
-            last_name='Brown',
-            email='bob.brown@example.com',
-            status='donor'
+            first_name="Bob",
+            last_name="Brown",
+            email="bob.brown@example.com",
+            status="donor",
         )
 
         # Create journal_contacts
-        self.jc1 = JournalContact.objects.create(
-            journal=self.journal,
-            contact=self.contact_a1
-        )
-        self.jc2 = JournalContact.objects.create(
-            journal=self.journal,
-            contact=self.contact_a2
-        )
+        self.jc1 = JournalContact.objects.create(journal=self.journal, contact=self.contact_a1)
+        self.jc2 = JournalContact.objects.create(journal=self.journal, contact=self.contact_a2)
 
         # Create journal and contact for user_b
         self.journal_b = Journal.objects.create(
-            owner=self.user_b,
-            name='User B Journal',
-            goal_amount=30000.00
+            owner=self.user_b, name="User B Journal", goal_amount=30000.00
         )
         self.contact_b = Contact.objects.create(
             owner=self.user_b,
-            first_name='Charlie',
-            last_name='Clark',
-            email='charlie@example.com',
-            status='prospect'
+            first_name="Charlie",
+            last_name="Clark",
+            email="charlie@example.com",
+            status="prospect",
         )
-        self.jc_b = JournalContact.objects.create(
-            journal=self.journal_b,
-            contact=self.contact_b
-        )
+        self.jc_b = JournalContact.objects.create(journal=self.journal_b, contact=self.contact_b)
 
         # Default authentication to user_a
         self.client.force_authenticate(user=self.user_a)
@@ -100,107 +88,87 @@ class NextStepAPITests(APITestCase):
 
     def test_create_next_step_success(self):
         """Test successfully creating a next step with all fields."""
-        url = reverse('journals:nextstep-list')
+        url = reverse("journals:nextstep-list")
         data = {
-            'journal_contact': str(self.jc1.id),
-            'title': 'Send thank you email',
-            'notes': 'Follow up on meeting',
-            'due_date': '2025-02-15',
-            'order': 1
+            "journal_contact": str(self.jc1.id),
+            "title": "Send thank you email",
+            "notes": "Follow up on meeting",
+            "due_date": "2025-02-15",
+            "order": 1,
         }
 
-        response = self.client.post(url, data, format='json')
+        response = self.client.post(url, data, format="json")
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        self.assertIn('id', response.data)
-        self.assertEqual(str(response.data['journal_contact']), str(self.jc1.id))
-        self.assertEqual(response.data['title'], 'Send thank you email')
-        self.assertEqual(response.data['notes'], 'Follow up on meeting')
-        self.assertEqual(response.data['due_date'], '2025-02-15')
-        self.assertEqual(response.data['completed'], False)
-        self.assertIsNone(response.data['completed_at'])
+        self.assertIn("id", response.data)
+        self.assertEqual(str(response.data["journal_contact"]), str(self.jc1.id))
+        self.assertEqual(response.data["title"], "Send thank you email")
+        self.assertEqual(response.data["notes"], "Follow up on meeting")
+        self.assertEqual(response.data["due_date"], "2025-02-15")
+        self.assertEqual(response.data["completed"], False)
+        self.assertIsNone(response.data["completed_at"])
         self.assertEqual(NextStep.objects.count(), 1)
 
     def test_create_next_step_minimal(self):
         """Test creating next step with only required fields."""
-        url = reverse('journals:nextstep-list')
-        data = {
-            'journal_contact': str(self.jc1.id),
-            'title': 'Call donor'
-        }
+        url = reverse("journals:nextstep-list")
+        data = {"journal_contact": str(self.jc1.id), "title": "Call donor"}
 
-        response = self.client.post(url, data, format='json')
+        response = self.client.post(url, data, format="json")
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        self.assertEqual(response.data['title'], 'Call donor')
-        self.assertEqual(response.data['notes'], '')
-        self.assertIsNone(response.data['due_date'])
-        self.assertEqual(response.data['order'], 0)
+        self.assertEqual(response.data["title"], "Call donor")
+        self.assertEqual(response.data["notes"], "")
+        self.assertIsNone(response.data["due_date"])
+        self.assertEqual(response.data["order"], 0)
 
     # Test 2: List next steps with filter
 
     def test_list_next_steps_by_journal_contact(self):
         """Test listing next steps filtered by journal_contact."""
         # Create next steps for both journal_contacts
-        NextStep.objects.create(
-            journal_contact=self.jc1,
-            title='Step for JC1'
-        )
-        NextStep.objects.create(
-            journal_contact=self.jc2,
-            title='Step for JC2'
-        )
+        NextStep.objects.create(journal_contact=self.jc1, title="Step for JC1")
+        NextStep.objects.create(journal_contact=self.jc2, title="Step for JC2")
 
-        url = reverse('journals:nextstep-list')
-        response = self.client.get(url, {'journal_contact': str(self.jc1.id)})
+        url = reverse("journals:nextstep-list")
+        response = self.client.get(url, {"journal_contact": str(self.jc1.id)})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data['count'], 1)
-        self.assertEqual(response.data['results'][0]['title'], 'Step for JC1')
+        self.assertEqual(response.data["count"], 1)
+        self.assertEqual(response.data["results"][0]["title"], "Step for JC1")
 
     def test_list_next_steps_by_completed_status(self):
         """Test filtering next steps by completed status."""
         # Create completed and incomplete next steps
-        NextStep.objects.create(
-            journal_contact=self.jc1,
-            title='Incomplete step',
-            completed=False
-        )
-        NextStep.objects.create(
-            journal_contact=self.jc1,
-            title='Complete step',
-            completed=True
-        )
+        NextStep.objects.create(journal_contact=self.jc1, title="Incomplete step", completed=False)
+        NextStep.objects.create(journal_contact=self.jc1, title="Complete step", completed=True)
 
-        url = reverse('journals:nextstep-list')
+        url = reverse("journals:nextstep-list")
 
         # Filter for incomplete
-        response = self.client.get(url, {'completed': 'false'})
+        response = self.client.get(url, {"completed": "false"})
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data['count'], 1)
-        self.assertEqual(response.data['results'][0]['title'], 'Incomplete step')
+        self.assertEqual(response.data["count"], 1)
+        self.assertEqual(response.data["results"][0]["title"], "Incomplete step")
 
         # Filter for complete
-        response = self.client.get(url, {'completed': 'true'})
+        response = self.client.get(url, {"completed": "true"})
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data['count'], 1)
-        self.assertEqual(response.data['results'][0]['title'], 'Complete step')
+        self.assertEqual(response.data["count"], 1)
+        self.assertEqual(response.data["results"][0]["title"], "Complete step")
 
     # Test 3: Mark complete
 
     def test_mark_next_step_complete(self):
         """Test marking a next step as complete sets completed_at."""
-        next_step = NextStep.objects.create(
-            journal_contact=self.jc1,
-            title='Send email'
-        )
+        next_step = NextStep.objects.create(journal_contact=self.jc1, title="Send email")
 
-        url = reverse('journals:nextstep-detail', kwargs={'pk': next_step.id})
-        response = self.client.patch(url, {'completed': True}, format='json')
+        url = reverse("journals:nextstep-detail", kwargs={"pk": next_step.id})
+        response = self.client.patch(url, {"completed": True}, format="json")
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data['completed'], True)
-        self.assertIsNotNone(response.data['completed_at'])
+        self.assertEqual(response.data["completed"], True)
+        self.assertIsNotNone(response.data["completed_at"])
 
         # Verify in database
         next_step.refresh_from_db()
@@ -215,17 +183,17 @@ class NextStepAPITests(APITestCase):
 
         next_step = NextStep.objects.create(
             journal_contact=self.jc1,
-            title='Send email',
+            title="Send email",
             completed=True,
-            completed_at=timezone.now()
+            completed_at=timezone.now(),
         )
 
-        url = reverse('journals:nextstep-detail', kwargs={'pk': next_step.id})
-        response = self.client.patch(url, {'completed': False}, format='json')
+        url = reverse("journals:nextstep-detail", kwargs={"pk": next_step.id})
+        response = self.client.patch(url, {"completed": False}, format="json")
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data['completed'], False)
-        self.assertIsNone(response.data['completed_at'])
+        self.assertEqual(response.data["completed"], False)
+        self.assertIsNone(response.data["completed_at"])
 
         # Verify in database
         next_step.refresh_from_db()
@@ -236,12 +204,9 @@ class NextStepAPITests(APITestCase):
 
     def test_delete_next_step(self):
         """Test deleting a next step."""
-        next_step = NextStep.objects.create(
-            journal_contact=self.jc1,
-            title='Send email'
-        )
+        next_step = NextStep.objects.create(journal_contact=self.jc1, title="Send email")
 
-        url = reverse('journals:nextstep-detail', kwargs={'pk': next_step.id})
+        url = reverse("journals:nextstep-detail", kwargs={"pk": next_step.id})
         response = self.client.delete(url)
 
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
@@ -251,65 +216,53 @@ class NextStepAPITests(APITestCase):
 
     def test_cannot_create_next_step_for_other_users_journal_contact(self):
         """Test that user_a cannot create next step for user_b's journal_contact."""
-        url = reverse('journals:nextstep-list')
-        data = {
-            'journal_contact': str(self.jc_b.id),
-            'title': 'Try to add to user_b contact'
-        }
+        url = reverse("journals:nextstep-list")
+        data = {"journal_contact": str(self.jc_b.id), "title": "Try to add to user_b contact"}
 
-        response = self.client.post(url, data, format='json')
+        response = self.client.post(url, data, format="json")
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertIn('journal_contact', response.data)
+        self.assertIn("journal_contact", response.data)
 
     # Test 7: Cross-user protection
 
     def test_cannot_see_other_users_next_steps(self):
         """Test that user_b cannot see user_a's next steps."""
         # Create next step for user_a's journal_contact
-        NextStep.objects.create(
-            journal_contact=self.jc1,
-            title='User A step'
-        )
+        NextStep.objects.create(journal_contact=self.jc1, title="User A step")
 
         # Authenticate as user_b
         self.client.force_authenticate(user=self.user_b)
 
-        url = reverse('journals:nextstep-list')
+        url = reverse("journals:nextstep-list")
         response = self.client.get(url)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         # user_b should see 0 next steps (user_a's are filtered out)
-        self.assertEqual(response.data['count'], 0)
+        self.assertEqual(response.data["count"], 0)
 
     def test_cannot_update_other_users_next_step(self):
         """Test that user_b cannot update user_a's next step."""
         # Create next step for user_a's journal_contact
-        next_step = NextStep.objects.create(
-            journal_contact=self.jc1,
-            title='User A step'
-        )
+        next_step = NextStep.objects.create(journal_contact=self.jc1, title="User A step")
 
         # Authenticate as user_b
         self.client.force_authenticate(user=self.user_b)
 
-        url = reverse('journals:nextstep-detail', kwargs={'pk': next_step.id})
-        response = self.client.patch(url, {'title': 'Hacked'}, format='json')
+        url = reverse("journals:nextstep-detail", kwargs={"pk": next_step.id})
+        response = self.client.patch(url, {"title": "Hacked"}, format="json")
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_cannot_delete_other_users_next_step(self):
         """Test that user_b cannot delete user_a's next step."""
         # Create next step for user_a's journal_contact
-        next_step = NextStep.objects.create(
-            journal_contact=self.jc1,
-            title='User A step'
-        )
+        next_step = NextStep.objects.create(journal_contact=self.jc1, title="User A step")
 
         # Authenticate as user_b
         self.client.force_authenticate(user=self.user_b)
 
-        url = reverse('journals:nextstep-detail', kwargs={'pk': next_step.id})
+        url = reverse("journals:nextstep-detail", kwargs={"pk": next_step.id})
         response = self.client.delete(url)
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
@@ -321,27 +274,15 @@ class NextStepAPITests(APITestCase):
     def test_next_steps_ordered_by_order_then_created_at(self):
         """Test that next steps are returned in correct order."""
         # Create next steps with different orders
-        ns3 = NextStep.objects.create(
-            journal_contact=self.jc1,
-            title='Third',
-            order=3
-        )
-        ns1 = NextStep.objects.create(
-            journal_contact=self.jc1,
-            title='First',
-            order=1
-        )
-        ns2 = NextStep.objects.create(
-            journal_contact=self.jc1,
-            title='Second',
-            order=2
-        )
+        ns3 = NextStep.objects.create(journal_contact=self.jc1, title="Third", order=3)
+        ns1 = NextStep.objects.create(journal_contact=self.jc1, title="First", order=1)
+        ns2 = NextStep.objects.create(journal_contact=self.jc1, title="Second", order=2)
 
-        url = reverse('journals:nextstep-list')
-        response = self.client.get(url, {'journal_contact': str(self.jc1.id)})
+        url = reverse("journals:nextstep-list")
+        response = self.client.get(url, {"journal_contact": str(self.jc1.id)})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data['count'], 3)
-        self.assertEqual(response.data['results'][0]['title'], 'First')
-        self.assertEqual(response.data['results'][1]['title'], 'Second')
-        self.assertEqual(response.data['results'][2]['title'], 'Third')
+        self.assertEqual(response.data["count"], 3)
+        self.assertEqual(response.data["results"][0]["title"], "First")
+        self.assertEqual(response.data["results"][1]["title"], "Second")
+        self.assertEqual(response.data["results"][2]["title"], "Third")

--- a/apps/journals/tests/test_scheduled_stage.py
+++ b/apps/journals/tests/test_scheduled_stage.py
@@ -43,8 +43,8 @@ class ScheduledStageModelTests(TestCase):
         self.assertEqual(meet_idx, scheduled_idx + 1)
 
     def test_create_event_with_scheduled_stage_and_valid_metadata(self):
-        """Test 2: Creating JournalStageEvent with stage='scheduled', event_type='meeting_scheduled',
-        metadata={'scheduled_date': '2026-04-15'} succeeds."""
+        """Test 2: Creating JournalStageEvent with stage='scheduled',
+        event_type='meeting_scheduled', metadata={'scheduled_date': '2026-04-15'} succeeds."""
         user = User.objects.create_user(
             email="test@example.com",
             password="pass123",

--- a/apps/journals/tests/test_scheduled_stage.py
+++ b/apps/journals/tests/test_scheduled_stage.py
@@ -15,19 +15,12 @@ from decimal import Decimal
 
 from django.contrib.auth import get_user_model
 from django.test import TestCase
+
 from rest_framework.test import APIRequestFactory
 
 from apps.contacts.models import Contact
-from apps.journals.models import (
-    Journal,
-    JournalContact,
-    JournalStageEvent,
-    PipelineStage,
-)
-from apps.journals.serializers import (
-    JournalContactSerializer,
-    JournalStageEventSerializer,
-)
+from apps.journals.models import Journal, JournalContact, JournalStageEvent, PipelineStage
+from apps.journals.serializers import JournalContactSerializer, JournalStageEventSerializer
 
 User = get_user_model()
 
@@ -37,15 +30,15 @@ class ScheduledStageModelTests(TestCase):
 
     def test_scheduled_enum_exists(self):
         """Test 1: PipelineStage.SCHEDULED exists with value 'scheduled' and label 'Scheduled'."""
-        self.assertEqual(PipelineStage.SCHEDULED.value, 'scheduled')
-        self.assertEqual(PipelineStage.SCHEDULED.label, 'Scheduled')
+        self.assertEqual(PipelineStage.SCHEDULED.value, "scheduled")
+        self.assertEqual(PipelineStage.SCHEDULED.label, "Scheduled")
 
     def test_scheduled_between_contact_and_meet(self):
         """Verify SCHEDULED is positioned between CONTACT and MEET in the enum."""
         values = PipelineStage.values
-        contact_idx = values.index('contact')
-        scheduled_idx = values.index('scheduled')
-        meet_idx = values.index('meet')
+        contact_idx = values.index("contact")
+        scheduled_idx = values.index("scheduled")
+        meet_idx = values.index("meet")
         self.assertEqual(scheduled_idx, contact_idx + 1)
         self.assertEqual(meet_idx, scheduled_idx + 1)
 
@@ -53,28 +46,35 @@ class ScheduledStageModelTests(TestCase):
         """Test 2: Creating JournalStageEvent with stage='scheduled', event_type='meeting_scheduled',
         metadata={'scheduled_date': '2026-04-15'} succeeds."""
         user = User.objects.create_user(
-            email='test@example.com', password='pass123',
-            first_name='Test', last_name='User', role='missionary',
+            email="test@example.com",
+            password="pass123",
+            first_name="Test",
+            last_name="User",
+            role="missionary",
         )
         journal = Journal.objects.create(
-            owner=user, name='Test Journal', goal_amount=Decimal('10000.00'),
+            owner=user,
+            name="Test Journal",
+            goal_amount=Decimal("10000.00"),
         )
         contact = Contact.objects.create(
-            owner=user, first_name='Alice', last_name='Smith',
-            email='alice@example.com',
+            owner=user,
+            first_name="Alice",
+            last_name="Smith",
+            email="alice@example.com",
         )
         jc = JournalContact.objects.create(journal=journal, contact=contact)
 
         event = JournalStageEvent.objects.create(
             journal_contact=jc,
-            stage='scheduled',
-            event_type='meeting_scheduled',
-            metadata={'scheduled_date': '2026-04-15'},
+            stage="scheduled",
+            event_type="meeting_scheduled",
+            metadata={"scheduled_date": "2026-04-15"},
             triggered_by=user,
         )
-        self.assertEqual(event.stage, 'scheduled')
-        self.assertEqual(event.event_type, 'meeting_scheduled')
-        self.assertEqual(event.metadata['scheduled_date'], '2026-04-15')
+        self.assertEqual(event.stage, "scheduled")
+        self.assertEqual(event.event_type, "meeting_scheduled")
+        self.assertEqual(event.metadata["scheduled_date"], "2026-04-15")
 
 
 class ScheduledStageSerializerTests(TestCase):
@@ -82,23 +82,31 @@ class ScheduledStageSerializerTests(TestCase):
 
     def setUp(self):
         self.user = User.objects.create_user(
-            email='test@example.com', password='pass123',
-            first_name='Test', last_name='User', role='missionary',
+            email="test@example.com",
+            password="pass123",
+            first_name="Test",
+            last_name="User",
+            role="missionary",
         )
         self.journal = Journal.objects.create(
-            owner=self.user, name='Test Journal', goal_amount=Decimal('10000.00'),
+            owner=self.user,
+            name="Test Journal",
+            goal_amount=Decimal("10000.00"),
         )
         self.contact = Contact.objects.create(
-            owner=self.user, first_name='Alice', last_name='Smith',
-            email='alice@example.com',
+            owner=self.user,
+            first_name="Alice",
+            last_name="Smith",
+            email="alice@example.com",
         )
         self.jc = JournalContact.objects.create(
-            journal=self.journal, contact=self.contact,
+            journal=self.journal,
+            contact=self.contact,
         )
         self.factory = APIRequestFactory()
 
     def _get_request(self):
-        request = self.factory.post('/fake/')
+        request = self.factory.post("/fake/")
         request.user = self.user
         return request
 
@@ -107,31 +115,31 @@ class ScheduledStageSerializerTests(TestCase):
         raises ValidationError containing 'scheduled_date is required'."""
         serializer = JournalStageEventSerializer(
             data={
-                'journal_contact': str(self.jc.id),
-                'stage': 'scheduled',
-                'event_type': 'meeting_scheduled',
-                'metadata': {},
+                "journal_contact": str(self.jc.id),
+                "stage": "scheduled",
+                "event_type": "meeting_scheduled",
+                "metadata": {},
             },
-            context={'request': self._get_request()},
+            context={"request": self._get_request()},
         )
         self.assertFalse(serializer.is_valid())
         errors_str = str(serializer.errors)
-        self.assertIn('scheduled_date', errors_str.lower())
+        self.assertIn("scheduled_date", errors_str.lower())
 
     def test_scheduled_stage_with_date_and_time_succeeds(self):
         """Test 4: Creating JournalStageEvent with stage='scheduled' and metadata with
         scheduled_date and scheduled_time succeeds."""
         serializer = JournalStageEventSerializer(
             data={
-                'journal_contact': str(self.jc.id),
-                'stage': 'scheduled',
-                'event_type': 'meeting_scheduled',
-                'metadata': {
-                    'scheduled_date': '2026-04-15',
-                    'scheduled_time': '14:30',
+                "journal_contact": str(self.jc.id),
+                "stage": "scheduled",
+                "event_type": "meeting_scheduled",
+                "metadata": {
+                    "scheduled_date": "2026-04-15",
+                    "scheduled_time": "14:30",
                 },
             },
-            context={'request': self._get_request()},
+            context={"request": self._get_request()},
         )
         self.assertTrue(serializer.is_valid(), serializer.errors)
 
@@ -139,14 +147,14 @@ class ScheduledStageSerializerTests(TestCase):
         """Scheduled stage with only scheduled_date (no time) succeeds."""
         serializer = JournalStageEventSerializer(
             data={
-                'journal_contact': str(self.jc.id),
-                'stage': 'scheduled',
-                'event_type': 'meeting_scheduled',
-                'metadata': {
-                    'scheduled_date': '2026-04-15',
+                "journal_contact": str(self.jc.id),
+                "stage": "scheduled",
+                "event_type": "meeting_scheduled",
+                "metadata": {
+                    "scheduled_date": "2026-04-15",
                 },
             },
-            context={'request': self._get_request()},
+            context={"request": self._get_request()},
         )
         self.assertTrue(serializer.is_valid(), serializer.errors)
 
@@ -156,18 +164,26 @@ class ScheduledStageSummaryTests(TestCase):
 
     def setUp(self):
         self.user = User.objects.create_user(
-            email='test@example.com', password='pass123',
-            first_name='Test', last_name='User', role='missionary',
+            email="test@example.com",
+            password="pass123",
+            first_name="Test",
+            last_name="User",
+            role="missionary",
         )
         self.journal = Journal.objects.create(
-            owner=self.user, name='Test Journal', goal_amount=Decimal('10000.00'),
+            owner=self.user,
+            name="Test Journal",
+            goal_amount=Decimal("10000.00"),
         )
         self.contact = Contact.objects.create(
-            owner=self.user, first_name='Alice', last_name='Smith',
-            email='alice@example.com',
+            owner=self.user,
+            first_name="Alice",
+            last_name="Smith",
+            email="alice@example.com",
         )
         self.jc = JournalContact.objects.create(
-            journal=self.journal, contact=self.contact,
+            journal=self.journal,
+            contact=self.contact,
         )
 
     def test_scheduled_summary_includes_scheduled_date(self):
@@ -175,37 +191,37 @@ class ScheduledStageSummaryTests(TestCase):
         key extracted from most recent event's metadata."""
         JournalStageEvent.objects.create(
             journal_contact=self.jc,
-            stage='scheduled',
-            event_type='meeting_scheduled',
-            metadata={'scheduled_date': '2026-04-15'},
+            stage="scheduled",
+            event_type="meeting_scheduled",
+            metadata={"scheduled_date": "2026-04-15"},
             triggered_by=self.user,
         )
         factory = APIRequestFactory()
-        request = factory.get('/fake/')
+        request = factory.get("/fake/")
         request.user = self.user
 
-        serializer = JournalContactSerializer(self.jc, context={'request': request})
-        stage_events = serializer.data['stage_events']
-        scheduled = stage_events['scheduled']
+        serializer = JournalContactSerializer(self.jc, context={"request": request})
+        stage_events = serializer.data["stage_events"]
+        scheduled = stage_events["scheduled"]
 
-        self.assertTrue(scheduled['has_events'])
-        self.assertIn('scheduled_date', scheduled)
-        self.assertEqual(scheduled['scheduled_date'], '2026-04-15')
+        self.assertTrue(scheduled["has_events"])
+        self.assertIn("scheduled_date", scheduled)
+        self.assertEqual(scheduled["scheduled_date"], "2026-04-15")
 
     def test_scheduled_summary_no_events_has_null_scheduled_date(self):
         """Test 6: get_stage_events summary for 'scheduled' stage with no events
         has scheduled_date=None."""
         factory = APIRequestFactory()
-        request = factory.get('/fake/')
+        request = factory.get("/fake/")
         request.user = self.user
 
-        serializer = JournalContactSerializer(self.jc, context={'request': request})
-        stage_events = serializer.data['stage_events']
-        scheduled = stage_events['scheduled']
+        serializer = JournalContactSerializer(self.jc, context={"request": request})
+        stage_events = serializer.data["stage_events"]
+        scheduled = stage_events["scheduled"]
 
-        self.assertFalse(scheduled['has_events'])
-        self.assertIn('scheduled_date', scheduled)
-        self.assertIsNone(scheduled['scheduled_date'])
+        self.assertFalse(scheduled["has_events"])
+        self.assertIn("scheduled_date", scheduled)
+        self.assertIsNone(scheduled["scheduled_date"])
 
 
 class GoalExclusionTests(TestCase):
@@ -213,22 +229,31 @@ class GoalExclusionTests(TestCase):
 
     def setUp(self):
         self.user = User.objects.create_user(
-            email='test@example.com', password='pass123',
-            first_name='Test', last_name='User', role='missionary',
+            email="test@example.com",
+            password="pass123",
+            first_name="Test",
+            last_name="User",
+            role="missionary",
             monthly_support_goal_cents=500000,
         )
         self.journal = Journal.objects.create(
-            owner=self.user, name='Test Journal', goal_amount=Decimal('10000.00'),
+            owner=self.user,
+            name="Test Journal",
+            goal_amount=Decimal("10000.00"),
         )
         self.contact = Contact.objects.create(
-            owner=self.user, first_name='Alice', last_name='Smith',
-            email='alice@example.com',
+            owner=self.user,
+            first_name="Alice",
+            last_name="Smith",
+            email="alice@example.com",
         )
         self.jc = JournalContact.objects.create(
-            journal=self.journal, contact=self.contact,
+            journal=self.journal,
+            contact=self.contact,
         )
         # Select this journal for goal tracking
         from apps.users.models import GoalJournalSelection
+
         GoalJournalSelection.objects.create(user=self.user, journal=self.journal)
 
     def test_calls_count_excludes_meeting_scheduled(self):
@@ -236,43 +261,45 @@ class GoalExclusionTests(TestCase):
         # Create a meeting_scheduled event (should NOT count as a call)
         JournalStageEvent.objects.create(
             journal_contact=self.jc,
-            stage='scheduled',
-            event_type='meeting_scheduled',
-            metadata={'scheduled_date': '2026-04-15'},
+            stage="scheduled",
+            event_type="meeting_scheduled",
+            metadata={"scheduled_date": "2026-04-15"},
             triggered_by=self.user,
         )
         # Create an actual call event (should count)
         JournalStageEvent.objects.create(
             journal_contact=self.jc,
-            stage='contact',
-            event_type='call_logged',
+            stage="contact",
+            event_type="call_logged",
             triggered_by=self.user,
         )
 
         from apps.users.goal_services import get_goal_progress
+
         progress = get_goal_progress(self.user)
 
-        self.assertEqual(progress['calls_count'], 1)
+        self.assertEqual(progress["calls_count"], 1)
 
     def test_meetings_count_excludes_meeting_scheduled(self):
         """Test 8: Goal services meetings_count excludes meeting_scheduled events."""
         # Create a meeting_scheduled event (should NOT count as meeting)
         JournalStageEvent.objects.create(
             journal_contact=self.jc,
-            stage='scheduled',
-            event_type='meeting_scheduled',
-            metadata={'scheduled_date': '2026-04-15'},
+            stage="scheduled",
+            event_type="meeting_scheduled",
+            metadata={"scheduled_date": "2026-04-15"},
             triggered_by=self.user,
         )
         # Create an actual meeting completed event (should count)
         JournalStageEvent.objects.create(
             journal_contact=self.jc,
-            stage='meet',
-            event_type='meeting_completed',
+            stage="meet",
+            event_type="meeting_completed",
             triggered_by=self.user,
         )
 
         from apps.users.goal_services import get_goal_progress
+
         progress = get_goal_progress(self.user)
 
-        self.assertEqual(progress['meetings_count'], 1)
+        self.assertEqual(progress["meetings_count"], 1)

--- a/apps/journals/urls.py
+++ b/apps/journals/urls.py
@@ -2,6 +2,7 @@
 URL configuration for journals app.
 """
 from django.urls import include, path
+
 from rest_framework.routers import DefaultRouter
 
 from apps.journals.export_views import JournalExportCSVView
@@ -20,23 +21,31 @@ from apps.journals.views import (
     NextStepListCreateView,
 )
 
-app_name = 'journals'
+app_name = "journals"
 
 router = DefaultRouter()
-router.register(r'analytics', JournalAnalyticsViewSet, basename='journal-analytics')
+router.register(r"analytics", JournalAnalyticsViewSet, basename="journal-analytics")
 
 urlpatterns = [
-    path('', JournalListCreateView.as_view(), name='journal-list'),
-    path('export/csv/', JournalExportCSVView.as_view(), name='journal-export-csv'),
-    path('<uuid:pk>/', JournalDetailView.as_view(), name='journal-detail'),
-    path('stage-events/', JournalStageEventListCreateView.as_view(), name='stage-event-list'),
-    path('stage-events/delete-by-stage/', JournalStageEventDeleteByStageView.as_view(), name='stage-event-delete-by-stage'),
-    path('journal-members/', JournalContactListCreateView.as_view(), name='journal-member-list'),
-    path('journal-members/<uuid:pk>/', JournalContactDestroyView.as_view(), name='journal-member-detail'),
-    path('decisions/', DecisionListCreateView.as_view(), name='decision-list'),
-    path('decisions/<uuid:pk>/', DecisionDetailView.as_view(), name='decision-detail'),
-    path('decision-history/', DecisionHistoryListView.as_view(), name='decision-history-list'),
-    path('next-steps/', NextStepListCreateView.as_view(), name='nextstep-list'),
-    path('next-steps/<uuid:pk>/', NextStepDetailView.as_view(), name='nextstep-detail'),
-    path('', include(router.urls)),
+    path("", JournalListCreateView.as_view(), name="journal-list"),
+    path("export/csv/", JournalExportCSVView.as_view(), name="journal-export-csv"),
+    path("<uuid:pk>/", JournalDetailView.as_view(), name="journal-detail"),
+    path("stage-events/", JournalStageEventListCreateView.as_view(), name="stage-event-list"),
+    path(
+        "stage-events/delete-by-stage/",
+        JournalStageEventDeleteByStageView.as_view(),
+        name="stage-event-delete-by-stage",
+    ),
+    path("journal-members/", JournalContactListCreateView.as_view(), name="journal-member-list"),
+    path(
+        "journal-members/<uuid:pk>/",
+        JournalContactDestroyView.as_view(),
+        name="journal-member-detail",
+    ),
+    path("decisions/", DecisionListCreateView.as_view(), name="decision-list"),
+    path("decisions/<uuid:pk>/", DecisionDetailView.as_view(), name="decision-detail"),
+    path("decision-history/", DecisionHistoryListView.as_view(), name="decision-history-list"),
+    path("next-steps/", NextStepListCreateView.as_view(), name="nextstep-list"),
+    path("next-steps/<uuid:pk>/", NextStepDetailView.as_view(), name="nextstep-detail"),
+    path("", include(router.urls)),
 ]

--- a/apps/journals/views.py
+++ b/apps/journals/views.py
@@ -9,12 +9,14 @@ from django.db.models import Count, OuterRef, Prefetch, Subquery, Sum
 from django.db.models.functions import TruncMonth
 from django.shortcuts import get_object_or_404
 from django.utils import timezone
-from django_filters.rest_framework import DjangoFilterBackend
-from drf_spectacular.utils import extend_schema
+
 from rest_framework import filters, generics, permissions, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.pagination import PageNumberPagination
 from rest_framework.response import Response
+
+from django_filters.rest_framework import DjangoFilterBackend
+from drf_spectacular.utils import extend_schema
 
 from apps.core.permissions import (
     IsAdmin,

--- a/apps/prayers/admin.py
+++ b/apps/prayers/admin.py
@@ -9,7 +9,8 @@ from apps.prayers.models import PrayerIntention
 @admin.register(PrayerIntention)
 class PrayerIntentionAdmin(admin.ModelAdmin):
     """Admin configuration for PrayerIntention model."""
-    list_display = ['id', 'title', 'contact', 'status', 'answered_at', 'archived_at', 'created_at']
-    list_filter = ['status']
-    search_fields = ['title', 'contact__first_name', 'contact__last_name']
-    readonly_fields = ['id', 'created_at', 'updated_at']
+
+    list_display = ["id", "title", "contact", "status", "answered_at", "archived_at", "created_at"]
+    list_filter = ["status"]
+    search_fields = ["title", "contact__first_name", "contact__last_name"]
+    readonly_fields = ["id", "created_at", "updated_at"]

--- a/apps/prayers/apps.py
+++ b/apps/prayers/apps.py
@@ -5,6 +5,6 @@ from django.apps import AppConfig
 
 
 class PrayersConfig(AppConfig):
-    default_auto_field = 'django.db.models.BigAutoField'
-    name = 'apps.prayers'
-    verbose_name = 'Prayer Intentions'
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "apps.prayers"
+    verbose_name = "Prayer Intentions"

--- a/apps/prayers/filters.py
+++ b/apps/prayers/filters.py
@@ -8,9 +8,10 @@ from apps.prayers.models import PrayerIntention
 
 class PrayerIntentionFilterSet(django_filters.FilterSet):
     """Filter set for PrayerIntention model."""
-    status = django_filters.CharFilter(field_name='status')
-    owner = django_filters.NumberFilter(field_name='contact__owner_id')
+
+    status = django_filters.CharFilter(field_name="status")
+    owner = django_filters.NumberFilter(field_name="contact__owner_id")
 
     class Meta:
         model = PrayerIntention
-        fields = ['status', 'owner']
+        fields = ["status", "owner"]

--- a/apps/prayers/serializers.py
+++ b/apps/prayers/serializers.py
@@ -2,6 +2,7 @@
 Serializers for PrayerIntention model.
 """
 from django.utils import timezone
+
 from rest_framework import serializers
 
 from apps.prayers.models import PrayerIntention
@@ -16,39 +17,53 @@ class PrayerIntentionSerializer(serializers.ModelSerializer):
     - answered: sets answered_at, clears archived_at
     - archived: sets archived_at, clears answered_at
     """
-    contact_name = serializers.CharField(source='contact.full_name', read_only=True)
+
+    contact_name = serializers.CharField(source="contact.full_name", read_only=True)
     owner_name = serializers.SerializerMethodField()
 
     class Meta:
         model = PrayerIntention
         fields = [
-            'id', 'contact', 'contact_name', 'owner_name', 'title', 'description',
-            'status', 'last_prayed_at', 'answered_at', 'archived_at',
-            'created_at', 'updated_at',
+            "id",
+            "contact",
+            "contact_name",
+            "owner_name",
+            "title",
+            "description",
+            "status",
+            "last_prayed_at",
+            "answered_at",
+            "archived_at",
+            "created_at",
+            "updated_at",
         ]
         read_only_fields = [
-            'id', 'answered_at', 'archived_at', 'last_prayed_at',
-            'created_at', 'updated_at',
+            "id",
+            "answered_at",
+            "archived_at",
+            "last_prayed_at",
+            "created_at",
+            "updated_at",
         ]
 
     def get_owner_name(self, obj):
-        contact = getattr(obj, 'contact', None)
+        contact = getattr(obj, "contact", None)
         if contact:
-            owner = getattr(contact, 'owner', None)
+            owner = getattr(contact, "owner", None)
             return owner.full_name if owner else None
         return None
 
     def update(self, instance, validated_data):
-        new_status = validated_data.get('status')
+        new_status = validated_data.get("status")
         if new_status and new_status != instance.status:
             now = timezone.now()
-            if new_status == 'answered':
-                validated_data['answered_at'] = now
-                validated_data['archived_at'] = None
-            elif new_status == 'archived':
-                validated_data['archived_at'] = now
-                validated_data['answered_at'] = None
-            elif new_status == 'active':
-                validated_data['answered_at'] = None
-                validated_data['archived_at'] = None
+            if new_status == "answered":
+                validated_data["answered_at"] = now
+                validated_data["archived_at"] = None
+            elif new_status == "archived":
+                validated_data["archived_at"] = now
+                validated_data["answered_at"] = None
+            elif new_status == "active":
+                validated_data["answered_at"] = None
+                validated_data["archived_at"] = None
         return super().update(instance, validated_data)

--- a/apps/prayers/urls.py
+++ b/apps/prayers/urls.py
@@ -10,11 +10,11 @@ from apps.prayers.views import (
     TodaysFocusView,
 )
 
-app_name = 'prayers'
+app_name = "prayers"
 
 urlpatterns = [
-    path('', PrayerIntentionListCreateView.as_view(), name='prayer-list'),
-    path('focus/', TodaysFocusView.as_view(), name='prayer-focus'),
-    path('<uuid:pk>/', PrayerIntentionDetailView.as_view(), name='prayer-detail'),
-    path('<uuid:pk>/prayed/', MarkPrayedView.as_view(), name='prayer-mark-prayed'),
+    path("", PrayerIntentionListCreateView.as_view(), name="prayer-list"),
+    path("focus/", TodaysFocusView.as_view(), name="prayer-focus"),
+    path("<uuid:pk>/", PrayerIntentionDetailView.as_view(), name="prayer-detail"),
+    path("<uuid:pk>/prayed/", MarkPrayedView.as_view(), name="prayer-mark-prayed"),
 ]

--- a/apps/prayers/views.py
+++ b/apps/prayers/views.py
@@ -5,11 +5,13 @@ import hashlib
 
 from django.db.models import Case, Value, When
 from django.utils import timezone
-from django_filters.rest_framework import DjangoFilterBackend
+
 from rest_framework import generics, permissions, status
 from rest_framework.filters import OrderingFilter, SearchFilter
 from rest_framework.response import Response
 from rest_framework.views import APIView
+
+from django_filters.rest_framework import DjangoFilterBackend
 
 from apps.core.permissions import get_visible_user_ids
 from apps.prayers.filters import PrayerIntentionFilterSet
@@ -19,7 +21,7 @@ from apps.prayers.serializers import PrayerIntentionSerializer
 
 def _owner_scoped_queryset(user, request=None):
     """Return PrayerIntention queryset scoped by ownership."""
-    qs = PrayerIntention.objects.select_related('contact', 'contact__owner').all()
+    qs = PrayerIntention.objects.select_related("contact", "contact__owner").all()
     visible = get_visible_user_ids(user, request=request)
     qs = qs.filter(contact__owner_id__in=visible)
     return qs
@@ -30,22 +32,27 @@ class PrayerIntentionListCreateView(generics.ListCreateAPIView):
     GET: List prayer intentions (owner-scoped)
     POST: Create a new prayer intention
     """
+
     permission_classes = [permissions.IsAuthenticated]
     serializer_class = PrayerIntentionSerializer
     filterset_class = PrayerIntentionFilterSet
     filter_backends = [DjangoFilterBackend, SearchFilter, OrderingFilter]
-    search_fields = ['title', 'contact__first_name', 'contact__last_name']
-    ordering_fields = ['created_at', 'status', 'last_prayed_at']
+    search_fields = ["title", "contact__first_name", "contact__last_name"]
+    ordering_fields = ["created_at", "status", "last_prayed_at"]
 
     def get_queryset(self):
-        return _owner_scoped_queryset(self.request.user, request=self.request).annotate(
-            status_order=Case(
-                When(status='active', then=Value(0)),
-                When(status='answered', then=Value(1)),
-                When(status='archived', then=Value(2)),
-                default=Value(3),
+        return (
+            _owner_scoped_queryset(self.request.user, request=self.request)
+            .annotate(
+                status_order=Case(
+                    When(status="active", then=Value(0)),
+                    When(status="answered", then=Value(1)),
+                    When(status="archived", then=Value(2)),
+                    default=Value(3),
+                )
             )
-        ).order_by('status_order', '-created_at')
+            .order_by("status_order", "-created_at")
+        )
 
 
 class PrayerIntentionDetailView(generics.RetrieveUpdateDestroyAPIView):
@@ -54,6 +61,7 @@ class PrayerIntentionDetailView(generics.RetrieveUpdateDestroyAPIView):
     PATCH/PUT: Update prayer intention (with status timestamp management)
     DELETE: Delete prayer intention
     """
+
     permission_classes = [permissions.IsAuthenticated]
     serializer_class = PrayerIntentionSerializer
 
@@ -65,6 +73,7 @@ class MarkPrayedView(APIView):
     """
     POST: Mark a prayer intention as prayed (sets last_prayed_at to now).
     """
+
     permission_classes = [permissions.IsAuthenticated]
 
     def post(self, request, pk):
@@ -73,12 +82,12 @@ class MarkPrayedView(APIView):
             intention = qs.get(pk=pk)
         except PrayerIntention.DoesNotExist:
             return Response(
-                {'detail': 'Not found.'},
+                {"detail": "Not found."},
                 status=status.HTTP_404_NOT_FOUND,
             )
         intention.last_prayed_at = timezone.now()
-        intention.save(update_fields=['last_prayed_at'])
-        return Response({'detail': 'Marked as prayed.'})
+        intention.save(update_fields=["last_prayed_at"])
+        return Response({"detail": "Marked as prayed."})
 
 
 class TodaysFocusView(generics.ListAPIView):
@@ -89,13 +98,14 @@ class TodaysFocusView(generics.ListAPIView):
     Uses deterministic daily rotation based on hash of date + user pk.
     Limited to min(5, total active intentions).
     """
+
     permission_classes = [permissions.IsAuthenticated]
     serializer_class = PrayerIntentionSerializer
     pagination_class = None
 
     def get_queryset(self):
         user = self.request.user
-        qs = _owner_scoped_queryset(user, request=self.request).filter(status='active')
+        qs = _owner_scoped_queryset(user, request=self.request).filter(status="active")
 
         # Deterministic daily rotation: compute offset from hash of date + user pk
         today_str = timezone.now().date().isoformat()
@@ -108,8 +118,8 @@ class TodaysFocusView(generics.ListAPIView):
                 When(last_prayed_at__isnull=True, then=Value(0)),
                 default=Value(1),
             ),
-            'last_prayed_at',
-            'created_at',
+            "last_prayed_at",
+            "created_at",
         )
 
         total = ordered.count()
@@ -120,15 +130,16 @@ class TodaysFocusView(generics.ListAPIView):
         offset = hash_val % total
 
         # Wrap around: pick `limit` items starting at offset
-        pks = list(ordered.values_list('pk', flat=True))
+        pks = list(ordered.values_list("pk", flat=True))
         selected_pks = []
         for i in range(limit):
             selected_pks.append(pks[(offset + i) % total])
 
         # Preserve the ordering from the selected set
-        preserved = Case(
-            *[When(pk=pk, then=Value(i)) for i, pk in enumerate(selected_pks)]
+        preserved = Case(*[When(pk=pk, then=Value(i)) for i, pk in enumerate(selected_pks)])
+        return (
+            PrayerIntention.objects.select_related("contact", "contact__owner")
+            .filter(pk__in=selected_pks)
+            .annotate(focus_order=preserved)
+            .order_by("focus_order")
         )
-        return PrayerIntention.objects.select_related('contact', 'contact__owner').filter(
-            pk__in=selected_pks
-        ).annotate(focus_order=preserved).order_by('focus_order')

--- a/apps/tasks/admin.py
+++ b/apps/tasks/admin.py
@@ -9,16 +9,23 @@ from apps.tasks.models import Task
 @admin.register(Task)
 class TaskAdmin(admin.ModelAdmin):
     list_display = (
-        'title', 'owner', 'contact', 'task_type',
-        'priority', 'status', 'due_date', 'is_overdue'
+        "title",
+        "owner",
+        "contact",
+        "task_type",
+        "priority",
+        "status",
+        "due_date",
+        "is_overdue",
     )
-    list_filter = ('status', 'task_type', 'priority', 'due_date')
-    search_fields = ('title', 'description', 'contact__first_name', 'contact__last_name')
-    ordering = ('due_date', '-priority')
+    list_filter = ("status", "task_type", "priority", "due_date")
+    search_fields = ("title", "description", "contact__first_name", "contact__last_name")
+    ordering = ("due_date", "-priority")
 
-    readonly_fields = ('completed_at', 'completed_by', 'created_at', 'updated_at')
+    readonly_fields = ("completed_at", "completed_by", "created_at", "updated_at")
 
     def is_overdue(self, obj):
         return obj.is_overdue
+
     is_overdue.boolean = True
-    is_overdue.short_description = 'Overdue'
+    is_overdue.short_description = "Overdue"

--- a/apps/tasks/apps.py
+++ b/apps/tasks/apps.py
@@ -2,6 +2,6 @@ from django.apps import AppConfig
 
 
 class TasksConfig(AppConfig):
-    default_auto_field = 'django.db.models.BigAutoField'
-    name = 'apps.tasks'
-    verbose_name = 'Tasks'
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "apps.tasks"
+    verbose_name = "Tasks"

--- a/apps/tasks/broadcast_serializers.py
+++ b/apps/tasks/broadcast_serializers.py
@@ -79,7 +79,9 @@ class BroadcastCreateSerializer(serializers.Serializer):
         if target_type == "specific_users" and not specific_user_ids:
             raise serializers.ValidationError(
                 {
-                    "specific_user_ids": "At least one user ID is required for specific_users target type."
+                    "specific_user_ids": (
+                        "At least one user ID is required for specific_users target type."
+                    )
                 }
             )
 
@@ -89,7 +91,9 @@ class BroadcastCreateSerializer(serializers.Serializer):
             if target_type in ("all_missionaries", "all_supervisors"):
                 raise serializers.ValidationError(
                     {
-                        "target_type": "Supervisors cannot target all missionaries or all supervisors."
+                        "target_type": (
+                            "Supervisors cannot target all missionaries or all supervisors."
+                        )
                     }
                 )
 

--- a/apps/tasks/broadcast_serializers.py
+++ b/apps/tasks/broadcast_serializers.py
@@ -5,23 +5,34 @@ Provides list, detail, and create serializers for the BroadcastTask model.
 """
 from rest_framework import serializers
 
-from apps.tasks.models import BroadcastTask, TaskType, TaskPriority
+from apps.tasks.models import BroadcastTask, TaskPriority, TaskType
 
 
 class BroadcastTaskListSerializer(serializers.ModelSerializer):
     """Serializer for broadcast task list views with completion stats."""
-    sender_name = serializers.CharField(source='sender.full_name', read_only=True)
+
+    sender_name = serializers.CharField(source="sender.full_name", read_only=True)
     completed_count = serializers.IntegerField(read_only=True)
     total_count = serializers.IntegerField(read_only=True)
 
     class Meta:
         model = BroadcastTask
         fields = [
-            'id', 'sender', 'sender_name',
-            'title', 'description', 'task_type', 'priority', 'due_date',
-            'target_type', 'recipient_count',
-            'completed_count', 'total_count',
-            'is_cancelled', 'cancelled_at', 'created_at',
+            "id",
+            "sender",
+            "sender_name",
+            "title",
+            "description",
+            "task_type",
+            "priority",
+            "due_date",
+            "target_type",
+            "recipient_count",
+            "completed_count",
+            "total_count",
+            "is_cancelled",
+            "cancelled_at",
+            "created_at",
         ]
 
 
@@ -29,13 +40,14 @@ class BroadcastTaskDetailSerializer(BroadcastTaskListSerializer):
     """Extended serializer that includes recipient_ids for detail views."""
 
     class Meta(BroadcastTaskListSerializer.Meta):
-        fields = BroadcastTaskListSerializer.Meta.fields + ['recipient_ids']
+        fields = BroadcastTaskListSerializer.Meta.fields + ["recipient_ids"]
 
 
 class BroadcastCreateSerializer(serializers.Serializer):
     """Serializer for validating broadcast creation requests."""
+
     title = serializers.CharField(max_length=255)
-    description = serializers.CharField(required=False, default='')
+    description = serializers.CharField(required=False, default="")
     task_type = serializers.ChoiceField(
         choices=TaskType.choices,
         default=TaskType.OTHER,
@@ -47,10 +59,10 @@ class BroadcastCreateSerializer(serializers.Serializer):
     due_date = serializers.DateField()
     target_type = serializers.ChoiceField(
         choices=[
-            ('all_missionaries', 'All Missionaries'),
-            ('all_supervisors', 'All Supervisors'),
-            ('specific_users', 'Specific Users'),
-            ('my_team', 'My Team'),
+            ("all_missionaries", "All Missionaries"),
+            ("all_supervisors", "All Supervisors"),
+            ("specific_users", "Specific Users"),
+            ("my_team", "My Team"),
         ],
     )
     specific_user_ids = serializers.ListField(
@@ -60,21 +72,25 @@ class BroadcastCreateSerializer(serializers.Serializer):
     )
 
     def validate(self, attrs):
-        target_type = attrs.get('target_type')
-        specific_user_ids = attrs.get('specific_user_ids', [])
+        target_type = attrs.get("target_type")
+        specific_user_ids = attrs.get("specific_user_ids", [])
 
         # Require specific_user_ids when target_type is 'specific_users'
-        if target_type == 'specific_users' and not specific_user_ids:
+        if target_type == "specific_users" and not specific_user_ids:
             raise serializers.ValidationError(
-                {"specific_user_ids": "At least one user ID is required for specific_users target type."}
+                {
+                    "specific_user_ids": "At least one user ID is required for specific_users target type."
+                }
             )
 
         # Supervisor role restrictions
-        request = self.context.get('request')
-        if request and request.user.role == 'supervisor':
-            if target_type in ('all_missionaries', 'all_supervisors'):
+        request = self.context.get("request")
+        if request and request.user.role == "supervisor":
+            if target_type in ("all_missionaries", "all_supervisors"):
                 raise serializers.ValidationError(
-                    {"target_type": "Supervisors cannot target all missionaries or all supervisors."}
+                    {
+                        "target_type": "Supervisors cannot target all missionaries or all supervisors."
+                    }
                 )
 
         return attrs
@@ -82,6 +98,7 @@ class BroadcastCreateSerializer(serializers.Serializer):
 
 class BroadcastUpdateSerializer(serializers.Serializer):
     """Serializer for validating broadcast update requests (all fields optional)."""
+
     title = serializers.CharField(max_length=255, required=False)
     description = serializers.CharField(required=False)
     task_type = serializers.ChoiceField(choices=TaskType.choices, required=False)

--- a/apps/tasks/broadcast_services.py
+++ b/apps/tasks/broadcast_services.py
@@ -6,6 +6,7 @@ All mutating operations are wrapped in database transactions for atomicity.
 """
 from django.db import transaction
 from django.utils import timezone
+
 from rest_framework.exceptions import ValidationError
 
 from apps.tasks.models import BroadcastTask, Task, TaskStatus
@@ -27,32 +28,33 @@ def resolve_recipients(sender, target_type, specific_user_ids=None):
     """
     from apps.users.models import User
 
-    if target_type == 'all_missionaries':
-        if sender.role != 'admin':
+    if target_type == "all_missionaries":
+        if sender.role != "admin":
             raise PermissionError("Only admins can target all missionaries")
-        return list(User.objects.filter(
-            role__in=['missionary', 'supervisor'], is_active=True
-        ).exclude(id=sender.id))
+        return list(
+            User.objects.filter(role__in=["missionary", "supervisor"], is_active=True).exclude(
+                id=sender.id
+            )
+        )
 
-    elif target_type == 'all_supervisors':
-        if sender.role != 'admin':
+    elif target_type == "all_supervisors":
+        if sender.role != "admin":
             raise PermissionError("Only admins can target all supervisors")
-        return list(User.objects.filter(role='supervisor', is_active=True))
+        return list(User.objects.filter(role="supervisor", is_active=True))
 
-    elif target_type == 'my_team':
-        if sender.role not in ('admin', 'supervisor'):
+    elif target_type == "my_team":
+        if sender.role not in ("admin", "supervisor"):
             raise PermissionError("Only admins and supervisors can target their team")
         return list(sender.supervised_users.filter(is_active=True))
 
-    elif target_type == 'specific_users':
+    elif target_type == "specific_users":
         if not specific_user_ids:
             return []
         users = User.objects.filter(id__in=specific_user_ids, is_active=True)
         # Server-side enforcement: supervisor can only target supervised users
-        if sender.role == 'supervisor':
+        if sender.role == "supervisor":
             allowed_ids = set(
-                sender.supervised_users.filter(is_active=True)
-                .values_list('id', flat=True)
+                sender.supervised_users.filter(is_active=True).values_list("id", flat=True)
             )
             users = users.filter(id__in=allowed_ids)
         return list(users)
@@ -61,8 +63,9 @@ def resolve_recipients(sender, target_type, specific_user_ids=None):
 
 
 @transaction.atomic
-def create_broadcast(sender, title, description, task_type, priority,
-                     due_date, target_type, specific_user_ids=None):
+def create_broadcast(
+    sender, title, description, task_type, priority, due_date, target_type, specific_user_ids=None
+):
     """Create a broadcast and distribute task copies to all resolved recipients.
 
     Args:
@@ -119,8 +122,9 @@ def create_broadcast(sender, title, description, task_type, priority,
 
 
 @transaction.atomic
-def update_broadcast(broadcast, title=None, description=None, task_type=None,
-                     priority=None, due_date=None):
+def update_broadcast(
+    broadcast, title=None, description=None, task_type=None, priority=None, due_date=None
+):
     """Update broadcast fields and cascade changes to incomplete copies only.
 
     Completed and cancelled copies are untouched.
@@ -142,40 +146,36 @@ def update_broadcast(broadcast, title=None, description=None, task_type=None,
 
     if title is not None:
         broadcast.title = title
-        broadcast_update_fields.append('title')
-        task_update_fields['title'] = title
+        broadcast_update_fields.append("title")
+        task_update_fields["title"] = title
 
     if description is not None:
         broadcast.description = description
-        broadcast_update_fields.append('description')
-        task_update_fields['description'] = description
+        broadcast_update_fields.append("description")
+        task_update_fields["description"] = description
 
     if task_type is not None:
         broadcast.task_type = task_type
-        broadcast_update_fields.append('task_type')
-        task_update_fields['task_type'] = task_type
+        broadcast_update_fields.append("task_type")
+        task_update_fields["task_type"] = task_type
 
     if priority is not None:
         broadcast.priority = priority
-        broadcast_update_fields.append('priority')
-        task_update_fields['priority'] = priority
+        broadcast_update_fields.append("priority")
+        task_update_fields["priority"] = priority
 
     if due_date is not None:
         broadcast.due_date = due_date
-        broadcast_update_fields.append('due_date')
-        task_update_fields['due_date'] = due_date
+        broadcast_update_fields.append("due_date")
+        task_update_fields["due_date"] = due_date
 
     if broadcast_update_fields:
-        broadcast_update_fields.append('updated_at')
+        broadcast_update_fields.append("updated_at")
         broadcast.save(update_fields=broadcast_update_fields)
 
     if task_update_fields:
         # Cascade to incomplete copies only
-        Task.objects.filter(
-            broadcast=broadcast
-        ).exclude(
-            status=TaskStatus.COMPLETED
-        ).exclude(
+        Task.objects.filter(broadcast=broadcast).exclude(status=TaskStatus.COMPLETED).exclude(
             status=TaskStatus.CANCELLED
         ).update(**task_update_fields)
 
@@ -195,15 +195,11 @@ def cancel_broadcast(broadcast):
         BroadcastTask: The updated broadcast record.
     """
     # Delete incomplete copies
-    Task.objects.filter(
-        broadcast=broadcast
-    ).exclude(
-        status=TaskStatus.COMPLETED
-    ).delete()
+    Task.objects.filter(broadcast=broadcast).exclude(status=TaskStatus.COMPLETED).delete()
 
     # Mark broadcast as cancelled
     broadcast.is_cancelled = True
     broadcast.cancelled_at = timezone.now()
-    broadcast.save(update_fields=['is_cancelled', 'cancelled_at', 'updated_at'])
+    broadcast.save(update_fields=["is_cancelled", "cancelled_at", "updated_at"])
 
     return broadcast

--- a/apps/tasks/broadcast_views.py
+++ b/apps/tasks/broadcast_views.py
@@ -1,9 +1,11 @@
 """Views for Broadcast Task management."""
 from django.db.models import Count, Q
-from django_filters.rest_framework import DjangoFilterBackend
+
 from rest_framework import filters, generics, permissions, status
 from rest_framework.response import Response
 from rest_framework.views import APIView
+
+from django_filters.rest_framework import DjangoFilterBackend
 
 from apps.tasks.broadcast_serializers import (
     BroadcastCreateSerializer,
@@ -22,20 +24,20 @@ def _broadcast_queryset_for_user(user):
     Admin sees all broadcasts. Supervisor sees only broadcasts they sent.
     All other roles get an empty queryset.
     """
-    if user.role == 'admin':
+    if user.role == "admin":
         qs = BroadcastTask.objects.all()
-    elif user.role == 'supervisor':
+    elif user.role == "supervisor":
         qs = BroadcastTask.objects.filter(sender=user)
     else:
         qs = BroadcastTask.objects.none()
 
     return qs.annotate(
         completed_count=Count(
-            'copies',
+            "copies",
             filter=Q(copies__status=TaskStatus.COMPLETED),
         ),
-        total_count=Count('copies'),
-    ).select_related('sender')
+        total_count=Count("copies"),
+    ).select_related("sender")
 
 
 class BroadcastListCreateView(generics.ListCreateAPIView):
@@ -43,29 +45,28 @@ class BroadcastListCreateView(generics.ListCreateAPIView):
     GET: List broadcasts (admin sees all, supervisor sees own).
     POST: Create a broadcast (admin/supervisor only).
     """
+
     permission_classes = [permissions.IsAuthenticated]
     filter_backends = [filters.OrderingFilter]
-    ordering_fields = ['created_at', 'due_date']
-    ordering = ['-created_at']
+    ordering_fields = ["created_at", "due_date"]
+    ordering = ["-created_at"]
 
     def get_queryset(self):
         return _broadcast_queryset_for_user(self.request.user)
 
     def get_serializer_class(self):
-        if self.request.method == 'POST':
+        if self.request.method == "POST":
             return BroadcastCreateSerializer
         return BroadcastTaskListSerializer
 
     def create(self, request, *args, **kwargs):
-        if request.user.role not in ('admin', 'supervisor'):
+        if request.user.role not in ("admin", "supervisor"):
             return Response(
-                {'detail': 'Only admins and supervisors can create broadcasts.'},
+                {"detail": "Only admins and supervisors can create broadcasts."},
                 status=status.HTTP_403_FORBIDDEN,
             )
 
-        serializer = BroadcastCreateSerializer(
-            data=request.data, context={'request': request}
-        )
+        serializer = BroadcastCreateSerializer(data=request.data, context={"request": request})
         serializer.is_valid(raise_exception=True)
 
         broadcast = create_broadcast(
@@ -75,9 +76,7 @@ class BroadcastListCreateView(generics.ListCreateAPIView):
 
         # Re-query with annotations for the response
         annotated = _broadcast_queryset_for_user(request.user).get(pk=broadcast.pk)
-        response_serializer = BroadcastTaskListSerializer(
-            annotated, context={'request': request}
-        )
+        response_serializer = BroadcastTaskListSerializer(annotated, context={"request": request})
         return Response(response_serializer.data, status=status.HTTP_201_CREATED)
 
 
@@ -86,6 +85,7 @@ class BroadcastDetailView(generics.RetrieveUpdateAPIView):
     GET: Retrieve broadcast detail (includes recipient_ids).
     PATCH/PUT: Update broadcast (cascades to incomplete copies).
     """
+
     permission_classes = [permissions.IsAuthenticated]
     serializer_class = BroadcastTaskDetailSerializer
 
@@ -96,9 +96,9 @@ class BroadcastDetailView(generics.RetrieveUpdateAPIView):
         broadcast = self.get_object()
 
         # Only sender or admin can update
-        if request.user.role != 'admin' and broadcast.sender_id != request.user.id:
+        if request.user.role != "admin" and broadcast.sender_id != request.user.id:
             return Response(
-                {'detail': 'Only the broadcast sender or an admin can update.'},
+                {"detail": "Only the broadcast sender or an admin can update."},
                 status=status.HTTP_403_FORBIDDEN,
             )
 
@@ -109,14 +109,13 @@ class BroadcastDetailView(generics.RetrieveUpdateAPIView):
 
         # Re-query with annotations
         annotated = self.get_queryset().get(pk=broadcast.pk)
-        serializer = BroadcastTaskDetailSerializer(
-            annotated, context={'request': request}
-        )
+        serializer = BroadcastTaskDetailSerializer(annotated, context={"request": request})
         return Response(serializer.data)
 
 
 class BroadcastCancelView(APIView):
     """POST: Cancel a broadcast (deletes incomplete copies, keeps completed)."""
+
     permission_classes = [permissions.IsAuthenticated]
 
     def post(self, request, pk):
@@ -125,41 +124,42 @@ class BroadcastCancelView(APIView):
             broadcast = qs.get(pk=pk)
         except BroadcastTask.DoesNotExist:
             return Response(
-                {'detail': 'Broadcast not found.'},
+                {"detail": "Broadcast not found."},
                 status=status.HTTP_404_NOT_FOUND,
             )
 
         # Only sender or admin can cancel
-        if request.user.role != 'admin' and broadcast.sender_id != request.user.id:
+        if request.user.role != "admin" and broadcast.sender_id != request.user.id:
             return Response(
-                {'detail': 'Only the broadcast sender or an admin can cancel.'},
+                {"detail": "Only the broadcast sender or an admin can cancel."},
                 status=status.HTTP_403_FORBIDDEN,
             )
 
         if broadcast.is_cancelled:
             return Response(
-                {'detail': 'Broadcast is already cancelled.'},
+                {"detail": "Broadcast is already cancelled."},
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
         cancel_broadcast(broadcast)
-        return Response({'detail': 'Broadcast cancelled.'})
+        return Response({"detail": "Broadcast cancelled."})
 
 
 class BroadcastCopyListView(generics.ListAPIView):
     """GET: List per-user task copies for a broadcast."""
+
     permission_classes = [permissions.IsAuthenticated]
     serializer_class = TaskSerializer
     filter_backends = [DjangoFilterBackend, filters.OrderingFilter]
-    ordering = ['owner__first_name']
+    ordering = ["owner__first_name"]
 
     def get_queryset(self):
         qs = _broadcast_queryset_for_user(self.request.user)
         try:
-            qs.get(pk=self.kwargs['pk'])
+            qs.get(pk=self.kwargs["pk"])
         except BroadcastTask.DoesNotExist:
             return Task.objects.none()
 
-        return Task.objects.filter(
-            broadcast_id=self.kwargs['pk']
-        ).select_related('owner', 'contact', 'broadcast__sender')
+        return Task.objects.filter(broadcast_id=self.kwargs["pk"]).select_related(
+            "owner", "contact", "broadcast__sender"
+        )

--- a/apps/tasks/export_views.py
+++ b/apps/tasks/export_views.py
@@ -4,9 +4,10 @@ CSV export view for tasks with FilterSet-based filtering.
 import csv
 from datetime import datetime
 
+from django.http import StreamingHttpResponse
+
 from rest_framework import permissions
 from rest_framework.views import APIView
-from django.http import StreamingHttpResponse
 
 from apps.core.permissions import get_visible_user_ids
 from apps.imports.services import sanitize_csv_value
@@ -16,6 +17,7 @@ from apps.tasks.models import Task
 
 class Echo:
     """Pseudo-buffer for csv.writer to write to StreamingHttpResponse."""
+
     def write(self, value):
         return value
 
@@ -25,6 +27,7 @@ class TaskExportCSVView(APIView):
     GET: Export tasks as filtered CSV file.
     Applies the same TaskFilterSet as the list endpoint.
     """
+
     permission_classes = [permissions.IsAuthenticated]
 
     def get(self, request):
@@ -36,41 +39,45 @@ class TaskExportCSVView(APIView):
 
         # Apply FilterSet (same as list endpoint)
         filterset = TaskFilterSet(request.query_params, queryset=queryset)
-        filtered_qs = filterset.qs.select_related('owner', 'contact')[:10000]
+        filtered_qs = filterset.qs.select_related("owner", "contact")[:10000]
 
-        filename = f'tasks_{datetime.now().date().isoformat()}.csv'
+        filename = f"tasks_{datetime.now().date().isoformat()}.csv"
 
         def generate_csv():
             pseudo_buffer = Echo()
             writer = csv.writer(pseudo_buffer)
 
             # Header
-            yield writer.writerow([
-                'Title',
-                'Contact',
-                'Status',
-                'Priority',
-                'Type',
-                'Due Date',
-                'Created At',
-            ])
+            yield writer.writerow(
+                [
+                    "Title",
+                    "Contact",
+                    "Status",
+                    "Priority",
+                    "Type",
+                    "Due Date",
+                    "Created At",
+                ]
+            )
 
             # Data rows
             for task in filtered_qs:
-                contact_name = ''
+                contact_name = ""
                 if task.contact:
-                    contact_name = f'{task.contact.first_name} {task.contact.last_name}'
+                    contact_name = f"{task.contact.first_name} {task.contact.last_name}"
 
-                yield writer.writerow([
-                    sanitize_csv_value(task.title or ''),
-                    sanitize_csv_value(contact_name),
-                    sanitize_csv_value(task.status or ''),
-                    sanitize_csv_value(task.priority or ''),
-                    sanitize_csv_value(task.task_type or ''),
-                    task.due_date or '',
-                    task.created_at.isoformat() if task.created_at else '',
-                ])
+                yield writer.writerow(
+                    [
+                        sanitize_csv_value(task.title or ""),
+                        sanitize_csv_value(contact_name),
+                        sanitize_csv_value(task.status or ""),
+                        sanitize_csv_value(task.priority or ""),
+                        sanitize_csv_value(task.task_type or ""),
+                        task.due_date or "",
+                        task.created_at.isoformat() if task.created_at else "",
+                    ]
+                )
 
-        response = StreamingHttpResponse(generate_csv(), content_type='text/csv')
-        response['Content-Disposition'] = f'attachment; filename="{filename}"'
+        response = StreamingHttpResponse(generate_csv(), content_type="text/csv")
+        response["Content-Disposition"] = f'attachment; filename="{filename}"'
         return response

--- a/apps/tasks/filters.py
+++ b/apps/tasks/filters.py
@@ -7,14 +7,22 @@ from apps.tasks.models import Task
 
 
 class TaskFilterSet(django_filters.FilterSet):
-    status = django_filters.CharFilter(field_name='status')
-    task_type = django_filters.CharFilter(field_name='task_type')
-    priority = django_filters.CharFilter(field_name='priority')
-    due_date_after = django_filters.DateFilter(field_name='due_date', lookup_expr='gte')
-    due_date_before = django_filters.DateFilter(field_name='due_date', lookup_expr='lte')
-    contact = django_filters.UUIDFilter(field_name='contact_id')
-    owner = django_filters.NumberFilter(field_name='owner_id')
+    status = django_filters.CharFilter(field_name="status")
+    task_type = django_filters.CharFilter(field_name="task_type")
+    priority = django_filters.CharFilter(field_name="priority")
+    due_date_after = django_filters.DateFilter(field_name="due_date", lookup_expr="gte")
+    due_date_before = django_filters.DateFilter(field_name="due_date", lookup_expr="lte")
+    contact = django_filters.UUIDFilter(field_name="contact_id")
+    owner = django_filters.NumberFilter(field_name="owner_id")
 
     class Meta:
         model = Task
-        fields = ['status', 'task_type', 'priority', 'due_date_after', 'due_date_before', 'contact', 'owner']
+        fields = [
+            "status",
+            "task_type",
+            "priority",
+            "due_date_after",
+            "due_date_before",
+            "contact",
+            "owner",
+        ]

--- a/apps/tasks/models.py
+++ b/apps/tasks/models.py
@@ -10,36 +10,40 @@ from apps.core.models import TimeStampedModel
 
 class TaskPriority(models.TextChoices):
     """Priority level for tasks."""
-    LOW = 'low', 'Low'
-    MEDIUM = 'medium', 'Medium'
-    HIGH = 'high', 'High'
-    URGENT = 'urgent', 'Urgent'
+
+    LOW = "low", "Low"
+    MEDIUM = "medium", "Medium"
+    HIGH = "high", "High"
+    URGENT = "urgent", "Urgent"
 
 
 class TaskStatus(models.TextChoices):
     """Status of a task."""
-    PENDING = 'pending', 'Pending'
-    IN_PROGRESS = 'in_progress', 'In Progress'
-    COMPLETED = 'completed', 'Completed'
-    CANCELLED = 'cancelled', 'Cancelled'
+
+    PENDING = "pending", "Pending"
+    IN_PROGRESS = "in_progress", "In Progress"
+    COMPLETED = "completed", "Completed"
+    CANCELLED = "cancelled", "Cancelled"
 
 
 class TaskType(models.TextChoices):
     """Type of task."""
-    CALL = 'call', 'Phone Call'
-    EMAIL = 'email', 'Email'
-    THANK_YOU = 'thank_you', 'Thank You'
-    MEETING = 'meeting', 'Meeting'
-    FOLLOW_UP = 'follow_up', 'Follow Up'
-    OTHER = 'other', 'Other'
+
+    CALL = "call", "Phone Call"
+    EMAIL = "email", "Email"
+    THANK_YOU = "thank_you", "Thank You"
+    MEETING = "meeting", "Meeting"
+    FOLLOW_UP = "follow_up", "Follow Up"
+    OTHER = "other", "Other"
 
 
 class BroadcastTask(TimeStampedModel):
     """Parent record for a broadcast task distribution."""
+
     sender = models.ForeignKey(
         settings.AUTH_USER_MODEL,
         on_delete=models.CASCADE,
-        related_name='sent_broadcasts',
+        related_name="sent_broadcasts",
         db_index=True,
     )
     title = models.CharField(max_length=255)
@@ -60,10 +64,10 @@ class BroadcastTask(TimeStampedModel):
     target_type = models.CharField(
         max_length=30,
         choices=[
-            ('all_missionaries', 'All Missionaries'),
-            ('all_supervisors', 'All Supervisors'),
-            ('specific_users', 'Specific Users'),
-            ('my_team', 'My Team'),
+            ("all_missionaries", "All Missionaries"),
+            ("all_supervisors", "All Supervisors"),
+            ("specific_users", "Specific Users"),
+            ("my_team", "My Team"),
         ],
     )
     # Store resolved recipient IDs at send time for audit trail
@@ -75,125 +79,116 @@ class BroadcastTask(TimeStampedModel):
     cancelled_at = models.DateTimeField(null=True, blank=True)
 
     class Meta:
-        db_table = 'broadcast_tasks'
-        ordering = ['-created_at']
+        db_table = "broadcast_tasks"
+        ordering = ["-created_at"]
         indexes = [
-            models.Index(fields=['sender', '-created_at']),
+            models.Index(fields=["sender", "-created_at"]),
         ]
 
     def __str__(self):
-        return f'Broadcast: {self.title} ({self.recipient_count} recipients)'
+        return f"Broadcast: {self.title} ({self.recipient_count} recipients)"
 
 
 class Task(TimeStampedModel):
     """
     Action item or reminder, optionally linked to a contact.
     """
+
     # Ownership
     owner = models.ForeignKey(
-        settings.AUTH_USER_MODEL,
-        on_delete=models.CASCADE,
-        related_name='tasks',
-        db_index=True
+        settings.AUTH_USER_MODEL, on_delete=models.CASCADE, related_name="tasks", db_index=True
     )
 
     # Optional contact link
     contact = models.ForeignKey(
-        'contacts.Contact',
-        on_delete=models.CASCADE,
-        null=True,
-        blank=True,
-        related_name='tasks'
+        "contacts.Contact", on_delete=models.CASCADE, null=True, blank=True, related_name="tasks"
     )
 
     # Optional journal link (for journal-specific tasks)
     journal = models.ForeignKey(
-        'journals.Journal',
+        "journals.Journal",
         on_delete=models.CASCADE,
         null=True,
         blank=True,
-        related_name='tasks',
-        help_text='Optional journal this task belongs to'
+        related_name="tasks",
+        help_text="Optional journal this task belongs to",
     )
 
     # Optional broadcast link (for broadcast-distributed tasks)
     broadcast = models.ForeignKey(
-        'tasks.BroadcastTask',
+        "tasks.BroadcastTask",
         on_delete=models.SET_NULL,
         null=True,
         blank=True,
-        related_name='copies',
+        related_name="copies",
         db_index=True,
     )
 
     # Task details
-    title = models.CharField('title', max_length=255)
-    description = models.TextField('description', blank=True)
+    title = models.CharField("title", max_length=255)
+    description = models.TextField("description", blank=True)
 
     task_type = models.CharField(
-        'type',
-        max_length=20,
-        choices=TaskType.choices,
-        default=TaskType.OTHER
+        "type", max_length=20, choices=TaskType.choices, default=TaskType.OTHER
     )
 
     priority = models.CharField(
-        'priority',
+        "priority",
         max_length=20,
         choices=TaskPriority.choices,
         default=TaskPriority.MEDIUM,
-        db_index=True
+        db_index=True,
     )
 
     status = models.CharField(
-        'status',
+        "status",
         max_length=20,
         choices=TaskStatus.choices,
         default=TaskStatus.PENDING,
-        db_index=True
+        db_index=True,
     )
 
     # Timing
-    due_date = models.DateField('due date', db_index=True)
-    due_time = models.TimeField('due time', null=True, blank=True)
-    reminder_date = models.DateField('reminder date', null=True, blank=True)
+    due_date = models.DateField("due date", db_index=True)
+    due_time = models.TimeField("due time", null=True, blank=True)
+    reminder_date = models.DateField("reminder date", null=True, blank=True)
 
     # Completion tracking
-    completed_at = models.DateTimeField('completed at', null=True, blank=True)
+    completed_at = models.DateTimeField("completed at", null=True, blank=True)
     completed_by = models.ForeignKey(
         settings.AUTH_USER_MODEL,
         on_delete=models.SET_NULL,
         null=True,
         blank=True,
-        related_name='completed_tasks'
+        related_name="completed_tasks",
     )
 
     # Auto-generated task tracking
-    auto_generated = models.BooleanField('auto generated', default=False)
+    auto_generated = models.BooleanField("auto generated", default=False)
     source_event = models.ForeignKey(
-        'events.Event',
+        "events.Event",
         on_delete=models.SET_NULL,
         null=True,
         blank=True,
-        related_name='generated_tasks'
+        related_name="generated_tasks",
     )
 
     class Meta:
-        db_table = 'tasks'
-        verbose_name = 'task'
-        verbose_name_plural = 'tasks'
-        ordering = ['due_date', '-priority', 'created_at']
+        db_table = "tasks"
+        verbose_name = "task"
+        verbose_name_plural = "tasks"
+        ordering = ["due_date", "-priority", "created_at"]
         indexes = [
-            models.Index(fields=['owner', 'status', 'due_date']),
-            models.Index(fields=['owner', 'due_date']),
-            models.Index(fields=['contact', 'status']),
-            models.Index(fields=['status', 'due_date']),
-            models.Index(fields=['journal', 'status']),
-            models.Index(fields=['broadcast', 'status']),
+            models.Index(fields=["owner", "status", "due_date"]),
+            models.Index(fields=["owner", "due_date"]),
+            models.Index(fields=["contact", "status"]),
+            models.Index(fields=["status", "due_date"]),
+            models.Index(fields=["journal", "status"]),
+            models.Index(fields=["broadcast", "status"]),
         ]
 
     def __str__(self):
-        return f'{self.title} (due: {self.due_date})'
+        return f"{self.title} (due: {self.due_date})"
 
     @property
     def is_overdue(self):
@@ -207,5 +202,4 @@ class Task(TimeStampedModel):
         self.status = TaskStatus.COMPLETED
         self.completed_at = timezone.now()
         self.completed_by = user
-        self.save(update_fields=['status', 'completed_at', 'completed_by'])
-
+        self.save(update_fields=["status", "completed_at", "completed_by"])

--- a/apps/tasks/serializers.py
+++ b/apps/tasks/serializers.py
@@ -3,58 +3,79 @@ Serializers for Task model.
 """
 from rest_framework import serializers
 
-from apps.tasks.models import Task
 from apps.journals.models import Journal
+from apps.tasks.models import Task
 
 
 class TaskSerializer(serializers.ModelSerializer):
     """
     Serializer for Task model.
     """
-    contact_name = serializers.CharField(source='contact.full_name', read_only=True, allow_null=True)
-    owner_name = serializers.CharField(source='owner.full_name', read_only=True)
+
+    contact_name = serializers.CharField(
+        source="contact.full_name", read_only=True, allow_null=True
+    )
+    owner_name = serializers.CharField(source="owner.full_name", read_only=True)
     is_overdue = serializers.BooleanField(read_only=True)
 
     # Journal field with ownership validation
     journal = serializers.PrimaryKeyRelatedField(
-        queryset=Journal.objects.all(),
-        required=False,
-        allow_null=True
+        queryset=Journal.objects.all(), required=False, allow_null=True
     )
-    journal_name = serializers.CharField(source='journal.name', read_only=True, allow_null=True)
+    journal_name = serializers.CharField(source="journal.name", read_only=True, allow_null=True)
 
     # Broadcast fields (read-only)
     broadcast_id = serializers.UUIDField(
-        source='broadcast.id', read_only=True, allow_null=True, default=None
+        source="broadcast.id", read_only=True, allow_null=True, default=None
     )
     broadcast_sender_name = serializers.CharField(
-        source='broadcast.sender.full_name', read_only=True, allow_null=True, default=None
+        source="broadcast.sender.full_name", read_only=True, allow_null=True, default=None
     )
 
     class Meta:
         model = Task
         fields = [
-            'id', 'owner', 'owner_name',
-            'contact', 'contact_name',
-            'journal', 'journal_name',
-            'title', 'description', 'task_type',
-            'priority', 'status',
-            'due_date', 'due_time', 'reminder_date',
-            'is_overdue', 'completed_at', 'completed_by',
-            'auto_generated', 'source_event',
-            'broadcast_id', 'broadcast_sender_name',
-            'created_at', 'updated_at'
+            "id",
+            "owner",
+            "owner_name",
+            "contact",
+            "contact_name",
+            "journal",
+            "journal_name",
+            "title",
+            "description",
+            "task_type",
+            "priority",
+            "status",
+            "due_date",
+            "due_time",
+            "reminder_date",
+            "is_overdue",
+            "completed_at",
+            "completed_by",
+            "auto_generated",
+            "source_event",
+            "broadcast_id",
+            "broadcast_sender_name",
+            "created_at",
+            "updated_at",
         ]
         read_only_fields = [
-            'id', 'owner', 'completed_at', 'completed_by',
-            'auto_generated', 'source_event',
-            'broadcast_id', 'broadcast_sender_name',
-            'created_at', 'updated_at'
+            "id",
+            "owner",
+            "completed_at",
+            "completed_by",
+            "auto_generated",
+            "source_event",
+            "broadcast_id",
+            "broadcast_sender_name",
+            "created_at",
+            "updated_at",
         ]
 
     def validate_journal(self, value):
         """Ensure journal belongs to the request user."""
-        if value and value.owner != self.context['request'].user:
+        if value and value.owner != self.context["request"].user:
             raise serializers.ValidationError("Journal does not belong to you")
         return value
 
@@ -63,28 +84,36 @@ class TaskCreateSerializer(serializers.ModelSerializer):
     """
     Serializer for creating tasks.
     """
+
     journal = serializers.PrimaryKeyRelatedField(
-        queryset=Journal.objects.all(),
-        required=False,
-        allow_null=True
+        queryset=Journal.objects.all(), required=False, allow_null=True
     )
 
     class Meta:
         model = Task
         fields = [
-            'id', 'contact', 'journal', 'title', 'description', 'task_type',
-            'priority', 'status', 'due_date', 'due_time', 'reminder_date'
+            "id",
+            "contact",
+            "journal",
+            "title",
+            "description",
+            "task_type",
+            "priority",
+            "status",
+            "due_date",
+            "due_time",
+            "reminder_date",
         ]
-        read_only_fields = ['id', 'status']
+        read_only_fields = ["id", "status"]
 
     def validate_journal(self, value):
         """Ensure journal belongs to the request user."""
-        if value and value.owner != self.context['request'].user:
+        if value and value.owner != self.context["request"].user:
             raise serializers.ValidationError("Journal does not belong to you")
         return value
 
     def create(self, validated_data):
-        request = self.context.get('request')
+        request = self.context.get("request")
         if request and request.user.is_authenticated:
-            validated_data['owner'] = request.user
+            validated_data["owner"] = request.user
         return super().create(validated_data)

--- a/apps/tasks/tests/factories.py
+++ b/apps/tasks/tests/factories.py
@@ -3,8 +3,9 @@ Factories for Task model tests.
 """
 from datetime import timedelta
 
-import factory
 from django.utils import timezone
+
+import factory
 from faker import Faker
 
 from apps.contacts.tests.factories import ContactFactory
@@ -23,7 +24,7 @@ class TaskFactory(factory.django.DjangoModelFactory):
     owner = factory.SubFactory(UserFactory)
     contact = factory.SubFactory(ContactFactory)
     title = factory.LazyFunction(lambda: fake.sentence(nb_words=4))
-    description = ''
+    description = ""
     task_type = TaskType.OTHER
     priority = TaskPriority.MEDIUM
     status = TaskStatus.PENDING
@@ -32,23 +33,27 @@ class TaskFactory(factory.django.DjangoModelFactory):
 
 class CallTaskFactory(TaskFactory):
     """Factory for phone call tasks."""
+
     task_type = TaskType.CALL
-    title = factory.LazyFunction(lambda: f'Call {fake.name()}')
+    title = factory.LazyFunction(lambda: f"Call {fake.name()}")
 
 
 class ThankYouTaskFactory(TaskFactory):
     """Factory for thank you tasks."""
+
     task_type = TaskType.THANK_YOU
     priority = TaskPriority.HIGH
 
 
 class OverdueTaskFactory(TaskFactory):
     """Factory for overdue tasks."""
+
     due_date = factory.LazyFunction(lambda: timezone.now().date() - timedelta(days=5))
 
 
 class CompletedTaskFactory(TaskFactory):
     """Factory for completed tasks."""
+
     status = TaskStatus.COMPLETED
     completed_at = factory.LazyFunction(timezone.now)
 
@@ -61,10 +66,10 @@ class BroadcastTaskFactory(factory.django.DjangoModelFactory):
 
     sender = factory.SubFactory(UserFactory)
     title = factory.LazyFunction(lambda: fake.sentence(nb_words=4))
-    description = ''
+    description = ""
     task_type = TaskType.OTHER
     priority = TaskPriority.MEDIUM
     due_date = factory.LazyFunction(lambda: timezone.now().date() + timedelta(days=7))
-    target_type = 'all_missionaries'
+    target_type = "all_missionaries"
     recipient_ids = factory.LazyFunction(list)
     recipient_count = 0

--- a/apps/tasks/tests/test_broadcast_services.py
+++ b/apps/tasks/tests/test_broadcast_services.py
@@ -16,7 +16,6 @@ from apps.tasks.broadcast_services import (
     update_broadcast,
 )
 from apps.tasks.models import BroadcastTask, Task, TaskStatus
-from apps.tasks.tests.factories import TaskFactory
 from apps.users.tests.factories import UserFactory
 
 
@@ -157,8 +156,9 @@ class TestUpdateBroadcast:
     def test_cascades_to_incomplete_only(self):
         admin = UserFactory(role="admin")
         m1 = UserFactory(role="missionary")
-        m2 = UserFactory(role="missionary")
-        m3 = UserFactory(role="missionary")
+        # Extra missionaries populate the broadcast recipient pool (side effect)
+        UserFactory(role="missionary")
+        UserFactory(role="missionary")
 
         broadcast = create_broadcast(
             sender=admin,
@@ -216,8 +216,9 @@ class TestCancelBroadcast:
     def test_deletes_incomplete_keeps_completed(self):
         admin = UserFactory(role="admin")
         m1 = UserFactory(role="missionary")
-        m2 = UserFactory(role="missionary")
-        m3 = UserFactory(role="missionary")
+        # Extra missionaries populate the broadcast recipient pool (side effect)
+        UserFactory(role="missionary")
+        UserFactory(role="missionary")
 
         broadcast = create_broadcast(
             sender=admin,

--- a/apps/tasks/tests/test_broadcast_services.py
+++ b/apps/tasks/tests/test_broadcast_services.py
@@ -3,9 +3,11 @@ Tests for broadcast task service functions.
 """
 from datetime import timedelta
 
-import pytest
 from django.utils import timezone
+
 from rest_framework.exceptions import ValidationError
+
+import pytest
 
 from apps.tasks.broadcast_services import (
     cancel_broadcast,
@@ -23,67 +25,67 @@ class TestResolveRecipients:
     """Tests for resolve_recipients function."""
 
     def test_all_missionaries_includes_supervisors(self):
-        admin = UserFactory(role='admin')
-        m1 = UserFactory(role='missionary')
-        m2 = UserFactory(role='missionary')
-        s1 = UserFactory(role='supervisor')
+        admin = UserFactory(role="admin")
+        m1 = UserFactory(role="missionary")
+        m2 = UserFactory(role="missionary")
+        s1 = UserFactory(role="supervisor")
 
-        result = resolve_recipients(admin, 'all_missionaries')
+        result = resolve_recipients(admin, "all_missionaries")
         result_ids = {u.id for u in result}
         assert result_ids == {m1.id, m2.id, s1.id}
         assert admin.id not in result_ids  # sender excluded
 
     def test_all_supervisors_returns_only_supervisors(self):
-        admin = UserFactory(role='admin')
-        UserFactory(role='missionary')
-        s1 = UserFactory(role='supervisor')
-        s2 = UserFactory(role='supervisor')
+        admin = UserFactory(role="admin")
+        UserFactory(role="missionary")
+        s1 = UserFactory(role="supervisor")
+        s2 = UserFactory(role="supervisor")
 
-        result = resolve_recipients(admin, 'all_supervisors')
+        result = resolve_recipients(admin, "all_supervisors")
         result_ids = {u.id for u in result}
         assert result_ids == {s1.id, s2.id}
 
     def test_my_team_returns_supervised_users(self):
-        sup = UserFactory(role='supervisor')
-        m1 = UserFactory(role='missionary')
-        m2 = UserFactory(role='missionary')
-        UserFactory(role='missionary')  # not supervised
+        sup = UserFactory(role="supervisor")
+        m1 = UserFactory(role="missionary")
+        m2 = UserFactory(role="missionary")
+        UserFactory(role="missionary")  # not supervised
 
         sup.supervised_users.add(m1, m2)
 
-        result = resolve_recipients(sup, 'my_team')
+        result = resolve_recipients(sup, "my_team")
         result_ids = {u.id for u in result}
         assert result_ids == {m1.id, m2.id}
 
     def test_specific_users_admin(self):
-        admin = UserFactory(role='admin')
-        m1 = UserFactory(role='missionary')
-        m2 = UserFactory(role='missionary')
-        m3 = UserFactory(role='missionary')
+        admin = UserFactory(role="admin")
+        m1 = UserFactory(role="missionary")
+        m2 = UserFactory(role="missionary")
+        m3 = UserFactory(role="missionary")
 
-        result = resolve_recipients(admin, 'specific_users', [m1.id, m2.id])
+        result = resolve_recipients(admin, "specific_users", [m1.id, m2.id])
         result_ids = {u.id for u in result}
         assert result_ids == {m1.id, m2.id}
         assert m3.id not in result_ids
 
     def test_specific_users_supervisor_filters_to_supervised(self):
-        sup = UserFactory(role='supervisor')
-        m1 = UserFactory(role='missionary')
-        m2 = UserFactory(role='missionary')
-        m3 = UserFactory(role='missionary')  # not supervised
+        sup = UserFactory(role="supervisor")
+        m1 = UserFactory(role="missionary")
+        m2 = UserFactory(role="missionary")
+        m3 = UserFactory(role="missionary")  # not supervised
 
         sup.supervised_users.add(m1, m2)
 
-        result = resolve_recipients(sup, 'specific_users', [m1.id, m2.id, m3.id])
+        result = resolve_recipients(sup, "specific_users", [m1.id, m2.id, m3.id])
         result_ids = {u.id for u in result}
         assert result_ids == {m1.id, m2.id}
         assert m3.id not in result_ids
 
     def test_supervisor_cannot_target_all_missionaries(self):
-        sup = UserFactory(role='supervisor')
+        sup = UserFactory(role="supervisor")
 
         with pytest.raises(PermissionError):
-            resolve_recipients(sup, 'all_missionaries')
+            resolve_recipients(sup, "all_missionaries")
 
 
 @pytest.mark.django_db
@@ -91,19 +93,19 @@ class TestCreateBroadcast:
     """Tests for create_broadcast function."""
 
     def test_creates_broadcast_and_copies(self):
-        admin = UserFactory(role='admin')
-        m1 = UserFactory(role='missionary')
-        m2 = UserFactory(role='missionary')
-        m3 = UserFactory(role='missionary')
+        admin = UserFactory(role="admin")
+        m1 = UserFactory(role="missionary")
+        m2 = UserFactory(role="missionary")
+        m3 = UserFactory(role="missionary")
 
         broadcast = create_broadcast(
             sender=admin,
-            title='Team update',
-            description='Please review',
-            task_type='other',
-            priority='medium',
+            title="Team update",
+            description="Please review",
+            task_type="other",
+            priority="medium",
             due_date=timezone.now().date() + timedelta(days=7),
-            target_type='all_missionaries',
+            target_type="all_missionaries",
         )
 
         assert BroadcastTask.objects.count() == 1
@@ -111,37 +113,37 @@ class TestCreateBroadcast:
         assert copies.count() == 3
 
         for copy in copies:
-            assert copy.title == 'Team update'
+            assert copy.title == "Team update"
             assert copy.status == TaskStatus.PENDING
             assert copy.owner_id in {m1.id, m2.id, m3.id}
 
     def test_no_recipients_raises_error(self):
-        admin = UserFactory(role='admin')
+        admin = UserFactory(role="admin")
 
         with pytest.raises(ValidationError, match="No valid recipients"):
             create_broadcast(
                 sender=admin,
-                title='Empty broadcast',
-                description='',
-                task_type='other',
-                priority='medium',
+                title="Empty broadcast",
+                description="",
+                task_type="other",
+                priority="medium",
                 due_date=timezone.now().date() + timedelta(days=7),
-                target_type='specific_users',
+                target_type="specific_users",
                 specific_user_ids=[],
             )
 
     def test_recipient_ids_stored_as_strings(self):
-        admin = UserFactory(role='admin')
-        m1 = UserFactory(role='missionary')
+        admin = UserFactory(role="admin")
+        m1 = UserFactory(role="missionary")
 
         broadcast = create_broadcast(
             sender=admin,
-            title='Test',
-            description='',
-            task_type='other',
-            priority='medium',
+            title="Test",
+            description="",
+            task_type="other",
+            priority="medium",
             due_date=timezone.now().date() + timedelta(days=7),
-            target_type='all_missionaries',
+            target_type="all_missionaries",
         )
 
         assert all(isinstance(rid, str) for rid in broadcast.recipient_ids)
@@ -153,57 +155,57 @@ class TestUpdateBroadcast:
     """Tests for update_broadcast function."""
 
     def test_cascades_to_incomplete_only(self):
-        admin = UserFactory(role='admin')
-        m1 = UserFactory(role='missionary')
-        m2 = UserFactory(role='missionary')
-        m3 = UserFactory(role='missionary')
+        admin = UserFactory(role="admin")
+        m1 = UserFactory(role="missionary")
+        m2 = UserFactory(role="missionary")
+        m3 = UserFactory(role="missionary")
 
         broadcast = create_broadcast(
             sender=admin,
-            title='Original',
-            description='',
-            task_type='other',
-            priority='medium',
+            title="Original",
+            description="",
+            task_type="other",
+            priority="medium",
             due_date=timezone.now().date() + timedelta(days=7),
-            target_type='all_missionaries',
+            target_type="all_missionaries",
         )
 
         # Mark one copy as completed
         completed_copy = Task.objects.filter(broadcast=broadcast, owner=m1).first()
         completed_copy.mark_complete(m1)
 
-        update_broadcast(broadcast, title='Updated')
+        update_broadcast(broadcast, title="Updated")
 
         # Completed copy still has old title
         completed_copy.refresh_from_db()
-        assert completed_copy.title == 'Original'
+        assert completed_copy.title == "Original"
 
         # Incomplete copies have updated title
         incomplete = Task.objects.filter(
             broadcast=broadcast,
         ).exclude(status=TaskStatus.COMPLETED)
         for copy in incomplete:
-            assert copy.title == 'Updated'
+            assert copy.title == "Updated"
 
     def test_updates_broadcast_fields(self):
-        admin = UserFactory(role='admin')
-        UserFactory(role='missionary')
+        admin = UserFactory(role="admin")
+        UserFactory(role="missionary")
 
         broadcast = create_broadcast(
             sender=admin,
-            title='Old title',
-            description='',
-            task_type='other',
-            priority='medium',
+            title="Old title",
+            description="",
+            task_type="other",
+            priority="medium",
             due_date=timezone.now().date() + timedelta(days=7),
-            target_type='all_missionaries',
+            target_type="all_missionaries",
         )
 
         new_date = timezone.now().date() + timedelta(days=14)
-        update_broadcast(broadcast, title='New title', due_date=new_date)
+        update_broadcast(broadcast, title="New title", due_date=new_date)
 
         broadcast.refresh_from_db()
-        assert broadcast.title == 'New title'
+        assert broadcast.title == "New title"
         assert broadcast.due_date == new_date
 
 
@@ -212,19 +214,19 @@ class TestCancelBroadcast:
     """Tests for cancel_broadcast function."""
 
     def test_deletes_incomplete_keeps_completed(self):
-        admin = UserFactory(role='admin')
-        m1 = UserFactory(role='missionary')
-        m2 = UserFactory(role='missionary')
-        m3 = UserFactory(role='missionary')
+        admin = UserFactory(role="admin")
+        m1 = UserFactory(role="missionary")
+        m2 = UserFactory(role="missionary")
+        m3 = UserFactory(role="missionary")
 
         broadcast = create_broadcast(
             sender=admin,
-            title='To cancel',
-            description='',
-            task_type='other',
-            priority='medium',
+            title="To cancel",
+            description="",
+            task_type="other",
+            priority="medium",
             due_date=timezone.now().date() + timedelta(days=7),
-            target_type='all_missionaries',
+            target_type="all_missionaries",
         )
 
         # Mark one copy as completed
@@ -243,17 +245,17 @@ class TestCancelBroadcast:
         assert broadcast.cancelled_at is not None
 
     def test_already_cancelled_is_idempotent(self):
-        admin = UserFactory(role='admin')
-        UserFactory(role='missionary')
+        admin = UserFactory(role="admin")
+        UserFactory(role="missionary")
 
         broadcast = create_broadcast(
             sender=admin,
-            title='Double cancel',
-            description='',
-            task_type='other',
-            priority='medium',
+            title="Double cancel",
+            description="",
+            task_type="other",
+            priority="medium",
             due_date=timezone.now().date() + timedelta(days=7),
-            target_type='all_missionaries',
+            target_type="all_missionaries",
         )
 
         cancel_broadcast(broadcast)

--- a/apps/tasks/tests/test_broadcast_views.py
+++ b/apps/tasks/tests/test_broadcast_views.py
@@ -3,10 +3,12 @@ Tests for broadcast task API views.
 """
 from datetime import timedelta
 
-import pytest
 from django.utils import timezone
+
 from rest_framework import status
 from rest_framework.test import APIClient
+
+import pytest
 
 from apps.tasks.broadcast_services import create_broadcast
 from apps.tasks.models import BroadcastTask, Task, TaskStatus
@@ -16,19 +18,19 @@ from apps.users.tests.factories import UserFactory
 
 def _broadcast_url(pk=None, action=None):
     """Build broadcast API URL."""
-    base = '/api/v1/tasks/broadcasts/'
+    base = "/api/v1/tasks/broadcasts/"
     if pk:
-        base += f'{pk}/'
+        base += f"{pk}/"
     if action:
-        base += f'{action}/'
+        base += f"{action}/"
     return base
 
 
 def _task_url(pk=None):
     """Build task API URL."""
-    base = '/api/v1/tasks/'
+    base = "/api/v1/tasks/"
     if pk:
-        base += f'{pk}/'
+        base += f"{pk}/"
     return base
 
 
@@ -37,100 +39,100 @@ class TestBroadcastListCreate:
     """Tests for broadcast list and create endpoints."""
 
     def test_admin_create_broadcast(self):
-        admin = UserFactory(role='admin')
-        UserFactory(role='missionary')
-        UserFactory(role='missionary')
+        admin = UserFactory(role="admin")
+        UserFactory(role="missionary")
+        UserFactory(role="missionary")
 
         client = APIClient()
         client.force_authenticate(user=admin)
 
         data = {
-            'title': 'Team update',
-            'description': 'Please review this.',
-            'due_date': (timezone.now().date() + timedelta(days=7)).isoformat(),
-            'target_type': 'all_missionaries',
+            "title": "Team update",
+            "description": "Please review this.",
+            "due_date": (timezone.now().date() + timedelta(days=7)).isoformat(),
+            "target_type": "all_missionaries",
         }
 
-        response = client.post(_broadcast_url(), data, format='json')
+        response = client.post(_broadcast_url(), data, format="json")
         assert response.status_code == status.HTTP_201_CREATED
-        assert response.data['id'] is not None
-        assert response.data['recipient_count'] == 2
+        assert response.data["id"] is not None
+        assert response.data["recipient_count"] == 2
 
     def test_supervisor_create_for_team(self):
-        sup = UserFactory(role='supervisor')
-        m1 = UserFactory(role='missionary')
-        m2 = UserFactory(role='missionary')
+        sup = UserFactory(role="supervisor")
+        m1 = UserFactory(role="missionary")
+        m2 = UserFactory(role="missionary")
         sup.supervised_users.add(m1, m2)
 
         client = APIClient()
         client.force_authenticate(user=sup)
 
         data = {
-            'title': 'Team task',
-            'due_date': (timezone.now().date() + timedelta(days=7)).isoformat(),
-            'target_type': 'my_team',
+            "title": "Team task",
+            "due_date": (timezone.now().date() + timedelta(days=7)).isoformat(),
+            "target_type": "my_team",
         }
 
-        response = client.post(_broadcast_url(), data, format='json')
+        response = client.post(_broadcast_url(), data, format="json")
         assert response.status_code == status.HTTP_201_CREATED
-        assert response.data['recipient_count'] == 2
+        assert response.data["recipient_count"] == 2
 
     def test_supervisor_cannot_target_all_missionaries(self):
-        sup = UserFactory(role='supervisor')
-        UserFactory(role='missionary')
+        sup = UserFactory(role="supervisor")
+        UserFactory(role="missionary")
 
         client = APIClient()
         client.force_authenticate(user=sup)
 
         data = {
-            'title': 'Should fail',
-            'due_date': (timezone.now().date() + timedelta(days=7)).isoformat(),
-            'target_type': 'all_missionaries',
+            "title": "Should fail",
+            "due_date": (timezone.now().date() + timedelta(days=7)).isoformat(),
+            "target_type": "all_missionaries",
         }
 
-        response = client.post(_broadcast_url(), data, format='json')
+        response = client.post(_broadcast_url(), data, format="json")
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
     def test_missionary_cannot_create(self):
-        missionary = UserFactory(role='missionary')
+        missionary = UserFactory(role="missionary")
 
         client = APIClient()
         client.force_authenticate(user=missionary)
 
         data = {
-            'title': 'Should fail',
-            'due_date': (timezone.now().date() + timedelta(days=7)).isoformat(),
-            'target_type': 'all_missionaries',
+            "title": "Should fail",
+            "due_date": (timezone.now().date() + timedelta(days=7)).isoformat(),
+            "target_type": "all_missionaries",
         }
 
-        response = client.post(_broadcast_url(), data, format='json')
+        response = client.post(_broadcast_url(), data, format="json")
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
     def test_admin_list_sees_all(self):
-        admin = UserFactory(role='admin')
-        sup = UserFactory(role='supervisor')
-        m1 = UserFactory(role='missionary')
-        m2 = UserFactory(role='missionary')
+        admin = UserFactory(role="admin")
+        sup = UserFactory(role="supervisor")
+        m1 = UserFactory(role="missionary")
+        m2 = UserFactory(role="missionary")
         sup.supervised_users.add(m1)
 
         # Create one broadcast from admin, one from supervisor
         create_broadcast(
             sender=admin,
-            title='Admin broadcast',
-            description='',
-            task_type='other',
-            priority='medium',
+            title="Admin broadcast",
+            description="",
+            task_type="other",
+            priority="medium",
             due_date=timezone.now().date() + timedelta(days=7),
-            target_type='all_missionaries',
+            target_type="all_missionaries",
         )
         create_broadcast(
             sender=sup,
-            title='Supervisor broadcast',
-            description='',
-            task_type='other',
-            priority='medium',
+            title="Supervisor broadcast",
+            description="",
+            task_type="other",
+            priority="medium",
             due_date=timezone.now().date() + timedelta(days=7),
-            target_type='my_team',
+            target_type="my_team",
         )
 
         client = APIClient()
@@ -138,32 +140,32 @@ class TestBroadcastListCreate:
 
         response = client.get(_broadcast_url())
         assert response.status_code == status.HTTP_200_OK
-        assert response.data['count'] >= 2
+        assert response.data["count"] >= 2
 
     def test_supervisor_list_sees_own_only(self):
-        admin = UserFactory(role='admin')
-        sup = UserFactory(role='supervisor')
-        m1 = UserFactory(role='missionary')
-        m2 = UserFactory(role='missionary')
+        admin = UserFactory(role="admin")
+        sup = UserFactory(role="supervisor")
+        m1 = UserFactory(role="missionary")
+        m2 = UserFactory(role="missionary")
         sup.supervised_users.add(m1)
 
         create_broadcast(
             sender=admin,
-            title='Admin broadcast',
-            description='',
-            task_type='other',
-            priority='medium',
+            title="Admin broadcast",
+            description="",
+            task_type="other",
+            priority="medium",
             due_date=timezone.now().date() + timedelta(days=7),
-            target_type='all_missionaries',
+            target_type="all_missionaries",
         )
         create_broadcast(
             sender=sup,
-            title='Sup broadcast',
-            description='',
-            task_type='other',
-            priority='medium',
+            title="Sup broadcast",
+            description="",
+            task_type="other",
+            priority="medium",
             due_date=timezone.now().date() + timedelta(days=7),
-            target_type='my_team',
+            target_type="my_team",
         )
 
         client = APIClient()
@@ -171,8 +173,8 @@ class TestBroadcastListCreate:
 
         response = client.get(_broadcast_url())
         assert response.status_code == status.HTTP_200_OK
-        assert response.data['count'] == 1
-        assert response.data['results'][0]['title'] == 'Sup broadcast'
+        assert response.data["count"] == 1
+        assert response.data["results"][0]["title"] == "Sup broadcast"
 
 
 @pytest.mark.django_db
@@ -180,17 +182,17 @@ class TestBroadcastDetail:
     """Tests for broadcast detail endpoint."""
 
     def test_get_detail_includes_recipient_ids(self):
-        admin = UserFactory(role='admin')
-        m1 = UserFactory(role='missionary')
+        admin = UserFactory(role="admin")
+        m1 = UserFactory(role="missionary")
 
         broadcast = create_broadcast(
             sender=admin,
-            title='Detail test',
-            description='',
-            task_type='other',
-            priority='medium',
+            title="Detail test",
+            description="",
+            task_type="other",
+            priority="medium",
             due_date=timezone.now().date() + timedelta(days=7),
-            target_type='all_missionaries',
+            target_type="all_missionaries",
         )
 
         client = APIClient()
@@ -198,23 +200,23 @@ class TestBroadcastDetail:
 
         response = client.get(_broadcast_url(pk=broadcast.id))
         assert response.status_code == status.HTTP_200_OK
-        assert 'recipient_ids' in response.data
-        assert str(m1.id) in response.data['recipient_ids']
+        assert "recipient_ids" in response.data
+        assert str(m1.id) in response.data["recipient_ids"]
 
     def test_patch_cascades_to_copies(self):
-        admin = UserFactory(role='admin')
-        m1 = UserFactory(role='missionary')
-        m2 = UserFactory(role='missionary')
-        m3 = UserFactory(role='missionary')
+        admin = UserFactory(role="admin")
+        m1 = UserFactory(role="missionary")
+        m2 = UserFactory(role="missionary")
+        m3 = UserFactory(role="missionary")
 
         broadcast = create_broadcast(
             sender=admin,
-            title='Before patch',
-            description='',
-            task_type='other',
-            priority='medium',
+            title="Before patch",
+            description="",
+            task_type="other",
+            priority="medium",
             due_date=timezone.now().date() + timedelta(days=7),
-            target_type='all_missionaries',
+            target_type="all_missionaries",
         )
 
         # Mark one copy completed
@@ -226,8 +228,8 @@ class TestBroadcastDetail:
 
         response = client.patch(
             _broadcast_url(pk=broadcast.id),
-            {'title': 'After patch'},
-            format='json',
+            {"title": "After patch"},
+            format="json",
         )
         assert response.status_code == status.HTTP_200_OK
 
@@ -236,11 +238,11 @@ class TestBroadcastDetail:
             broadcast=broadcast,
         ).exclude(status=TaskStatus.COMPLETED)
         for copy in incomplete:
-            assert copy.title == 'After patch'
+            assert copy.title == "After patch"
 
         # Completed copy should keep old title
         completed_copy.refresh_from_db()
-        assert completed_copy.title == 'Before patch'
+        assert completed_copy.title == "Before patch"
 
 
 @pytest.mark.django_db
@@ -248,19 +250,19 @@ class TestBroadcastCancel:
     """Tests for broadcast cancel endpoint."""
 
     def test_cancel_removes_incomplete(self):
-        admin = UserFactory(role='admin')
-        m1 = UserFactory(role='missionary')
-        m2 = UserFactory(role='missionary')
-        m3 = UserFactory(role='missionary')
+        admin = UserFactory(role="admin")
+        m1 = UserFactory(role="missionary")
+        m2 = UserFactory(role="missionary")
+        m3 = UserFactory(role="missionary")
 
         broadcast = create_broadcast(
             sender=admin,
-            title='To cancel',
-            description='',
-            task_type='other',
-            priority='medium',
+            title="To cancel",
+            description="",
+            task_type="other",
+            priority="medium",
             due_date=timezone.now().date() + timedelta(days=7),
-            target_type='all_missionaries',
+            target_type="all_missionaries",
         )
 
         # Mark one copy completed
@@ -270,13 +272,13 @@ class TestBroadcastCancel:
         client = APIClient()
         client.force_authenticate(user=admin)
 
-        response = client.post(_broadcast_url(pk=broadcast.id, action='cancel'))
+        response = client.post(_broadcast_url(pk=broadcast.id, action="cancel"))
         assert response.status_code == status.HTTP_200_OK
 
         # GET copies: only completed should remain
-        copies_response = client.get(_broadcast_url(pk=broadcast.id, action='copies'))
+        copies_response = client.get(_broadcast_url(pk=broadcast.id, action="copies"))
         assert copies_response.status_code == status.HTTP_200_OK
-        assert copies_response.data['count'] == 1
+        assert copies_response.data["count"] == 1
 
 
 @pytest.mark.django_db
@@ -284,32 +286,32 @@ class TestBroadcastCopyList:
     """Tests for broadcast copy list endpoint."""
 
     def test_list_copies(self):
-        admin = UserFactory(role='admin')
-        UserFactory(role='missionary')
-        UserFactory(role='missionary')
-        UserFactory(role='missionary')
+        admin = UserFactory(role="admin")
+        UserFactory(role="missionary")
+        UserFactory(role="missionary")
+        UserFactory(role="missionary")
 
         broadcast = create_broadcast(
             sender=admin,
-            title='Copy list test',
-            description='',
-            task_type='other',
-            priority='medium',
+            title="Copy list test",
+            description="",
+            task_type="other",
+            priority="medium",
             due_date=timezone.now().date() + timedelta(days=7),
-            target_type='all_missionaries',
+            target_type="all_missionaries",
         )
 
         client = APIClient()
         client.force_authenticate(user=admin)
 
-        response = client.get(_broadcast_url(pk=broadcast.id, action='copies'))
+        response = client.get(_broadcast_url(pk=broadcast.id, action="copies"))
         assert response.status_code == status.HTTP_200_OK
-        assert response.data['count'] == 3
+        assert response.data["count"] == 3
 
         # Each copy should have owner_name
-        for result in response.data['results']:
-            assert 'owner_name' in result
-            assert result['owner_name'] is not None
+        for result in response.data["results"]:
+            assert "owner_name" in result
+            assert result["owner_name"] is not None
 
 
 @pytest.mark.django_db
@@ -317,17 +319,17 @@ class TestMissionaryRestrictions:
     """Tests for missionary restrictions on broadcast task copies."""
 
     def test_missionary_cannot_edit_broadcast_task(self):
-        admin = UserFactory(role='admin')
-        missionary = UserFactory(role='missionary')
+        admin = UserFactory(role="admin")
+        missionary = UserFactory(role="missionary")
 
         broadcast = create_broadcast(
             sender=admin,
-            title='Cannot edit',
-            description='',
-            task_type='other',
-            priority='medium',
+            title="Cannot edit",
+            description="",
+            task_type="other",
+            priority="medium",
             due_date=timezone.now().date() + timedelta(days=7),
-            target_type='specific_users',
+            target_type="specific_users",
             specific_user_ids=[missionary.id],
         )
 
@@ -338,23 +340,23 @@ class TestMissionaryRestrictions:
 
         response = client.patch(
             _task_url(pk=copy.id),
-            {'title': 'Edited title'},
-            format='json',
+            {"title": "Edited title"},
+            format="json",
         )
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
     def test_missionary_cannot_delete_broadcast_task(self):
-        admin = UserFactory(role='admin')
-        missionary = UserFactory(role='missionary')
+        admin = UserFactory(role="admin")
+        missionary = UserFactory(role="missionary")
 
         broadcast = create_broadcast(
             sender=admin,
-            title='Cannot delete',
-            description='',
-            task_type='other',
-            priority='medium',
+            title="Cannot delete",
+            description="",
+            task_type="other",
+            priority="medium",
             due_date=timezone.now().date() + timedelta(days=7),
-            target_type='specific_users',
+            target_type="specific_users",
             specific_user_ids=[missionary.id],
         )
 
@@ -367,17 +369,17 @@ class TestMissionaryRestrictions:
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
     def test_missionary_can_complete_broadcast_task(self):
-        admin = UserFactory(role='admin')
-        missionary = UserFactory(role='missionary')
+        admin = UserFactory(role="admin")
+        missionary = UserFactory(role="missionary")
 
         broadcast = create_broadcast(
             sender=admin,
-            title='Can complete',
-            description='',
-            task_type='other',
-            priority='medium',
+            title="Can complete",
+            description="",
+            task_type="other",
+            priority="medium",
             due_date=timezone.now().date() + timedelta(days=7),
-            target_type='specific_users',
+            target_type="specific_users",
             specific_user_ids=[missionary.id],
         )
 
@@ -386,11 +388,11 @@ class TestMissionaryRestrictions:
         client = APIClient()
         client.force_authenticate(user=missionary)
 
-        response = client.post(f'{_task_url(pk=copy.id)}complete/')
+        response = client.post(f"{_task_url(pk=copy.id)}complete/")
         assert response.status_code == status.HTTP_200_OK
 
     def test_missionary_can_edit_own_regular_task(self):
-        missionary = UserFactory(role='missionary')
+        missionary = UserFactory(role="missionary")
         task = TaskFactory(owner=missionary, broadcast=None)
 
         client = APIClient()
@@ -398,9 +400,9 @@ class TestMissionaryRestrictions:
 
         response = client.patch(
             _task_url(pk=task.id),
-            {'title': 'New title'},
-            format='json',
+            {"title": "New title"},
+            format="json",
         )
         assert response.status_code == status.HTTP_200_OK
         task.refresh_from_db()
-        assert task.title == 'New title'
+        assert task.title == "New title"

--- a/apps/tasks/tests/test_broadcast_views.py
+++ b/apps/tasks/tests/test_broadcast_views.py
@@ -11,7 +11,7 @@ from rest_framework.test import APIClient
 import pytest
 
 from apps.tasks.broadcast_services import create_broadcast
-from apps.tasks.models import BroadcastTask, Task, TaskStatus
+from apps.tasks.models import Task, TaskStatus
 from apps.tasks.tests.factories import TaskFactory
 from apps.users.tests.factories import UserFactory
 
@@ -112,7 +112,8 @@ class TestBroadcastListCreate:
         admin = UserFactory(role="admin")
         sup = UserFactory(role="supervisor")
         m1 = UserFactory(role="missionary")
-        m2 = UserFactory(role="missionary")
+        # Extra missionary populates the broadcast recipient pool (side effect)
+        UserFactory(role="missionary")
         sup.supervised_users.add(m1)
 
         # Create one broadcast from admin, one from supervisor
@@ -146,7 +147,8 @@ class TestBroadcastListCreate:
         admin = UserFactory(role="admin")
         sup = UserFactory(role="supervisor")
         m1 = UserFactory(role="missionary")
-        m2 = UserFactory(role="missionary")
+        # Extra missionary populates the broadcast recipient pool (side effect)
+        UserFactory(role="missionary")
         sup.supervised_users.add(m1)
 
         create_broadcast(
@@ -206,8 +208,9 @@ class TestBroadcastDetail:
     def test_patch_cascades_to_copies(self):
         admin = UserFactory(role="admin")
         m1 = UserFactory(role="missionary")
-        m2 = UserFactory(role="missionary")
-        m3 = UserFactory(role="missionary")
+        # Extra missionaries populate the broadcast recipient pool (side effect)
+        UserFactory(role="missionary")
+        UserFactory(role="missionary")
 
         broadcast = create_broadcast(
             sender=admin,
@@ -252,8 +255,9 @@ class TestBroadcastCancel:
     def test_cancel_removes_incomplete(self):
         admin = UserFactory(role="admin")
         m1 = UserFactory(role="missionary")
-        m2 = UserFactory(role="missionary")
-        m3 = UserFactory(role="missionary")
+        # Extra missionaries populate the broadcast recipient pool (side effect)
+        UserFactory(role="missionary")
+        UserFactory(role="missionary")
 
         broadcast = create_broadcast(
             sender=admin,

--- a/apps/tasks/tests/test_models.py
+++ b/apps/tasks/tests/test_models.py
@@ -7,7 +7,7 @@ from django.utils import timezone
 
 import pytest
 
-from apps.tasks.models import Task, TaskPriority, TaskStatus, TaskType
+from apps.tasks.models import TaskPriority, TaskStatus, TaskType
 from apps.tasks.tests.factories import CompletedTaskFactory, OverdueTaskFactory, TaskFactory
 from apps.users.tests.factories import UserFactory
 

--- a/apps/tasks/tests/test_models.py
+++ b/apps/tasks/tests/test_models.py
@@ -3,15 +3,12 @@ Tests for Task model.
 """
 from datetime import timedelta
 
-import pytest
 from django.utils import timezone
 
+import pytest
+
 from apps.tasks.models import Task, TaskPriority, TaskStatus, TaskType
-from apps.tasks.tests.factories import (
-    CompletedTaskFactory,
-    OverdueTaskFactory,
-    TaskFactory,
-)
+from apps.tasks.tests.factories import CompletedTaskFactory, OverdueTaskFactory, TaskFactory
 from apps.users.tests.factories import UserFactory
 
 
@@ -21,9 +18,9 @@ class TestTaskModel:
 
     def test_task_str(self):
         """Test task string representation."""
-        task = TaskFactory(title='Call John')
-        assert 'Call John' in str(task)
-        assert 'due:' in str(task)
+        task = TaskFactory(title="Call John")
+        assert "Call John" in str(task)
+        assert "due:" in str(task)
 
     def test_task_is_overdue_pending(self):
         """Test is_overdue for overdue pending task."""
@@ -48,8 +45,7 @@ class TestTaskModel:
     def test_task_not_overdue_cancelled(self):
         """Test is_overdue for cancelled task (even if past due)."""
         task = TaskFactory(
-            status=TaskStatus.CANCELLED,
-            due_date=timezone.now().date() - timedelta(days=5)
+            status=TaskStatus.CANCELLED, due_date=timezone.now().date() - timedelta(days=5)
         )
         assert task.is_overdue is False
 
@@ -66,15 +62,15 @@ class TestTaskModel:
 
     def test_task_types(self):
         """Test task type choices."""
-        assert TaskType.CALL == 'call'
-        assert TaskType.EMAIL == 'email'
-        assert TaskType.THANK_YOU == 'thank_you'
-        assert TaskType.MEETING == 'meeting'
-        assert TaskType.FOLLOW_UP == 'follow_up'
+        assert TaskType.CALL == "call"
+        assert TaskType.EMAIL == "email"
+        assert TaskType.THANK_YOU == "thank_you"
+        assert TaskType.MEETING == "meeting"
+        assert TaskType.FOLLOW_UP == "follow_up"
 
     def test_task_priorities(self):
         """Test task priority choices."""
-        assert TaskPriority.LOW == 'low'
-        assert TaskPriority.MEDIUM == 'medium'
-        assert TaskPriority.HIGH == 'high'
-        assert TaskPriority.URGENT == 'urgent'
+        assert TaskPriority.LOW == "low"
+        assert TaskPriority.MEDIUM == "medium"
+        assert TaskPriority.HIGH == "high"
+        assert TaskPriority.URGENT == "urgent"

--- a/apps/tasks/tests/test_views.py
+++ b/apps/tasks/tests/test_views.py
@@ -3,10 +3,12 @@ Tests for Task API views.
 """
 from datetime import timedelta
 
-import pytest
 from django.utils import timezone
+
 from rest_framework import status
 from rest_framework.test import APIClient
+
+import pytest
 
 from apps.contacts.tests.factories import ContactFactory
 from apps.tasks.models import Task, TaskStatus
@@ -20,78 +22,78 @@ class TestTaskListCreateView:
 
     def test_list_tasks_authenticated(self):
         """Test listing tasks for authenticated user."""
-        user = UserFactory(role='missionary')
+        user = UserFactory(role="missionary")
         TaskFactory.create_batch(3, owner=user)
 
         client = APIClient()
         client.force_authenticate(user=user)
 
-        response = client.get('/api/v1/tasks/')
+        response = client.get("/api/v1/tasks/")
 
         assert response.status_code == status.HTTP_200_OK
-        assert response.data['count'] == 3
+        assert response.data["count"] == 3
 
     def test_list_tasks_unauthenticated(self):
         """Test that unauthenticated requests are rejected."""
         client = APIClient()
-        response = client.get('/api/v1/tasks/')
+        response = client.get("/api/v1/tasks/")
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
     def test_create_task(self):
         """Test creating a task."""
-        user = UserFactory(role='missionary')
+        user = UserFactory(role="missionary")
         contact = ContactFactory(owner=user)
 
         client = APIClient()
         client.force_authenticate(user=user)
 
         data = {
-            'title': 'Call John',
-            'contact': str(contact.id),
-            'task_type': 'call',
-            'priority': 'high',
-            'due_date': str(timezone.now().date() + timedelta(days=3))
+            "title": "Call John",
+            "contact": str(contact.id),
+            "task_type": "call",
+            "priority": "high",
+            "due_date": str(timezone.now().date() + timedelta(days=3)),
         }
 
-        response = client.post('/api/v1/tasks/', data)
+        response = client.post("/api/v1/tasks/", data)
 
         assert response.status_code == status.HTTP_201_CREATED
-        assert response.data['title'] == 'Call John'
-        assert response.data['status'] == 'pending'
+        assert response.data["title"] == "Call John"
+        assert response.data["status"] == "pending"
 
     def test_create_task_without_contact(self):
         """Test creating a task without contact link."""
-        user = UserFactory(role='missionary')
+        user = UserFactory(role="missionary")
 
         client = APIClient()
         client.force_authenticate(user=user)
 
         data = {
-            'title': 'General task',
-            'task_type': 'other',
-            'priority': 'medium',
-            'due_date': str(timezone.now().date() + timedelta(days=7))
+            "title": "General task",
+            "task_type": "other",
+            "priority": "medium",
+            "due_date": str(timezone.now().date() + timedelta(days=7)),
         }
 
-        response = client.post('/api/v1/tasks/', data)
+        response = client.post("/api/v1/tasks/", data)
 
         assert response.status_code == status.HTTP_201_CREATED
-        assert response.data['contact'] is None
+        assert response.data["contact"] is None
 
     def test_staff_only_sees_own_tasks(self):
         """Test that staff only sees their own tasks."""
-        user1 = UserFactory(role='missionary')
-        user2 = UserFactory(role='missionary')
+        user1 = UserFactory(role="missionary")
+        user2 = UserFactory(role="missionary")
         TaskFactory.create_batch(2, owner=user1)
         TaskFactory.create_batch(3, owner=user2)
 
         client = APIClient()
         client.force_authenticate(user=user1)
 
-        response = client.get('/api/v1/tasks/')
+        response = client.get("/api/v1/tasks/")
 
         assert response.status_code == status.HTTP_200_OK
-        assert response.data['count'] == 2
+        assert response.data["count"] == 2
 
 
 @pytest.mark.django_db
@@ -100,43 +102,40 @@ class TestTaskDetailView:
 
     def test_get_task_detail(self):
         """Test getting task detail."""
-        user = UserFactory(role='missionary')
-        task = TaskFactory(owner=user, title='Important task')
+        user = UserFactory(role="missionary")
+        task = TaskFactory(owner=user, title="Important task")
 
         client = APIClient()
         client.force_authenticate(user=user)
 
-        response = client.get(f'/api/v1/tasks/{task.id}/')
+        response = client.get(f"/api/v1/tasks/{task.id}/")
 
         assert response.status_code == status.HTTP_200_OK
-        assert response.data['title'] == 'Important task'
+        assert response.data["title"] == "Important task"
 
     def test_update_task(self):
         """Test updating a task."""
-        user = UserFactory(role='missionary')
-        task = TaskFactory(owner=user, priority='medium')
+        user = UserFactory(role="missionary")
+        task = TaskFactory(owner=user, priority="medium")
 
         client = APIClient()
         client.force_authenticate(user=user)
 
-        response = client.patch(
-            f'/api/v1/tasks/{task.id}/',
-            {'priority': 'urgent'}
-        )
+        response = client.patch(f"/api/v1/tasks/{task.id}/", {"priority": "urgent"})
 
         assert response.status_code == status.HTTP_200_OK
         task.refresh_from_db()
-        assert task.priority == 'urgent'
+        assert task.priority == "urgent"
 
     def test_delete_task(self):
         """Test deleting a task."""
-        user = UserFactory(role='missionary')
+        user = UserFactory(role="missionary")
         task = TaskFactory(owner=user)
 
         client = APIClient()
         client.force_authenticate(user=user)
 
-        response = client.delete(f'/api/v1/tasks/{task.id}/')
+        response = client.delete(f"/api/v1/tasks/{task.id}/")
 
         assert response.status_code == status.HTTP_204_NO_CONTENT
         assert not Task.objects.filter(id=task.id).exists()
@@ -148,13 +147,13 @@ class TestTaskCompleteView:
 
     def test_complete_task(self):
         """Test marking a task as complete."""
-        user = UserFactory(role='missionary')
+        user = UserFactory(role="missionary")
         task = TaskFactory(owner=user, status=TaskStatus.PENDING)
 
         client = APIClient()
         client.force_authenticate(user=user)
 
-        response = client.post(f'/api/v1/tasks/{task.id}/complete/')
+        response = client.post(f"/api/v1/tasks/{task.id}/complete/")
 
         assert response.status_code == status.HTTP_200_OK
         task.refresh_from_db()
@@ -168,7 +167,7 @@ class TestOverdueTasksView:
 
     def test_list_overdue_tasks(self):
         """Test listing overdue tasks."""
-        user = UserFactory(role='missionary')
+        user = UserFactory(role="missionary")
 
         # Create one overdue task
         overdue_task = OverdueTaskFactory(owner=user)
@@ -179,11 +178,11 @@ class TestOverdueTasksView:
         client = APIClient()
         client.force_authenticate(user=user)
 
-        response = client.get('/api/v1/tasks/overdue/')
+        response = client.get("/api/v1/tasks/overdue/")
 
         assert response.status_code == status.HTTP_200_OK
-        assert response.data['count'] == 1
-        assert response.data['results'][0]['id'] == str(overdue_task.id)
+        assert response.data["count"] == 1
+        assert response.data["results"][0]["id"] == str(overdue_task.id)
 
 
 @pytest.mark.django_db
@@ -192,7 +191,7 @@ class TestUpcomingTasksView:
 
     def test_list_upcoming_tasks(self):
         """Test listing upcoming tasks."""
-        user = UserFactory(role='missionary')
+        user = UserFactory(role="missionary")
 
         # Create tasks for today and next few days
         TaskFactory(owner=user, due_date=timezone.now().date())
@@ -204,8 +203,8 @@ class TestUpcomingTasksView:
         client = APIClient()
         client.force_authenticate(user=user)
 
-        response = client.get('/api/v1/tasks/upcoming/')
+        response = client.get("/api/v1/tasks/upcoming/")
 
         assert response.status_code == status.HTTP_200_OK
         # Should return tasks due within default upcoming window
-        assert response.data['count'] >= 2
+        assert response.data["count"] >= 2

--- a/apps/tasks/urls.py
+++ b/apps/tasks/urls.py
@@ -18,18 +18,18 @@ from apps.tasks.views import (
     UpcomingTasksView,
 )
 
-app_name = 'tasks'
+app_name = "tasks"
 
 urlpatterns = [
-    path('', TaskListCreateView.as_view(), name='task-list'),
-    path('export/csv/', TaskExportCSVView.as_view(), name='task-export-csv'),
-    path('overdue/', OverdueTasksView.as_view(), name='task-overdue'),
-    path('upcoming/', UpcomingTasksView.as_view(), name='task-upcoming'),
+    path("", TaskListCreateView.as_view(), name="task-list"),
+    path("export/csv/", TaskExportCSVView.as_view(), name="task-export-csv"),
+    path("overdue/", OverdueTasksView.as_view(), name="task-overdue"),
+    path("upcoming/", UpcomingTasksView.as_view(), name="task-upcoming"),
     # Broadcast URLs must come before <uuid:pk> to avoid UUID capture
-    path('broadcasts/', BroadcastListCreateView.as_view(), name='broadcast-list'),
-    path('broadcasts/<uuid:pk>/', BroadcastDetailView.as_view(), name='broadcast-detail'),
-    path('broadcasts/<uuid:pk>/cancel/', BroadcastCancelView.as_view(), name='broadcast-cancel'),
-    path('broadcasts/<uuid:pk>/copies/', BroadcastCopyListView.as_view(), name='broadcast-copies'),
-    path('<uuid:pk>/', TaskDetailView.as_view(), name='task-detail'),
-    path('<uuid:pk>/complete/', TaskCompleteView.as_view(), name='task-complete'),
+    path("broadcasts/", BroadcastListCreateView.as_view(), name="broadcast-list"),
+    path("broadcasts/<uuid:pk>/", BroadcastDetailView.as_view(), name="broadcast-detail"),
+    path("broadcasts/<uuid:pk>/cancel/", BroadcastCancelView.as_view(), name="broadcast-cancel"),
+    path("broadcasts/<uuid:pk>/copies/", BroadcastCopyListView.as_view(), name="broadcast-copies"),
+    path("<uuid:pk>/", TaskDetailView.as_view(), name="task-detail"),
+    path("<uuid:pk>/complete/", TaskCompleteView.as_view(), name="task-complete"),
 ]

--- a/apps/tasks/views.py
+++ b/apps/tasks/views.py
@@ -3,10 +3,11 @@ Views for Task management.
 """
 from datetime import date, timedelta
 
-from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import filters, generics, permissions, status
 from rest_framework.response import Response
 from rest_framework.views import APIView
+
+from django_filters.rest_framework import DjangoFilterBackend
 
 from apps.core.permissions import IsOwnerOrAdmin, IsSupervisorWriteRestricted, get_visible_user_ids
 from apps.core.utils import get_safe_int_param
@@ -20,10 +21,11 @@ class TaskListCreateView(generics.ListCreateAPIView):
     GET: List tasks
     POST: Create a new task
     """
+
     filter_backends = [DjangoFilterBackend, filters.SearchFilter, filters.OrderingFilter]
-    search_fields = ['title', 'description']
-    ordering_fields = ['due_date', 'priority', 'created_at']
-    ordering = ['due_date', '-priority']
+    search_fields = ["title", "description"]
+    ordering_fields = ["due_date", "priority", "created_at"]
+    ordering = ["due_date", "-priority"]
     filterset_class = TaskFilterSet
     permission_classes = [permissions.IsAuthenticated]
 
@@ -33,10 +35,10 @@ class TaskListCreateView(generics.ListCreateAPIView):
         visible = get_visible_user_ids(user, request=self.request)
         queryset = Task.objects.filter(owner_id__in=visible)
 
-        return queryset.select_related('owner', 'contact', 'broadcast__sender')
+        return queryset.select_related("owner", "contact", "broadcast__sender")
 
     def get_serializer_class(self):
-        if self.request.method == 'POST':
+        if self.request.method == "POST":
             return TaskCreateSerializer
         return TaskSerializer
 
@@ -47,6 +49,7 @@ class TaskDetailView(generics.RetrieveUpdateDestroyAPIView):
     PATCH/PUT: Update task
     DELETE: Delete task
     """
+
     serializer_class = TaskSerializer
     permission_classes = [permissions.IsAuthenticated, IsOwnerOrAdmin, IsSupervisorWriteRestricted]
 
@@ -54,7 +57,7 @@ class TaskDetailView(generics.RetrieveUpdateDestroyAPIView):
         user = self.request.user
         visible = get_visible_user_ids(user, request=self.request)
         return Task.objects.filter(owner_id__in=visible).select_related(
-            'owner', 'contact', 'broadcast__sender'
+            "owner", "contact", "broadcast__sender"
         )
 
     def update(self, request, *args, **kwargs):
@@ -62,10 +65,10 @@ class TaskDetailView(generics.RetrieveUpdateDestroyAPIView):
         if (
             task.broadcast_id
             and str(task.owner_id) == str(request.user.id)
-            and request.user.role == 'missionary'
+            and request.user.role == "missionary"
         ):
             return Response(
-                {'detail': 'Broadcast tasks cannot be edited by recipients.'},
+                {"detail": "Broadcast tasks cannot be edited by recipients."},
                 status=status.HTTP_403_FORBIDDEN,
             )
         return super().update(request, *args, **kwargs)
@@ -75,10 +78,10 @@ class TaskDetailView(generics.RetrieveUpdateDestroyAPIView):
         if (
             task.broadcast_id
             and str(task.owner_id) == str(request.user.id)
-            and request.user.role == 'missionary'
+            and request.user.role == "missionary"
         ):
             return Response(
-                {'detail': 'Broadcast tasks cannot be deleted by recipients.'},
+                {"detail": "Broadcast tasks cannot be deleted by recipients."},
                 status=status.HTTP_403_FORBIDDEN,
             )
         return super().destroy(request, *args, **kwargs)
@@ -88,6 +91,7 @@ class TaskCompleteView(APIView):
     """
     POST: Mark task as completed
     """
+
     permission_classes = [permissions.IsAuthenticated]
 
     def post(self, request, pk):
@@ -96,25 +100,22 @@ class TaskCompleteView(APIView):
             visible = get_visible_user_ids(user, request=request)
             task = Task.objects.get(pk=pk, owner_id__in=visible)
         except Task.DoesNotExist:
-            return Response(
-                {'detail': 'Task not found.'},
-                status=status.HTTP_404_NOT_FOUND
-            )
+            return Response({"detail": "Task not found."}, status=status.HTTP_404_NOT_FOUND)
 
         if task.status == TaskStatus.COMPLETED:
             return Response(
-                {'detail': 'Task is already completed.'},
-                status=status.HTTP_400_BAD_REQUEST
+                {"detail": "Task is already completed."}, status=status.HTTP_400_BAD_REQUEST
             )
 
         task.mark_complete(user)
-        return Response({'detail': 'Task marked as completed.'})
+        return Response({"detail": "Task marked as completed."})
 
 
 class OverdueTasksView(generics.ListAPIView):
     """
     GET: List overdue tasks
     """
+
     serializer_class = TaskSerializer
     permission_classes = [permissions.IsAuthenticated]
 
@@ -123,9 +124,8 @@ class OverdueTasksView(generics.ListAPIView):
         today = date.today()
 
         base_query = Task.objects.filter(
-            status__in=[TaskStatus.PENDING, TaskStatus.IN_PROGRESS],
-            due_date__lt=today
-        ).select_related('contact', 'owner')
+            status__in=[TaskStatus.PENDING, TaskStatus.IN_PROGRESS], due_date__lt=today
+        ).select_related("contact", "owner")
 
         visible = get_visible_user_ids(user, request=self.request)
         base_query = base_query.filter(owner_id__in=visible)
@@ -136,20 +136,21 @@ class UpcomingTasksView(generics.ListAPIView):
     """
     GET: List upcoming tasks (next 7 days)
     """
+
     serializer_class = TaskSerializer
     permission_classes = [permissions.IsAuthenticated]
 
     def get_queryset(self):
         user = self.request.user
         today = date.today()
-        days = get_safe_int_param(self.request, 'days', default=7, min_val=1, max_val=365)
+        days = get_safe_int_param(self.request, "days", default=7, min_val=1, max_val=365)
         end_date = today + timedelta(days=days)
 
         base_query = Task.objects.filter(
             status__in=[TaskStatus.PENDING, TaskStatus.IN_PROGRESS],
             due_date__gte=today,
-            due_date__lte=end_date
-        ).select_related('contact', 'owner')
+            due_date__lte=end_date,
+        ).select_related("contact", "owner")
 
         visible = get_visible_user_ids(user, request=self.request)
         base_query = base_query.filter(owner_id__in=visible)

--- a/apps/users/admin.py
+++ b/apps/users/admin.py
@@ -12,30 +12,54 @@ class UserAdmin(BaseUserAdmin):
     """Admin interface for User model."""
 
     list_display = (
-        'email', 'first_name', 'last_name', 'role',
-        'is_active', 'is_staff', 'date_joined'
+        "email",
+        "first_name",
+        "last_name",
+        "role",
+        "is_active",
+        "is_staff",
+        "date_joined",
     )
-    list_filter = ('role', 'is_active', 'is_staff', 'date_joined')
-    search_fields = ('email', 'first_name', 'last_name')
-    ordering = ('-date_joined',)
+    list_filter = ("role", "is_active", "is_staff", "date_joined")
+    search_fields = ("email", "first_name", "last_name")
+    ordering = ("-date_joined",)
 
     fieldsets = (
-        (None, {'fields': ('email', 'password')}),
-        ('Personal Info', {'fields': ('first_name', 'last_name', 'phone')}),
-        ('Role & Permissions', {
-            'fields': ('role', 'monthly_support_goal_cents', 'goal_weeks', 'is_active', 'is_staff', 'is_superuser')
-        }),
-        ('Preferences', {'fields': ('email_notifications',)}),
-        ('Important Dates', {'fields': ('last_login', 'date_joined')}),
-        ('Groups', {'fields': ('groups', 'user_permissions')}),
+        (None, {"fields": ("email", "password")}),
+        ("Personal Info", {"fields": ("first_name", "last_name", "phone")}),
+        (
+            "Role & Permissions",
+            {
+                "fields": (
+                    "role",
+                    "monthly_support_goal_cents",
+                    "goal_weeks",
+                    "is_active",
+                    "is_staff",
+                    "is_superuser",
+                )
+            },
+        ),
+        ("Preferences", {"fields": ("email_notifications",)}),
+        ("Important Dates", {"fields": ("last_login", "date_joined")}),
+        ("Groups", {"fields": ("groups", "user_permissions")}),
     )
 
     add_fieldsets = (
-        (None, {
-            'classes': ('wide',),
-            'fields': (
-                'email', 'first_name', 'last_name', 'password1', 'password2',
-                'role', 'is_active', 'is_staff'
-            ),
-        }),
+        (
+            None,
+            {
+                "classes": ("wide",),
+                "fields": (
+                    "email",
+                    "first_name",
+                    "last_name",
+                    "password1",
+                    "password2",
+                    "role",
+                    "is_active",
+                    "is_staff",
+                ),
+            },
+        ),
     )

--- a/apps/users/apps.py
+++ b/apps/users/apps.py
@@ -2,6 +2,6 @@ from django.apps import AppConfig
 
 
 class UsersConfig(AppConfig):
-    default_auto_field = 'django.db.models.BigAutoField'
-    name = 'apps.users'
-    verbose_name = 'Users'
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "apps.users"
+    verbose_name = "Users"

--- a/apps/users/goal_services.py
+++ b/apps/users/goal_services.py
@@ -28,20 +28,19 @@ def get_goal_progress(user):
             one_time_monthly (float, dollars)
     """
     selected_journal_ids = list(
-        GoalJournalSelection.objects.filter(user=user)
-        .values_list('journal_id', flat=True)
+        GoalJournalSelection.objects.filter(user=user).values_list("journal_id", flat=True)
     )
 
     if not selected_journal_ids:
         return {
-            'monthly_support_goal_cents': user.monthly_support_goal_cents,
-            'goal_weeks': user.goal_weeks,
-            'selected_journal_ids': [],
-            'effective_monthly_support': 0.0,
-            'recurring_monthly': 0.0,
-            'one_time_monthly': 0.0,
-            'calls_count': 0,
-            'meetings_count': 0,
+            "monthly_support_goal_cents": user.monthly_support_goal_cents,
+            "goal_weeks": user.goal_weeks,
+            "selected_journal_ids": [],
+            "effective_monthly_support": 0.0,
+            "recurring_monthly": 0.0,
+            "one_time_monthly": 0.0,
+            "calls_count": 0,
+            "meetings_count": 0,
         }
 
     # Contact IDs in selected journals — enforce journal ownership scoping
@@ -49,7 +48,7 @@ def get_goal_progress(user):
         JournalContact.objects.filter(
             journal__in=selected_journal_ids,
             journal__owner=user,
-        ).values_list('contact_id', flat=True)
+        ).values_list("contact_id", flat=True)
     )
 
     support = compute_monthly_support(Q(donor_contact_id__in=contact_ids))
@@ -57,22 +56,22 @@ def get_goal_progress(user):
     # Activity counts: count JournalStageEvents via journal_contact__journal_id__in
     calls_count = JournalStageEvent.objects.filter(
         journal_contact__journal_id__in=selected_journal_ids,
-        event_type='call_logged',
+        event_type="call_logged",
     ).count()
     meetings_count = JournalStageEvent.objects.filter(
         journal_contact__journal_id__in=selected_journal_ids,
-        event_type='meeting_completed',
+        event_type="meeting_completed",
     ).count()
 
     return {
-        'monthly_support_goal_cents': user.monthly_support_goal_cents,
-        'goal_weeks': user.goal_weeks,
-        'selected_journal_ids': [str(jid) for jid in selected_journal_ids],
-        'effective_monthly_support': support['effective_monthly_support'],
-        'recurring_monthly': support['recurring_monthly'],
-        'one_time_monthly': support['one_time_monthly'],
-        'calls_count': calls_count,
-        'meetings_count': meetings_count,
+        "monthly_support_goal_cents": user.monthly_support_goal_cents,
+        "goal_weeks": user.goal_weeks,
+        "selected_journal_ids": [str(jid) for jid in selected_journal_ids],
+        "effective_monthly_support": support["effective_monthly_support"],
+        "recurring_monthly": support["recurring_monthly"],
+        "one_time_monthly": support["one_time_monthly"],
+        "calls_count": calls_count,
+        "meetings_count": meetings_count,
     }
 
 
@@ -80,10 +79,10 @@ def get_goal_progress(user):
 # Mirrors Decision.monthly_equivalent in apps/journals/models.py.
 # Per GH-26 spec: one-time decisions are divided by 12.
 _DECISION_CADENCE_MULTIPLIERS = {
-    'one_time': Decimal('1') / Decimal('12'),
-    'monthly': Decimal('1'),
-    'quarterly': Decimal('1') / Decimal('3'),
-    'annual': Decimal('1') / Decimal('12'),
+    "one_time": Decimal("1") / Decimal("12"),
+    "monthly": Decimal("1"),
+    "quarterly": Decimal("1") / Decimal("3"),
+    "annual": Decimal("1") / Decimal("12"),
 }
 
 
@@ -102,42 +101,44 @@ def get_decisions_progress(user):
             decisions_percentage (float)       - (current / goal) * 100, or 0.0 if no goal
     """
     selected_journal_ids = list(
-        GoalJournalSelection.objects.filter(user=user)
-        .values_list('journal_id', flat=True)
+        GoalJournalSelection.objects.filter(user=user).values_list("journal_id", flat=True)
     )
 
     if not selected_journal_ids:
         return {
-            'decisions_current': 0.0,
-            'decisions_goal': 0.0,
-            'decisions_percentage': 0.0,
+            "decisions_current": 0.0,
+            "decisions_goal": 0.0,
+            "decisions_percentage": 0.0,
         }
 
     # Sum journal goal amounts (dollars, DecimalField)
     goal_total = (
-        Journal.objects.filter(id__in=selected_journal_ids, owner=user)
-        .aggregate(total=Sum('goal_amount'))['total']
-    ) or Decimal('0')
+        Journal.objects.filter(id__in=selected_journal_ids, owner=user).aggregate(
+            total=Sum("goal_amount")
+        )["total"]
+    ) or Decimal("0")
     decisions_goal = float(goal_total)
 
     # Query active + pending decisions scoped to selected journals + user ownership
     decisions = Decision.objects.filter(
         journal_contact__journal_id__in=selected_journal_ids,
         journal_contact__journal__owner=user,
-        status__in=['active', 'pending'],
-    ).values_list('amount', 'cadence')
+        status__in=["active", "pending"],
+    ).values_list("amount", "cadence")
 
     # Compute monthly-normalized sum
-    monthly_total = Decimal('0')
+    monthly_total = Decimal("0")
     for amount, cadence in decisions:
-        multiplier = _DECISION_CADENCE_MULTIPLIERS.get(cadence, Decimal('0'))
+        multiplier = _DECISION_CADENCE_MULTIPLIERS.get(cadence, Decimal("0"))
         monthly_total += amount * multiplier
 
     decisions_current = float(round(monthly_total, 2))
-    decisions_percentage = round((decisions_current / decisions_goal) * 100, 2) if decisions_goal > 0 else 0.0
+    decisions_percentage = (
+        round((decisions_current / decisions_goal) * 100, 2) if decisions_goal > 0 else 0.0
+    )
 
     return {
-        'decisions_current': decisions_current,
-        'decisions_goal': decisions_goal,
-        'decisions_percentage': decisions_percentage,
+        "decisions_current": decisions_current,
+        "decisions_goal": decisions_goal,
+        "decisions_percentage": decisions_percentage,
     }

--- a/apps/users/management/commands/capitalize_missionary_names.py
+++ b/apps/users/management/commands/capitalize_missionary_names.py
@@ -1,10 +1,11 @@
 """Capitalize first and last name of all missionary users."""
 from django.core.management.base import BaseCommand
+
 from apps.users.models import User, UserRole
 
 
 class Command(BaseCommand):
-    help = 'Capitalize first and last name of all missionary users.'
+    help = "Capitalize first and last name of all missionary users."
 
     def handle(self, *args, **options):
         updated = 0
@@ -14,7 +15,7 @@ class Command(BaseCommand):
             if u.first_name != nf or u.last_name != nl:
                 u.first_name = nf
                 u.last_name = nl
-                u.save(update_fields=['first_name', 'last_name'])
+                u.save(update_fields=["first_name", "last_name"])
                 updated += 1
-                self.stdout.write(f'  {u.email}: {nf} {nl}')
-        self.stdout.write(self.style.SUCCESS(f'Done. {updated} user(s) updated.'))
+                self.stdout.write(f"  {u.email}: {nf} {nl}")
+        self.stdout.write(self.style.SUCCESS(f"Done. {updated} user(s) updated."))

--- a/apps/users/management/commands/link_solicitors_and_reassign_owners.py
+++ b/apps/users/management/commands/link_solicitors_and_reassign_owners.py
@@ -20,7 +20,7 @@ from apps.users.models import User, UserRole
 
 def _solicitor_to_email(normalized_name: str) -> str:
     """Convert 'last, first' to 'first.last@spo.org'."""
-    parts = [p.strip() for p in normalized_name.split(',', 1)]
+    parts = [p.strip() for p in normalized_name.split(",", 1)]
     if len(parts) == 2:
         last, first = parts
         return f"{first.lower()}.{last.lower()}@spo.org"
@@ -29,34 +29,34 @@ def _solicitor_to_email(normalized_name: str) -> str:
 
 def _solicitor_to_names(normalized_name: str) -> tuple[str, str]:
     """Convert 'last, first' to (first, last)."""
-    parts = [p.strip() for p in normalized_name.split(',', 1)]
+    parts = [p.strip() for p in normalized_name.split(",", 1)]
     if len(parts) == 2:
         return parts[1], parts[0]
-    return normalized_name, ''
+    return normalized_name, ""
 
 
 class Command(BaseCommand):
     help = (
-        'Create User accounts for unlinked solicitors, link them, '
-        'then reassign contact owners based on gift credits.'
+        "Create User accounts for unlinked solicitors, link them, "
+        "then reassign contact owners based on gift credits."
     )
 
     def add_arguments(self, parser):
         parser.add_argument(
-            '--dry-run',
-            action='store_true',
-            help='Preview changes without writing to the database.',
+            "--dry-run",
+            action="store_true",
+            help="Preview changes without writing to the database.",
         )
 
     def handle(self, *args, **options):
-        dry_run = options['dry_run']
+        dry_run = options["dry_run"]
         if dry_run:
-            self.stdout.write(self.style.WARNING('DRY RUN — no changes will be saved.\n'))
+            self.stdout.write(self.style.WARNING("DRY RUN — no changes will be saved.\n"))
 
         # ── Step 1 & 2: Create users and link solicitors ──────────────────────
 
         unlinked = Solicitor.objects.filter(user__isnull=True).select_related()
-        self.stdout.write(f'Found {unlinked.count()} unlinked solicitor(s).\n')
+        self.stdout.write(f"Found {unlinked.count()} unlinked solicitor(s).\n")
 
         solicitors_linked = 0
         users_created = 0
@@ -94,8 +94,8 @@ class Command(BaseCommand):
 
         self.stdout.write(
             self.style.SUCCESS(
-                f'Step 1+2: {users_created} user(s) created, '
-                f'{solicitors_linked} solicitor(s) linked.\n'
+                f"Step 1+2: {users_created} user(s) created, "
+                f"{solicitors_linked} solicitor(s) linked.\n"
             )
         )
 
@@ -106,11 +106,16 @@ class Command(BaseCommand):
         # Set contact.owner = that solicitor's user.
 
         # Collect all contacts owned by non-missionaries
-        non_missionary_owners = User.objects.exclude(role=UserRole.MISSIONARY).values_list('id', flat=True)
+        non_missionary_owners = User.objects.exclude(role=UserRole.MISSIONARY).values_list(
+            "id", flat=True
+        )
 
         from apps.contacts.models import Contact  # avoid circular at module level
+
         contacts_to_fix = Contact.objects.filter(owner_id__in=non_missionary_owners)
-        self.stdout.write(f'Found {contacts_to_fix.count()} contact(s) owned by non-missionaries.\n')
+        self.stdout.write(
+            f"Found {contacts_to_fix.count()} contact(s) owned by non-missionaries.\n"
+        )
 
         reassigned = 0
         skipped_no_credits = 0
@@ -119,52 +124,58 @@ class Command(BaseCommand):
             # Find solicitor with highest total credit amount across both
             # one-time gifts (GiftCredit) and recurring gifts (RecurringGiftCredit).
             gift_credits = (
-                GiftCredit.objects
-                .filter(gift__donor_contact=contact, solicitor__user__isnull=False)
-                .values('solicitor__user')
-                .annotate(total=Sum('amount_cents'))
+                GiftCredit.objects.filter(
+                    gift__donor_contact=contact, solicitor__user__isnull=False
+                )
+                .values("solicitor__user")
+                .annotate(total=Sum("amount_cents"))
             )
             recurring_credits = (
-                RecurringGiftCredit.objects
-                .filter(recurring_gift__donor_contact=contact, solicitor__user__isnull=False)
-                .values('solicitor__user')
-                .annotate(total=Sum('amount_cents'))
+                RecurringGiftCredit.objects.filter(
+                    recurring_gift__donor_contact=contact, solicitor__user__isnull=False
+                )
+                .values("solicitor__user")
+                .annotate(total=Sum("amount_cents"))
             )
 
             combined: dict[int, int] = {}
             for row in gift_credits:
-                combined[row['solicitor__user']] = combined.get(row['solicitor__user'], 0) + row['total']
+                combined[row["solicitor__user"]] = (
+                    combined.get(row["solicitor__user"], 0) + row["total"]
+                )
             for row in recurring_credits:
-                combined[row['solicitor__user']] = combined.get(row['solicitor__user'], 0) + row['total']
+                combined[row["solicitor__user"]] = (
+                    combined.get(row["solicitor__user"], 0) + row["total"]
+                )
 
             if not combined:
                 skipped_no_credits += 1
                 self.stdout.write(
-                    f'  SKIP {contact.id} ({contact.first_name} {contact.last_name})'
-                    ' — no credited solicitor with a linked user'
+                    f"  SKIP {contact.id} ({contact.first_name} {contact.last_name})"
+                    " — no credited solicitor with a linked user"
                 )
                 continue
 
             new_owner_id = max(combined, key=combined.get)
             new_owner = User.objects.get(pk=new_owner_id)
             self.stdout.write(
-                f'  REASSIGN {contact.first_name} {contact.last_name or contact.organization_name}'
-                f' → {new_owner.email}'
+                f"  REASSIGN {contact.first_name} {contact.last_name or contact.organization_name}"
+                f" → {new_owner.email}"
             )
 
             if not dry_run:
                 contact.owner = new_owner
-                contact.save(update_fields=['owner_id'])
+                contact.save(update_fields=["owner_id"])
             reassigned += 1
 
         self.stdout.write(
             self.style.SUCCESS(
-                f'Step 3: {reassigned} contact(s) reassigned, '
-                f'{skipped_no_credits} skipped (no linked solicitor).\n'
+                f"Step 3: {reassigned} contact(s) reassigned, "
+                f"{skipped_no_credits} skipped (no linked solicitor).\n"
             )
         )
 
         if dry_run:
-            self.stdout.write(self.style.WARNING('Dry run complete — no changes written.'))
+            self.stdout.write(self.style.WARNING("Dry run complete — no changes written."))
         else:
-            self.stdout.write(self.style.SUCCESS('Done.'))
+            self.stdout.write(self.style.SUCCESS("Done."))

--- a/apps/users/management/commands/purge_ghost_assignments.py
+++ b/apps/users/management/commands/purge_ghost_assignments.py
@@ -6,33 +6,33 @@ where the referenced user no longer holds the expected role (supervisor or coach
 These were created by migration 0006 which copied FK data without role validation.
 """
 from django.core.management.base import BaseCommand
+
 from apps.users.models import User
 
 
 class Command(BaseCommand):
-    help = 'Purge ghost supervisor/coach M2M assignments where user role has changed'
+    help = "Purge ghost supervisor/coach M2M assignments where user role has changed"
 
     def add_arguments(self, parser):
         parser.add_argument(
-            '--dry-run',
-            action='store_true',
-            help='Show what would be removed without making changes',
+            "--dry-run",
+            action="store_true",
+            help="Show what would be removed without making changes",
         )
 
     def handle(self, *args, **options):
-        dry_run = options['dry_run']
+        dry_run = options["dry_run"]
         sup_removed = 0
         coach_removed = 0
 
-        missionaries = User.objects.filter(
-            role='missionary', is_active=True
-        ).prefetch_related('supervisors', 'coaches')
+        missionaries = User.objects.filter(role="missionary", is_active=True).prefetch_related(
+            "supervisors", "coaches"
+        )
 
         for missionary in missionaries:
             # Ghost supervisors: in M2M but no longer have role=supervisor
             ghost_sups = [
-                u for u in missionary.supervisors.all()
-                if u.role != 'supervisor' or not u.is_active
+                u for u in missionary.supervisors.all() if u.role != "supervisor" or not u.is_active
             ]
             if ghost_sups:
                 if not dry_run:
@@ -46,8 +46,7 @@ class Command(BaseCommand):
 
             # Ghost coaches: in M2M but no longer have role=coach
             ghost_coaches = [
-                u for u in missionary.coaches.all()
-                if u.role != 'coach' or not u.is_active
+                u for u in missionary.coaches.all() if u.role != "coach" or not u.is_active
             ]
             if ghost_coaches:
                 if not dry_run:
@@ -59,7 +58,7 @@ class Command(BaseCommand):
                         f"{g.email} (role={g.role}) from missionary {missionary.email}"
                     )
 
-        mode = 'Would remove' if dry_run else 'Removed'
+        mode = "Would remove" if dry_run else "Removed"
         self.stdout.write(
             self.style.SUCCESS(
                 f"{mode} {sup_removed} ghost supervisor row(s) and "

--- a/apps/users/management/commands/set_missionary_goals.py
+++ b/apps/users/management/commands/set_missionary_goals.py
@@ -6,7 +6,10 @@ from apps.users.models import User
 
 
 class Command(BaseCommand):
-    help = "Set a random monthly_support_goal_cents (2500-5000, rounded to nearest 100) for missionary accounts."
+    help = (
+        "Set a random monthly_support_goal_cents (2500-5000, rounded to nearest 100) "
+        "for missionary accounts."
+    )
 
     def add_arguments(self, parser):
         parser.add_argument(
@@ -40,8 +43,9 @@ class Command(BaseCommand):
             self.stdout.write("No missionary accounts to update (all already have goals set).")
             return
 
+        prefix = "[DRY RUN] " if dry_run else ""
         self.stdout.write(
-            f'{"[DRY RUN] " if dry_run else ""}Setting monthly goals for {len(missionaries)} missionary account(s):\n'
+            f"{prefix}Setting monthly goals for {len(missionaries)} missionary account(s):\n"
         )
 
         for user in missionaries:

--- a/apps/users/management/commands/set_missionary_goals.py
+++ b/apps/users/management/commands/set_missionary_goals.py
@@ -1,41 +1,43 @@
 import random
+
 from django.core.management.base import BaseCommand
+
 from apps.users.models import User
 
 
 class Command(BaseCommand):
-    help = 'Set a random monthly_support_goal_cents (2500-5000, rounded to nearest 100) for missionary accounts.'
+    help = "Set a random monthly_support_goal_cents (2500-5000, rounded to nearest 100) for missionary accounts."
 
     def add_arguments(self, parser):
         parser.add_argument(
-            '--overwrite',
-            action='store_true',
-            help='Overwrite existing goals (default: only set if currently null or zero)',
+            "--overwrite",
+            action="store_true",
+            help="Overwrite existing goals (default: only set if currently null or zero)",
         )
         parser.add_argument(
-            '--dry-run',
-            action='store_true',
-            help='Preview changes without saving',
+            "--dry-run",
+            action="store_true",
+            help="Preview changes without saving",
         )
 
     def handle(self, *args, **options):
-        overwrite = options['overwrite']
-        dry_run = options['dry_run']
+        overwrite = options["overwrite"]
+        dry_run = options["dry_run"]
 
-        qs = User.objects.filter(role='missionary', is_active=True)
+        qs = User.objects.filter(role="missionary", is_active=True)
         if not overwrite:
             # Re-evaluate as a list to avoid ORM union issues
             ids_no_goal = list(
-                User.objects.filter(role='missionary', is_active=True)
+                User.objects.filter(role="missionary", is_active=True)
                 .exclude(monthly_support_goal_cents__gt=0)
-                .values_list('id', flat=True)
+                .values_list("id", flat=True)
             )
             qs = User.objects.filter(id__in=ids_no_goal)
 
-        missionaries = list(qs.order_by('email'))
+        missionaries = list(qs.order_by("email"))
 
         if not missionaries:
-            self.stdout.write('No missionary accounts to update (all already have goals set).')
+            self.stdout.write("No missionary accounts to update (all already have goals set).")
             return
 
         self.stdout.write(
@@ -47,12 +49,12 @@ class Command(BaseCommand):
             # goal in dollars (2500-5000, multiple of 100), convert to cents
             goal_dollars = random.randint(25, 50) * 100
             goal_cents = goal_dollars * 100
-            self.stdout.write(f'  {user.email}: ${goal_dollars:,}')
+            self.stdout.write(f"  {user.email}: ${goal_dollars:,}")
             if not dry_run:
                 user.monthly_support_goal_cents = goal_cents
-                user.save(update_fields=['monthly_support_goal_cents'])
+                user.save(update_fields=["monthly_support_goal_cents"])
 
         if dry_run:
-            self.stdout.write('\nDry run complete — no changes saved.')
+            self.stdout.write("\nDry run complete — no changes saved.")
         else:
-            self.stdout.write(f'\nDone. Updated {len(missionaries)} account(s).')
+            self.stdout.write(f"\nDone. Updated {len(missionaries)} account(s).")

--- a/apps/users/management/commands/sync_solicitor_accounts.py
+++ b/apps/users/management/commands/sync_solicitor_accounts.py
@@ -4,8 +4,8 @@ exist with @spo.org emails and a consistent password.
 """
 import os
 
-from django.core.management.base import BaseCommand
 from django.contrib.auth import get_user_model
+from django.core.management.base import BaseCommand
 
 User = get_user_model()
 
@@ -37,7 +37,7 @@ SOLICITORS = [
     ("Andrew", "Anderson"),
 ]
 
-SOLICITOR_PASSWORD = os.environ.get('DEMO_USER_PASSWORD', 'changeme')
+SOLICITOR_PASSWORD = os.environ.get("DEMO_USER_PASSWORD", "changeme")
 
 
 def solicitor_email(first, last):
@@ -109,4 +109,6 @@ class Command(BaseCommand):
         except User.DoesNotExist:
             pass
 
-        self.stdout.write(self.style.SUCCESS("\nDone. Password set from DEMO_USER_PASSWORD env var."))
+        self.stdout.write(
+            self.style.SUCCESS("\nDone. Password set from DEMO_USER_PASSWORD env var.")
+        )

--- a/apps/users/managers.py
+++ b/apps/users/managers.py
@@ -14,11 +14,11 @@ class UserManager(BaseUserManager):
         Create and save a regular User with the given email and password.
         """
         if not email:
-            raise ValueError('The Email field must be set')
+            raise ValueError("The Email field must be set")
 
         email = self.normalize_email(email)
-        extra_fields.setdefault('is_staff', False)
-        extra_fields.setdefault('is_superuser', False)
+        extra_fields.setdefault("is_staff", False)
+        extra_fields.setdefault("is_superuser", False)
 
         user = self.model(email=email, **extra_fields)
         user.set_password(password)
@@ -29,14 +29,14 @@ class UserManager(BaseUserManager):
         """
         Create and save a SuperUser with the given email and password.
         """
-        extra_fields.setdefault('is_staff', True)
-        extra_fields.setdefault('is_superuser', True)
-        extra_fields.setdefault('role', 'admin')
+        extra_fields.setdefault("is_staff", True)
+        extra_fields.setdefault("is_superuser", True)
+        extra_fields.setdefault("role", "admin")
 
-        if extra_fields.get('is_staff') is not True:
-            raise ValueError('Superuser must have is_staff=True.')
-        if extra_fields.get('is_superuser') is not True:
-            raise ValueError('Superuser must have is_superuser=True.')
+        if extra_fields.get("is_staff") is not True:
+            raise ValueError("Superuser must have is_staff=True.")
+        if extra_fields.get("is_superuser") is not True:
+            raise ValueError("Superuser must have is_superuser=True.")
 
         return self.create_user(email, password, **extra_fields)
 

--- a/apps/users/models.py
+++ b/apps/users/models.py
@@ -14,10 +14,11 @@ class UserRole(models.TextChoices):
     """
     User roles determine permissions across the system.
     """
-    MISSIONARY = 'missionary', 'Missionary'
-    ADMIN = 'admin', 'Admin'
-    SUPERVISOR = 'supervisor', 'Supervisor'
-    COACH = 'coach', 'Coach'
+
+    MISSIONARY = "missionary", "Missionary"
+    ADMIN = "admin", "Admin"
+    SUPERVISOR = "supervisor", "Supervisor"
+    COACH = "coach", "Coach"
 
 
 class User(AbstractBaseUser, PermissionsMixin, TimeStampedModel):
@@ -30,97 +31,92 @@ class User(AbstractBaseUser, PermissionsMixin, TimeStampedModel):
     - Supervisor: View/manage supervised missionaries' data
     - Coach: View/manage coached users' data (financial data excluded)
     """
+
     # Remove username, use email instead
-    email = models.EmailField('email address', unique=True)
+    email = models.EmailField("email address", unique=True)
 
     # Profile information
-    first_name = models.CharField('first name', max_length=150)
-    last_name = models.CharField('last name', max_length=150)
-    phone = models.CharField('phone number', max_length=20, blank=True)
+    first_name = models.CharField("first name", max_length=150)
+    last_name = models.CharField("last name", max_length=150)
+    phone = models.CharField("phone number", max_length=20, blank=True)
 
     # Role-based permissions
     role = models.CharField(
-        'role',
-        max_length=25,
-        choices=UserRole.choices,
-        default=UserRole.MISSIONARY,
-        db_index=True
+        "role", max_length=25, choices=UserRole.choices, default=UserRole.MISSIONARY, db_index=True
     )
 
     # Supervisor relationships (M2M: a missionary can have multiple supervisors)
     supervisors = models.ManyToManyField(
-        'self',
+        "self",
         symmetrical=False,
         blank=True,
-        related_name='supervised_users',
-        help_text='Supervisors assigned to this missionary'
+        related_name="supervised_users",
+        help_text="Supervisors assigned to this missionary",
     )
 
     # Coach relationships (M2M: a missionary can have multiple coaches)
     coaches = models.ManyToManyField(
-        'self',
+        "self",
         symmetrical=False,
         blank=True,
-        related_name='coached_users',
-        help_text='Coaches assigned to this missionary'
+        related_name="coached_users",
+        help_text="Coaches assigned to this missionary",
     )
 
     # Support goal tracking for staff users
     monthly_support_goal_cents = models.PositiveBigIntegerField(
-        'monthly support goal (cents)',
+        "monthly support goal (cents)",
         default=0,
-        help_text='Monthly support goal in cents (e.g., 350000 = $3,500.00)'
+        help_text="Monthly support goal in cents (e.g., 350000 = $3,500.00)",
     )
     goal_weeks = models.PositiveIntegerField(
-        'goal weeks',
-        default=52,
-        help_text='Number of weeks to accomplish support goal'
+        "goal weeks", default=52, help_text="Number of weeks to accomplish support goal"
     )
 
     # Dashboard preferences
     dashboard_layout = models.JSONField(
-        'dashboard layout',
+        "dashboard layout",
         default=dict,
         blank=True,
-        help_text='User dashboard tile ordering preferences'
+        help_text="User dashboard tile ordering preferences",
     )
 
     # Django auth fields
     is_staff = models.BooleanField(
-        'staff status',
+        "staff status",
         default=False,
-        help_text='Designates whether the user can log into the admin site.'
+        help_text="Designates whether the user can log into the admin site.",
     )
     is_active = models.BooleanField(
-        'active',
+        "active",
         default=True,
-        help_text='Designates whether this user should be treated as active.'
+        help_text="Designates whether this user should be treated as active.",
     )
-    date_joined = models.DateTimeField('date joined', default=timezone.now)
+    date_joined = models.DateTimeField("date joined", default=timezone.now)
 
     # Activity tracking
-    last_login_at = models.DateTimeField('last login', null=True, blank=True)
+    last_login_at = models.DateTimeField("last login", null=True, blank=True)
 
     # Notification preferences
     email_notifications = models.BooleanField(
-        'email notifications',
+        "email notifications",
         default=True,
-        help_text='Whether to send email notifications for important events'
+        help_text="Whether to send email notifications for important events",
     )
 
     objects = UserManager()
 
-    USERNAME_FIELD = 'email'
-    REQUIRED_FIELDS = ['first_name', 'last_name']
+    USERNAME_FIELD = "email"
+    REQUIRED_FIELDS = ["first_name", "last_name"]
 
     class Meta:
-        db_table = 'users'
-        verbose_name = 'user'
-        verbose_name_plural = 'users'
+        db_table = "users"
+        verbose_name = "user"
+        verbose_name_plural = "users"
         indexes = [
-            models.Index(fields=['email']),
-            models.Index(fields=['role']),
-            models.Index(fields=['is_active']),
+            models.Index(fields=["email"]),
+            models.Index(fields=["role"]),
+            models.Index(fields=["is_active"]),
         ]
 
     def save(self, *args, **kwargs):
@@ -128,7 +124,7 @@ class User(AbstractBaseUser, PermissionsMixin, TimeStampedModel):
         old_role = None
         if self.pk:
             try:
-                old_role = User.objects.filter(pk=self.pk).values_list('role', flat=True).first()
+                old_role = User.objects.filter(pk=self.pk).values_list("role", flat=True).first()
             except Exception:
                 pass
         super().save(*args, **kwargs)
@@ -139,35 +135,35 @@ class User(AbstractBaseUser, PermissionsMixin, TimeStampedModel):
                 self.coached_users.clear()
 
     def __str__(self):
-        return f'{self.first_name} {self.last_name} ({self.email})'
+        return f"{self.first_name} {self.last_name} ({self.email})"
 
     @property
     def full_name(self):
         """Return the user's full name."""
-        return f'{self.first_name} {self.last_name}'.strip()
-
+        return f"{self.first_name} {self.last_name}".strip()
 
 
 class GoalJournalSelection(TimeStampedModel):
     """Journals selected by a user to count toward their support goal."""
+
     user = models.ForeignKey(
-        'users.User',
+        "users.User",
         on_delete=models.CASCADE,
-        related_name='goal_journal_selections',
+        related_name="goal_journal_selections",
         db_index=True,
     )
     journal = models.ForeignKey(
-        'journals.Journal',
+        "journals.Journal",
         on_delete=models.CASCADE,
-        related_name='goal_selections',
+        related_name="goal_selections",
         db_index=True,
     )
 
     class Meta:
-        db_table = 'goal_journal_selections'
-        verbose_name = 'goal journal selection'
-        verbose_name_plural = 'goal journal selections'
-        unique_together = [['user', 'journal']]
+        db_table = "goal_journal_selections"
+        verbose_name = "goal journal selection"
+        verbose_name_plural = "goal journal selections"
+        unique_together = [["user", "journal"]]
 
     def __str__(self):
-        return f'{self.user.email} \u2192 journal {self.journal_id}'
+        return f"{self.user.email} \u2192 journal {self.journal_id}"

--- a/apps/users/models.py
+++ b/apps/users/models.py
@@ -120,7 +120,7 @@ class User(AbstractBaseUser, PermissionsMixin, TimeStampedModel):
         ]
 
     def save(self, *args, **kwargs):
-        """Override save to auto-clear M2M assignments when role changes away from supervisor/coach."""
+        """Auto-clear M2M assignments when role changes away from supervisor/coach."""
         old_role = None
         if self.pk:
             try:

--- a/apps/users/serializers.py
+++ b/apps/users/serializers.py
@@ -2,6 +2,7 @@
 Serializers for User model and authentication.
 """
 from django.contrib.auth.password_validation import validate_password
+
 from rest_framework import serializers
 
 from apps.users.models import User
@@ -12,6 +13,7 @@ class UserSerializer(serializers.ModelSerializer):
     Serializer for User model (read operations).
     Used only by admin-gated endpoints (UserListCreateView, UserDetailView).
     """
+
     full_name = serializers.CharField(read_only=True)
     supervisor_ids = serializers.SerializerMethodField()
     coach_ids = serializers.SerializerMethodField()
@@ -25,46 +27,60 @@ class UserSerializer(serializers.ModelSerializer):
     class Meta:
         model = User
         fields = [
-            'id', 'email', 'first_name', 'last_name', 'full_name',
-            'phone', 'role', 'supervisor_ids', 'coach_ids', 'monthly_support_goal_cents',
-            'email_notifications', 'is_active', 'date_joined', 'last_login_at'
+            "id",
+            "email",
+            "first_name",
+            "last_name",
+            "full_name",
+            "phone",
+            "role",
+            "supervisor_ids",
+            "coach_ids",
+            "monthly_support_goal_cents",
+            "email_notifications",
+            "is_active",
+            "date_joined",
+            "last_login_at",
         ]
-        read_only_fields = ['id', 'date_joined', 'last_login_at']
+        read_only_fields = ["id", "date_joined", "last_login_at"]
 
 
 class UserCreateSerializer(serializers.ModelSerializer):
     """
     Serializer for creating new users (admin only).
     """
+
     password = serializers.CharField(
         write_only=True,
         required=True,
         validators=[validate_password],
-        style={'input_type': 'password'}
+        style={"input_type": "password"},
     )
     password_confirm = serializers.CharField(
-        write_only=True,
-        required=True,
-        style={'input_type': 'password'}
+        write_only=True, required=True, style={"input_type": "password"}
     )
 
     class Meta:
         model = User
         fields = [
-            'email', 'first_name', 'last_name', 'phone',
-            'role', 'monthly_support_goal_cents', 'password', 'password_confirm'
+            "email",
+            "first_name",
+            "last_name",
+            "phone",
+            "role",
+            "monthly_support_goal_cents",
+            "password",
+            "password_confirm",
         ]
 
     def validate(self, attrs):
-        if attrs['password'] != attrs['password_confirm']:
-            raise serializers.ValidationError({
-                'password_confirm': 'Passwords do not match.'
-            })
+        if attrs["password"] != attrs["password_confirm"]:
+            raise serializers.ValidationError({"password_confirm": "Passwords do not match."})
         return attrs
 
     def create(self, validated_data):
-        validated_data.pop('password_confirm')
-        password = validated_data.pop('password')
+        validated_data.pop("password_confirm")
+        password = validated_data.pop("password")
         user = User.objects.create_user(password=password, **validated_data)
         return user
 
@@ -73,12 +89,17 @@ class UserUpdateSerializer(serializers.ModelSerializer):
     """
     Serializer for updating user profile.
     """
+
     class Meta:
         model = User
         fields = [
-            'first_name', 'last_name', 'phone',
-            'monthly_support_goal_cents', 'goal_weeks',
-            'email_notifications', 'dashboard_layout'
+            "first_name",
+            "last_name",
+            "phone",
+            "monthly_support_goal_cents",
+            "goal_weeks",
+            "email_notifications",
+            "dashboard_layout",
         ]
 
 
@@ -86,30 +107,37 @@ class UserAdminUpdateSerializer(serializers.ModelSerializer):
     """
     Serializer for admin updating any user.
     """
+
     supervised_user_ids = serializers.ListField(
         child=serializers.UUIDField(),
         write_only=True,
         required=False,
-        help_text='List of user IDs to assign as supervised users'
+        help_text="List of user IDs to assign as supervised users",
     )
     coached_user_ids = serializers.ListField(
         child=serializers.UUIDField(),
         write_only=True,
         required=False,
-        help_text='List of user IDs to assign as coached users'
+        help_text="List of user IDs to assign as coached users",
     )
 
     class Meta:
         model = User
         fields = [
-            'first_name', 'last_name', 'phone', 'role',
-            'monthly_support_goal_cents', 'email_notifications', 'is_active',
-            'supervised_user_ids', 'coached_user_ids'
+            "first_name",
+            "last_name",
+            "phone",
+            "role",
+            "monthly_support_goal_cents",
+            "email_notifications",
+            "is_active",
+            "supervised_user_ids",
+            "coached_user_ids",
         ]
 
     def update(self, instance, validated_data):
-        supervised_ids = validated_data.pop('supervised_user_ids', None)
-        coached_ids = validated_data.pop('coached_user_ids', None)
+        supervised_ids = validated_data.pop("supervised_user_ids", None)
+        coached_ids = validated_data.pop("coached_user_ids", None)
         instance = super().update(instance, validated_data)
         if supervised_ids is not None:
             # Set supervised users via M2M (replaces existing assignments)
@@ -126,36 +154,29 @@ class PasswordChangeSerializer(serializers.Serializer):
     """
     Serializer for password change.
     """
-    old_password = serializers.CharField(
-        required=True,
-        style={'input_type': 'password'}
-    )
+
+    old_password = serializers.CharField(required=True, style={"input_type": "password"})
     new_password = serializers.CharField(
-        required=True,
-        validators=[validate_password],
-        style={'input_type': 'password'}
+        required=True, validators=[validate_password], style={"input_type": "password"}
     )
-    new_password_confirm = serializers.CharField(
-        required=True,
-        style={'input_type': 'password'}
-    )
+    new_password_confirm = serializers.CharField(required=True, style={"input_type": "password"})
 
     def validate_old_password(self, value):
-        user = self.context['request'].user
+        user = self.context["request"].user
         if not user.check_password(value):
-            raise serializers.ValidationError('Current password is incorrect.')
+            raise serializers.ValidationError("Current password is incorrect.")
         return value
 
     def validate(self, attrs):
-        if attrs['new_password'] != attrs['new_password_confirm']:
-            raise serializers.ValidationError({
-                'new_password_confirm': 'New passwords do not match.'
-            })
+        if attrs["new_password"] != attrs["new_password_confirm"]:
+            raise serializers.ValidationError(
+                {"new_password_confirm": "New passwords do not match."}
+            )
         return attrs
 
     def save(self):
-        user = self.context['request'].user
-        user.set_password(self.validated_data['new_password'])
+        user = self.context["request"].user
+        user.set_password(self.validated_data["new_password"])
         user.save()
         return user
 
@@ -164,25 +185,19 @@ class AdminPasswordResetSerializer(serializers.Serializer):
     """
     Serializer for admin-initiated password reset (no old password required).
     """
+
     new_password = serializers.CharField(
-        required=True,
-        validators=[validate_password],
-        style={'input_type': 'password'}
+        required=True, validators=[validate_password], style={"input_type": "password"}
     )
-    new_password_confirm = serializers.CharField(
-        required=True,
-        style={'input_type': 'password'}
-    )
+    new_password_confirm = serializers.CharField(required=True, style={"input_type": "password"})
 
     def validate(self, attrs):
-        if attrs['new_password'] != attrs['new_password_confirm']:
-            raise serializers.ValidationError({
-                'new_password_confirm': 'Passwords do not match.'
-            })
+        if attrs["new_password"] != attrs["new_password_confirm"]:
+            raise serializers.ValidationError({"new_password_confirm": "Passwords do not match."})
         return attrs
 
     def save(self, user):
-        user.set_password(self.validated_data['new_password'])
+        user.set_password(self.validated_data["new_password"])
         user.save()
         return user
 
@@ -191,6 +206,7 @@ class CurrentUserSerializer(serializers.ModelSerializer):
     """
     Serializer for the current authenticated user with additional stats.
     """
+
     full_name = serializers.CharField(read_only=True)
     contact_count = serializers.SerializerMethodField()
     active_pledge_count = serializers.SerializerMethodField()
@@ -199,54 +215,65 @@ class CurrentUserSerializer(serializers.ModelSerializer):
     class Meta:
         model = User
         fields = [
-            'id', 'email', 'first_name', 'last_name', 'full_name',
-            'phone', 'role', 'monthly_support_goal_cents', 'goal_weeks', 'email_notifications',
-            'date_joined', 'last_login_at',
-            'contact_count', 'active_pledge_count', 'dashboard_layout',
-            'supervised_users'
+            "id",
+            "email",
+            "first_name",
+            "last_name",
+            "full_name",
+            "phone",
+            "role",
+            "monthly_support_goal_cents",
+            "goal_weeks",
+            "email_notifications",
+            "date_joined",
+            "last_login_at",
+            "contact_count",
+            "active_pledge_count",
+            "dashboard_layout",
+            "supervised_users",
         ]
         read_only_fields = fields
 
     def get_contact_count(self, obj):
         """Get count of contacts owned by this user."""
         # Use annotated value if available (from view), otherwise query
-        if hasattr(obj, '_contact_count'):
+        if hasattr(obj, "_contact_count"):
             return obj._contact_count
-        if hasattr(obj, 'contacts'):
+        if hasattr(obj, "contacts"):
             return obj.contacts.count()
         return 0
 
     def get_active_pledge_count(self, obj):
         """Get count of active recurring gifts for contacts owned by this user."""
         # Use annotated value if available (from view), otherwise single query
-        if hasattr(obj, '_active_pledge_count'):
+        if hasattr(obj, "_active_pledge_count"):
             return obj._active_pledge_count
 
         from apps.gifts.models import RecurringGift, RecurringGiftStatus
+
         return RecurringGift.objects.filter(
-            donor_contact__owner=obj,
-            status=RecurringGiftStatus.ACTIVE
+            donor_contact__owner=obj, status=RecurringGiftStatus.ACTIVE
         ).count()
 
     def get_supervised_users(self, obj):
         """Return list of supervised/coached user summaries for supervisor or coach."""
-        if obj.role == 'supervisor':
+        if obj.role == "supervisor":
             qs = obj.supervised_users.filter(is_active=True)
-        elif obj.role == 'coach':
+        elif obj.role == "coach":
             qs = obj.coached_users.filter(is_active=True)
         else:
             return []
         return list(
-            qs.values('id', 'first_name', 'last_name', 'email')
-            .order_by('last_name', 'first_name')
+            qs.values("id", "first_name", "last_name", "email").order_by("last_name", "first_name")
         )
 
 
 class ViewableUserSerializer(serializers.ModelSerializer):
     """Minimal serializer for View As user list. Exposes only id and full_name."""
+
     id = serializers.UUIDField(read_only=True)
     full_name = serializers.CharField(read_only=True)
 
     class Meta:
         model = User
-        fields = ['id', 'full_name']
+        fields = ["id", "full_name"]

--- a/apps/users/tests/factories.py
+++ b/apps/users/tests/factories.py
@@ -18,27 +18,32 @@ class UserFactory(factory.django.DjangoModelFactory):
     email = factory.LazyFunction(fake.email)
     first_name = factory.LazyFunction(fake.first_name)
     last_name = factory.LazyFunction(fake.last_name)
-    phone = factory.LazyFunction(lambda: fake.numerify('###-###-####'))
+    phone = factory.LazyFunction(lambda: fake.numerify("###-###-####"))
     role = UserRole.MISSIONARY
-    monthly_support_goal_cents = factory.LazyFunction(lambda: fake.random_int(min=100000, max=1000000))
+    monthly_support_goal_cents = factory.LazyFunction(
+        lambda: fake.random_int(min=100000, max=1000000)
+    )
     goal_weeks = 52
     is_active = True
-    password = factory.PostGenerationMethodCall('set_password', 'testpass123')
+    password = factory.PostGenerationMethodCall("set_password", "testpass123")
 
 
 class AdminUserFactory(UserFactory):
     """Factory for creating Admin users."""
+
     role = UserRole.ADMIN
     is_staff = True
 
 
 class SupervisorUserFactory(UserFactory):
     """Factory for creating Supervisor users."""
+
     role = UserRole.SUPERVISOR
     email = factory.Sequence(lambda n: f"supervisor{n}@example.com")
 
 
 class CoachUserFactory(UserFactory):
     """Factory for creating Coach users."""
+
     role = UserRole.COACH
     email = factory.Sequence(lambda n: f"coach{n}@example.com")

--- a/apps/users/tests/test_goal_services.py
+++ b/apps/users/tests/test_goal_services.py
@@ -10,29 +10,29 @@ import pytest
 
 from apps.contacts.tests.factories import ContactFactory
 from apps.gifts.tests.factories import GiftFactory, RecurringGiftFactory
-from apps.users.goal_services import get_goal_progress, get_decisions_progress
+from apps.journals.models import Decision, Journal, JournalContact
+from apps.users.goal_services import get_decisions_progress, get_goal_progress
 from apps.users.models import GoalJournalSelection
 from apps.users.tests.factories import UserFactory
-from apps.journals.models import Decision, Journal, JournalContact
 
 
 def _make_journal(user, contacts=None):
     """Create a Journal owned by user and optionally link contacts to it."""
     journal = Journal.objects.create(
         owner=user,
-        name='Test Journal',
-        goal_amount=Decimal('10000.00'),
+        name="Test Journal",
+        goal_amount=Decimal("10000.00"),
     )
-    for contact in (contacts or []):
+    for contact in contacts or []:
         JournalContact.objects.create(journal=journal, contact=contact)
     return journal
 
 
 def _select_journals(user, journals):
     """Create GoalJournalSelection entries linking user to the given journals."""
-    GoalJournalSelection.objects.bulk_create([
-        GoalJournalSelection(user=user, journal=j) for j in journals
-    ])
+    GoalJournalSelection.objects.bulk_create(
+        [GoalJournalSelection(user=user, journal=j) for j in journals]
+    )
 
 
 @pytest.mark.django_db
@@ -40,10 +40,10 @@ def test_goal_progress_no_journals():
     """GOAL-04: When no GoalJournalSelections exist, effective_monthly_support == 0.0."""
     user = UserFactory()
     result = get_goal_progress(user)
-    assert result['effective_monthly_support'] == 0.0
-    assert result['recurring_monthly'] == 0.0
-    assert result['one_time_monthly'] == 0.0
-    assert result['selected_journal_ids'] == []
+    assert result["effective_monthly_support"] == 0.0
+    assert result["recurring_monthly"] == 0.0
+    assert result["one_time_monthly"] == 0.0
+    assert result["selected_journal_ids"] == []
 
 
 @pytest.mark.django_db
@@ -52,16 +52,16 @@ def test_goal_progress_recurring_only():
     user = UserFactory()
     contact = ContactFactory(owner=user)
     # $100/month recurring
-    RecurringGiftFactory(donor_contact=contact, amount_cents=10000, frequency='monthly')
+    RecurringGiftFactory(donor_contact=contact, amount_cents=10000, frequency="monthly")
 
     journal = _make_journal(user, contacts=[contact])
     _select_journals(user, [journal])
 
     result = get_goal_progress(user)
 
-    assert result['recurring_monthly'] == 100.0
-    assert result['one_time_monthly'] == 0.0
-    assert result['effective_monthly_support'] == 100.0
+    assert result["recurring_monthly"] == 100.0
+    assert result["one_time_monthly"] == 0.0
+    assert result["effective_monthly_support"] == 100.0
 
 
 @pytest.mark.django_db
@@ -79,9 +79,9 @@ def test_goal_progress_one_time_only():
     result = get_goal_progress(user)
 
     # $600 / 12 = $50/mo
-    assert result['one_time_monthly'] == 50.0
-    assert result['recurring_monthly'] == 0.0
-    assert result['effective_monthly_support'] == 50.0
+    assert result["one_time_monthly"] == 50.0
+    assert result["recurring_monthly"] == 0.0
+    assert result["effective_monthly_support"] == 50.0
 
 
 @pytest.mark.django_db
@@ -95,13 +95,16 @@ def test_goal_progress_excludes_recurring_sourced_gifts():
 
     # $100/mo active pledge
     pledge = RecurringGiftFactory(
-        donor_contact=contact, amount_cents=10000, frequency='monthly',
+        donor_contact=contact,
+        amount_cents=10000,
+        frequency="monthly",
     )
     # 3 prior pledge payments this fiscal year ($300 total)
     today = date.today()
     for _ in range(3):
-        GiftFactory(donor_contact=contact, amount_cents=10000,
-                    gift_date=today, recurring_gift=pledge)
+        GiftFactory(
+            donor_contact=contact, amount_cents=10000, gift_date=today, recurring_gift=pledge
+        )
 
     journal = _make_journal(user, contacts=[contact])
     _select_journals(user, [journal])
@@ -109,9 +112,9 @@ def test_goal_progress_excludes_recurring_sourced_gifts():
     result = get_goal_progress(user)
 
     # recurring_monthly should be the pledge value; one_time_monthly should be 0
-    assert result['recurring_monthly'] == 100.0
-    assert result['one_time_monthly'] == 0.0
-    assert result['effective_monthly_support'] == 100.0
+    assert result["recurring_monthly"] == 100.0
+    assert result["one_time_monthly"] == 0.0
+    assert result["effective_monthly_support"] == 100.0
 
 
 @pytest.mark.django_db
@@ -121,7 +124,7 @@ def test_goal_progress_recurring_plus_one_time():
     contact = ContactFactory(owner=user)
     today = date.today()
 
-    RecurringGiftFactory(donor_contact=contact, amount_cents=10000, frequency='monthly')
+    RecurringGiftFactory(donor_contact=contact, amount_cents=10000, frequency="monthly")
     GiftFactory(donor_contact=contact, amount_cents=120000, gift_date=today)
 
     journal = _make_journal(user, contacts=[contact])
@@ -129,9 +132,9 @@ def test_goal_progress_recurring_plus_one_time():
 
     result = get_goal_progress(user)
 
-    assert result['recurring_monthly'] == 100.0
-    assert result['one_time_monthly'] == 100.0
-    assert result['effective_monthly_support'] == 200.0
+    assert result["recurring_monthly"] == 100.0
+    assert result["one_time_monthly"] == 100.0
+    assert result["effective_monthly_support"] == 200.0
 
 
 @pytest.mark.django_db
@@ -144,32 +147,37 @@ def test_goal_progress_scoping():
     contact_b = ContactFactory(owner=user_b)
 
     # $200/month recurring for user_b's contact — should NOT appear in user_a's result
-    RecurringGiftFactory(donor_contact=contact_b, amount_cents=20000, frequency='monthly')
+    RecurringGiftFactory(donor_contact=contact_b, amount_cents=20000, frequency="monthly")
 
     journal_a = _make_journal(user_a, contacts=[contact_a])
     _select_journals(user_a, [journal_a])
 
     result = get_goal_progress(user_a)
 
-    assert result['recurring_monthly'] == 0.0
-    assert result['effective_monthly_support'] == 0.0
+    assert result["recurring_monthly"] == 0.0
+    assert result["effective_monthly_support"] == 0.0
 
 
 @pytest.mark.django_db
 def test_goal_progress_excludes_cancelled_recurring():
     """Cancelled recurring gifts should not count toward recurring_monthly."""
     from apps.gifts.models import RecurringGiftStatus
+
     user = UserFactory()
     contact = ContactFactory(owner=user)
-    RecurringGiftFactory(donor_contact=contact, amount_cents=10000, frequency='monthly',
-                         status=RecurringGiftStatus.CANCELLED)
+    RecurringGiftFactory(
+        donor_contact=contact,
+        amount_cents=10000,
+        frequency="monthly",
+        status=RecurringGiftStatus.CANCELLED,
+    )
 
     journal = _make_journal(user, contacts=[contact])
     _select_journals(user, [journal])
 
     result = get_goal_progress(user)
 
-    assert result['recurring_monthly'] == 0.0
+    assert result["recurring_monthly"] == 0.0
 
 
 @pytest.mark.django_db
@@ -178,8 +186,8 @@ def test_goal_progress_returns_goal_fields():
     user = UserFactory(monthly_support_goal_cents=320000, goal_weeks=52)
     result = get_goal_progress(user)
 
-    assert result['monthly_support_goal_cents'] == 320000
-    assert result['goal_weeks'] == 52
+    assert result["monthly_support_goal_cents"] == 320000
+    assert result["goal_weeks"] == 52
 
 
 # ---------------------------------------------------------------------------
@@ -192,9 +200,9 @@ def test_decisions_progress_no_selected_journals():
     """GH-26: No selected journals returns all zeros."""
     user = UserFactory()
     result = get_decisions_progress(user)
-    assert result['decisions_current'] == 0.0
-    assert result['decisions_goal'] == 0.0
-    assert result['decisions_percentage'] == 0.0
+    assert result["decisions_current"] == 0.0
+    assert result["decisions_goal"] == 0.0
+    assert result["decisions_percentage"] == 0.0
 
 
 @pytest.mark.django_db
@@ -204,21 +212,25 @@ def test_decisions_progress_monthly_and_one_time():
     contact1 = ContactFactory(owner=user)
     contact2 = ContactFactory(owner=user)
     journal = Journal.objects.create(
-        owner=user, name='J1', goal_amount=Decimal('5000.00'),
+        owner=user,
+        name="J1",
+        goal_amount=Decimal("5000.00"),
     )
     jc1 = JournalContact.objects.create(journal=journal, contact=contact1)
     jc2 = JournalContact.objects.create(journal=journal, contact=contact2)
     _select_journals(user, [journal])
 
-    Decision.objects.create(journal_contact=jc1, amount=Decimal('200.00'),
-                            cadence='monthly', status='active')
-    Decision.objects.create(journal_contact=jc2, amount=Decimal('1200.00'),
-                            cadence='one_time', status='pending')
+    Decision.objects.create(
+        journal_contact=jc1, amount=Decimal("200.00"), cadence="monthly", status="active"
+    )
+    Decision.objects.create(
+        journal_contact=jc2, amount=Decimal("1200.00"), cadence="one_time", status="pending"
+    )
 
     result = get_decisions_progress(user)
-    assert result['decisions_current'] == 300.0   # 200 + 1200/12
-    assert result['decisions_goal'] == 5000.0
-    assert result['decisions_percentage'] == 6.0   # (300/5000)*100 = 6.0
+    assert result["decisions_current"] == 300.0  # 200 + 1200/12
+    assert result["decisions_goal"] == 5000.0
+    assert result["decisions_percentage"] == 6.0  # (300/5000)*100 = 6.0
 
 
 @pytest.mark.django_db
@@ -227,16 +239,19 @@ def test_decisions_progress_quarterly():
     user = UserFactory()
     contact = ContactFactory(owner=user)
     journal = Journal.objects.create(
-        owner=user, name='J1', goal_amount=Decimal('10000.00'),
+        owner=user,
+        name="J1",
+        goal_amount=Decimal("10000.00"),
     )
     jc = JournalContact.objects.create(journal=journal, contact=contact)
     _select_journals(user, [journal])
 
-    Decision.objects.create(journal_contact=jc, amount=Decimal('300.00'),
-                            cadence='quarterly', status='active')
+    Decision.objects.create(
+        journal_contact=jc, amount=Decimal("300.00"), cadence="quarterly", status="active"
+    )
 
     result = get_decisions_progress(user)
-    assert result['decisions_current'] == 100.0
+    assert result["decisions_current"] == 100.0
 
 
 @pytest.mark.django_db
@@ -245,16 +260,19 @@ def test_decisions_progress_annual():
     user = UserFactory()
     contact = ContactFactory(owner=user)
     journal = Journal.objects.create(
-        owner=user, name='J1', goal_amount=Decimal('10000.00'),
+        owner=user,
+        name="J1",
+        goal_amount=Decimal("10000.00"),
     )
     jc = JournalContact.objects.create(journal=journal, contact=contact)
     _select_journals(user, [journal])
 
-    Decision.objects.create(journal_contact=jc, amount=Decimal('1200.00'),
-                            cadence='annual', status='active')
+    Decision.objects.create(
+        journal_contact=jc, amount=Decimal("1200.00"), cadence="annual", status="active"
+    )
 
     result = get_decisions_progress(user)
-    assert result['decisions_current'] == 100.0
+    assert result["decisions_current"] == 100.0
 
 
 @pytest.mark.django_db
@@ -264,19 +282,23 @@ def test_decisions_progress_excludes_declined_paused():
     contact1 = ContactFactory(owner=user)
     contact2 = ContactFactory(owner=user)
     journal = Journal.objects.create(
-        owner=user, name='J1', goal_amount=Decimal('10000.00'),
+        owner=user,
+        name="J1",
+        goal_amount=Decimal("10000.00"),
     )
     jc1 = JournalContact.objects.create(journal=journal, contact=contact1)
     jc2 = JournalContact.objects.create(journal=journal, contact=contact2)
     _select_journals(user, [journal])
 
-    Decision.objects.create(journal_contact=jc1, amount=Decimal('500.00'),
-                            cadence='monthly', status='declined')
-    Decision.objects.create(journal_contact=jc2, amount=Decimal('500.00'),
-                            cadence='monthly', status='paused')
+    Decision.objects.create(
+        journal_contact=jc1, amount=Decimal("500.00"), cadence="monthly", status="declined"
+    )
+    Decision.objects.create(
+        journal_contact=jc2, amount=Decimal("500.00"), cadence="monthly", status="paused"
+    )
 
     result = get_decisions_progress(user)
-    assert result['decisions_current'] == 0.0
+    assert result["decisions_current"] == 0.0
 
 
 @pytest.mark.django_db
@@ -286,10 +308,14 @@ def test_decisions_progress_scoping():
     contact = ContactFactory(owner=user)
 
     journal_selected = Journal.objects.create(
-        owner=user, name='Selected', goal_amount=Decimal('5000.00'),
+        owner=user,
+        name="Selected",
+        goal_amount=Decimal("5000.00"),
     )
     journal_other = Journal.objects.create(
-        owner=user, name='Other', goal_amount=Decimal('5000.00'),
+        owner=user,
+        name="Other",
+        goal_amount=Decimal("5000.00"),
     )
     jc_selected = JournalContact.objects.create(journal=journal_selected, contact=contact)
     jc_other = JournalContact.objects.create(journal=journal_other, contact=contact)
@@ -297,40 +323,43 @@ def test_decisions_progress_scoping():
     # Only select one journal
     _select_journals(user, [journal_selected])
 
-    Decision.objects.create(journal_contact=jc_selected, amount=Decimal('100.00'),
-                            cadence='monthly', status='active')
-    Decision.objects.create(journal_contact=jc_other, amount=Decimal('999.00'),
-                            cadence='monthly', status='active')
+    Decision.objects.create(
+        journal_contact=jc_selected, amount=Decimal("100.00"), cadence="monthly", status="active"
+    )
+    Decision.objects.create(
+        journal_contact=jc_other, amount=Decimal("999.00"), cadence="monthly", status="active"
+    )
 
     result = get_decisions_progress(user)
-    assert result['decisions_current'] == 100.0
-    assert result['decisions_goal'] == 5000.0
+    assert result["decisions_current"] == 100.0
+    assert result["decisions_goal"] == 5000.0
 
 
 @pytest.mark.django_db
 def test_decisions_progress_multiple_journals_sum_goals():
     """GH-26: Multiple selected journals sum their goal_amounts."""
     user = UserFactory()
-    j1 = Journal.objects.create(owner=user, name='J1', goal_amount=Decimal('3000.00'))
-    j2 = Journal.objects.create(owner=user, name='J2', goal_amount=Decimal('2000.00'))
+    j1 = Journal.objects.create(owner=user, name="J1", goal_amount=Decimal("3000.00"))
+    j2 = Journal.objects.create(owner=user, name="J2", goal_amount=Decimal("2000.00"))
     _select_journals(user, [j1, j2])
 
     result = get_decisions_progress(user)
-    assert result['decisions_goal'] == 5000.0
-    assert result['decisions_current'] == 0.0
-    assert result['decisions_percentage'] == 0.0
+    assert result["decisions_goal"] == 5000.0
+    assert result["decisions_current"] == 0.0
+    assert result["decisions_percentage"] == 0.0
 
 
 @pytest.mark.django_db
 def test_goal_api_includes_decisions_fields():
     """GH-26: GET /api/v1/goals/me/ includes decisions_current, decisions_goal, decisions_percentage."""
     from rest_framework.test import APIClient
+
     user = UserFactory()
     api_client = APIClient()
     api_client.force_authenticate(user=user)
-    response = api_client.get('/api/v1/goals/me/')
+    response = api_client.get("/api/v1/goals/me/")
     assert response.status_code == 200
     data = response.data
-    assert 'decisions_current' in data
-    assert 'decisions_goal' in data
-    assert 'decisions_percentage' in data
+    assert "decisions_current" in data
+    assert "decisions_goal" in data
+    assert "decisions_percentage" in data

--- a/apps/users/tests/test_goal_services.py
+++ b/apps/users/tests/test_goal_services.py
@@ -1,7 +1,8 @@
 """
 Tests for goal progress service functions.
 GOAL-04: get_goal_progress(user) computes effective_monthly_support from journal-scoped donations.
-GH-26: get_decisions_progress(user) computes monthly-normalized decision amounts vs journal goal sums.
+GH-26: get_decisions_progress(user) computes monthly-normalized decision amounts
+vs journal goal sums.
 """
 from datetime import date
 from decimal import Decimal
@@ -351,7 +352,7 @@ def test_decisions_progress_multiple_journals_sum_goals():
 
 @pytest.mark.django_db
 def test_goal_api_includes_decisions_fields():
-    """GH-26: GET /api/v1/goals/me/ includes decisions_current, decisions_goal, decisions_percentage."""
+    """GH-26: goals/me/ includes decisions_current, decisions_goal, decisions_percentage."""
     from rest_framework.test import APIClient
 
     user = UserFactory()

--- a/apps/users/tests/test_link_solicitors_command.py
+++ b/apps/users/tests/test_link_solicitors_command.py
@@ -6,28 +6,23 @@ and RecurringGiftCredit records.
 """
 from datetime import date
 
-import pytest
 from django.core.management import call_command
 
+import pytest
+
 from apps.contacts.models import Contact
-from apps.gifts.models import (
-    Gift,
-    GiftCredit,
-    RecurringGift,
-    RecurringGiftCredit,
-    Solicitor,
-)
+from apps.gifts.models import Gift, GiftCredit, RecurringGift, RecurringGiftCredit, Solicitor
 from apps.users.tests.factories import AdminUserFactory, UserFactory
 
 
 @pytest.fixture
 def admin_user():
-    return AdminUserFactory(email='cmd-admin@test.com')
+    return AdminUserFactory(email="cmd-admin@test.com")
 
 
 @pytest.fixture
 def missionary():
-    return UserFactory(email='cmd-missionary@test.com', first_name='John', last_name='Doe')
+    return UserFactory(email="cmd-missionary@test.com", first_name="John", last_name="Doe")
 
 
 @pytest.mark.django_db
@@ -37,23 +32,23 @@ class TestLinkSolicitorsCommand:
     def test_reassigns_via_recurring_gift_credit_only(self, admin_user, missionary):
         """Contact with only RecurringGiftCredit (no GiftCredit) gets reassigned."""
         solicitor = Solicitor.objects.create(
-            normalized_name='doe, john',
-            external_solicitor_id='SOL-CMD-01',
+            normalized_name="doe, john",
+            external_solicitor_id="SOL-CMD-01",
             user=missionary,
         )
         contact = Contact.objects.create(
             owner=admin_user,
-            external_constituent_id='C-CMD-01',
-            first_name='Recurring',
-            last_name='Only',
+            external_constituent_id="C-CMD-01",
+            first_name="Recurring",
+            last_name="Only",
         )
         rg = RecurringGift.objects.create(
-            external_gift_id='RG-CMD-01',
+            external_gift_id="RG-CMD-01",
             donor_contact=contact,
             amount_cents=10000,
-            frequency='monthly',
+            frequency="monthly",
             start_date=date(2025, 1, 1),
-            status='active',
+            status="active",
         )
         RecurringGiftCredit.objects.create(
             recurring_gift=rg,
@@ -61,28 +56,28 @@ class TestLinkSolicitorsCommand:
             amount_cents=10000,
         )
 
-        call_command('link_solicitors_and_reassign_owners')
+        call_command("link_solicitors_and_reassign_owners")
 
         contact.refresh_from_db()
-        assert contact.owner == missionary, (
-            f"Expected owner={missionary.email}, got {contact.owner.email}"
-        )
+        assert (
+            contact.owner == missionary
+        ), f"Expected owner={missionary.email}, got {contact.owner.email}"
 
     def test_reassigns_via_gift_credit_only(self, admin_user, missionary):
         """Contact with only GiftCredit (no RecurringGiftCredit) still works."""
         solicitor = Solicitor.objects.create(
-            normalized_name='doe, john',
-            external_solicitor_id='SOL-CMD-02',
+            normalized_name="doe, john",
+            external_solicitor_id="SOL-CMD-02",
             user=missionary,
         )
         contact = Contact.objects.create(
             owner=admin_user,
-            external_constituent_id='C-CMD-02',
-            first_name='Gift',
-            last_name='Only',
+            external_constituent_id="C-CMD-02",
+            first_name="Gift",
+            last_name="Only",
         )
         gift = Gift.objects.create(
-            external_gift_id='G-CMD-01',
+            external_gift_id="G-CMD-01",
             donor_contact=contact,
             amount_cents=50000,
             gift_date=date(2025, 6, 15),
@@ -93,34 +88,34 @@ class TestLinkSolicitorsCommand:
             amount_cents=50000,
         )
 
-        call_command('link_solicitors_and_reassign_owners')
+        call_command("link_solicitors_and_reassign_owners")
 
         contact.refresh_from_db()
         assert contact.owner == missionary
 
     def test_combined_credits_highest_total_wins(self, admin_user):
         """When two solicitors have credits, the one with highest combined total wins."""
-        missionary_a = UserFactory(email='cmd-miss-a@test.com')
-        missionary_b = UserFactory(email='cmd-miss-b@test.com')
+        missionary_a = UserFactory(email="cmd-miss-a@test.com")
+        missionary_b = UserFactory(email="cmd-miss-b@test.com")
         sol_a = Solicitor.objects.create(
-            normalized_name='alpha, ann',
-            external_solicitor_id='SOL-A',
+            normalized_name="alpha, ann",
+            external_solicitor_id="SOL-A",
             user=missionary_a,
         )
         sol_b = Solicitor.objects.create(
-            normalized_name='beta, bob',
-            external_solicitor_id='SOL-B',
+            normalized_name="beta, bob",
+            external_solicitor_id="SOL-B",
             user=missionary_b,
         )
         contact = Contact.objects.create(
             owner=admin_user,
-            external_constituent_id='C-CMD-03',
-            first_name='Mixed',
-            last_name='Credits',
+            external_constituent_id="C-CMD-03",
+            first_name="Mixed",
+            last_name="Credits",
         )
         # Sol A: GiftCredit $100
         gift = Gift.objects.create(
-            external_gift_id='G-CMD-02',
+            external_gift_id="G-CMD-02",
             donor_contact=contact,
             amount_cents=10000,
             gift_date=date(2025, 6, 15),
@@ -129,35 +124,36 @@ class TestLinkSolicitorsCommand:
 
         # Sol B: RecurringGiftCredit $500 (higher total)
         rg = RecurringGift.objects.create(
-            external_gift_id='RG-CMD-02',
+            external_gift_id="RG-CMD-02",
             donor_contact=contact,
             amount_cents=50000,
-            frequency='monthly',
+            frequency="monthly",
             start_date=date(2025, 1, 1),
-            status='active',
+            status="active",
         )
         RecurringGiftCredit.objects.create(
-            recurring_gift=rg, solicitor=sol_b, amount_cents=50000,
+            recurring_gift=rg,
+            solicitor=sol_b,
+            amount_cents=50000,
         )
 
-        call_command('link_solicitors_and_reassign_owners')
+        call_command("link_solicitors_and_reassign_owners")
 
         contact.refresh_from_db()
         assert contact.owner == missionary_b, (
-            f"Expected owner={missionary_b.email} (highest total), "
-            f"got {contact.owner.email}"
+            f"Expected owner={missionary_b.email} (highest total), " f"got {contact.owner.email}"
         )
 
     def test_skips_contact_with_no_credits(self, admin_user):
         """Contact with no GiftCredit or RecurringGiftCredit is skipped."""
         contact = Contact.objects.create(
             owner=admin_user,
-            external_constituent_id='C-CMD-04',
-            first_name='No',
-            last_name='Credits',
+            external_constituent_id="C-CMD-04",
+            first_name="No",
+            last_name="Credits",
         )
 
-        call_command('link_solicitors_and_reassign_owners')
+        call_command("link_solicitors_and_reassign_owners")
 
         contact.refresh_from_db()
         assert contact.owner == admin_user
@@ -165,29 +161,31 @@ class TestLinkSolicitorsCommand:
     def test_dry_run_does_not_change_ownership(self, admin_user, missionary):
         """--dry-run previews changes without writing."""
         solicitor = Solicitor.objects.create(
-            normalized_name='doe, john',
-            external_solicitor_id='SOL-CMD-DRY',
+            normalized_name="doe, john",
+            external_solicitor_id="SOL-CMD-DRY",
             user=missionary,
         )
         contact = Contact.objects.create(
             owner=admin_user,
-            external_constituent_id='C-CMD-DRY',
-            first_name='Dry',
-            last_name='Run',
+            external_constituent_id="C-CMD-DRY",
+            first_name="Dry",
+            last_name="Run",
         )
         rg = RecurringGift.objects.create(
-            external_gift_id='RG-CMD-DRY',
+            external_gift_id="RG-CMD-DRY",
             donor_contact=contact,
             amount_cents=10000,
-            frequency='monthly',
+            frequency="monthly",
             start_date=date(2025, 1, 1),
-            status='active',
+            status="active",
         )
         RecurringGiftCredit.objects.create(
-            recurring_gift=rg, solicitor=solicitor, amount_cents=10000,
+            recurring_gift=rg,
+            solicitor=solicitor,
+            amount_cents=10000,
         )
 
-        call_command('link_solicitors_and_reassign_owners', dry_run=True)
+        call_command("link_solicitors_and_reassign_owners", dry_run=True)
 
         contact.refresh_from_db()
         assert contact.owner == admin_user, "Dry run should not change ownership"

--- a/apps/users/tests/test_m2m_assignments.py
+++ b/apps/users/tests/test_m2m_assignments.py
@@ -385,7 +385,8 @@ def test_migration_preserves_existing_fk_supervisor_assignment():
     in `missionary.supervisors.all()` after the Plan 02 migration runs.
 
     This test requires running against the full migration history:
-        pytest apps/users/tests/test_m2m_assignments.py::test_migration_preserves_existing_fk_supervisor_assignment --migrations
+        pytest apps/users/tests/test_m2m_assignments.py\
+            ::test_migration_preserves_existing_fk_supervisor_assignment --migrations
     """
     # Verify post-migration state — illustrative, not runnable in unit suite
     pass  # pragma: no cover

--- a/apps/users/tests/test_m2m_assignments.py
+++ b/apps/users/tests/test_m2m_assignments.py
@@ -10,8 +10,9 @@ yet created — current model has ForeignKey `supervisor` not ManyToManyField
 
 Run: pytest apps/users/tests/test_m2m_assignments.py -q
 """
-import pytest
 from rest_framework.test import APIClient
+
+import pytest
 
 from apps.users.models import User, UserRole
 from apps.users.tests.factories import (
@@ -21,10 +22,10 @@ from apps.users.tests.factories import (
     UserFactory,
 )
 
-
 # ---------------------------------------------------------------------------
 # Model-level M2M behaviors
 # ---------------------------------------------------------------------------
+
 
 @pytest.mark.django_db
 class TestM2MModelBehaviors:
@@ -44,7 +45,7 @@ class TestM2MModelBehaviors:
         missionary.supervisors.add(sup1)
         missionary.supervisors.add(sup2)
 
-        assigned_ids = set(missionary.supervisors.values_list('id', flat=True))
+        assigned_ids = set(missionary.supervisors.values_list("id", flat=True))
         assert sup1.id in assigned_ids
         assert sup2.id in assigned_ids
         assert missionary.supervisors.count() == 2
@@ -83,6 +84,7 @@ class TestM2MModelBehaviors:
 # AssignmentsView — M2M API shape (GET and PATCH)
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.django_db
 class TestAssignmentsViewM2M:
     """Integration tests for AssignmentsView returning/accepting M2M arrays."""
@@ -110,22 +112,22 @@ class TestAssignmentsViewM2M:
         # Plan 02 will provide: missionary.supervisors.add(sup)
         missionary.supervisors.add(sup)
 
-        response = client.get('/api/v1/users/admin/assignments/')
+        response = client.get("/api/v1/users/admin/assignments/")
 
         assert response.status_code == 200
-        missionaries_data = response.data['missionaries']
+        missionaries_data = response.data["missionaries"]
         missionary_entry = next(
-            (m for m in missionaries_data if str(m['id']) == str(missionary.id)),
+            (m for m in missionaries_data if str(m["id"]) == str(missionary.id)),
             None,
         )
         assert missionary_entry is not None, "Missionary not in response"
 
         # Plan 03 changes `supervisor_id` → `supervisor_ids` (list field)
-        assert 'supervisor_ids' in missionary_entry, (
-            "Expected `supervisor_ids` list field, got scalar `supervisor_id`"
-        )
-        assert isinstance(missionary_entry['supervisor_ids'], list)
-        assert str(sup.id) in missionary_entry['supervisor_ids']
+        assert (
+            "supervisor_ids" in missionary_entry
+        ), "Expected `supervisor_ids` list field, got scalar `supervisor_id`"
+        assert isinstance(missionary_entry["supervisor_ids"], list)
+        assert str(sup.id) in missionary_entry["supervisor_ids"]
 
     def test_patch_additive_appends_supervisor_assignments(self):
         """PATCH with additive=True appends supervisors without replacing.
@@ -145,25 +147,25 @@ class TestAssignmentsViewM2M:
         missionary.supervisors.add(sup1)
 
         payload = {
-            'assignments': [
+            "assignments": [
                 {
-                    'missionary_id': str(missionary.id),
-                    'supervisor_ids': [str(sup2.id)],
-                    'additive': True,
+                    "missionary_id": str(missionary.id),
+                    "supervisor_ids": [str(sup2.id)],
+                    "additive": True,
                 }
             ]
         }
         response = client.patch(
-            '/api/v1/users/admin/assignments/',
+            "/api/v1/users/admin/assignments/",
             data=payload,
-            format='json',
+            format="json",
         )
 
         assert response.status_code == 200
         missionary.refresh_from_db()
 
         # Both should remain after additive patch
-        assigned_ids = set(missionary.supervisors.values_list('id', flat=True))
+        assigned_ids = set(missionary.supervisors.values_list("id", flat=True))
         assert sup1.id in assigned_ids, "Additive patch should not remove sup1"
         assert sup2.id in assigned_ids, "Additive patch should add sup2"
 
@@ -185,24 +187,24 @@ class TestAssignmentsViewM2M:
         missionary.supervisors.add(sup1, sup2)
 
         payload = {
-            'assignments': [
+            "assignments": [
                 {
-                    'missionary_id': str(missionary.id),
-                    'supervisor_ids': [str(sup3.id)],
+                    "missionary_id": str(missionary.id),
+                    "supervisor_ids": [str(sup3.id)],
                     # additive defaults to False — full replacement
                 }
             ]
         }
         response = client.patch(
-            '/api/v1/users/admin/assignments/',
+            "/api/v1/users/admin/assignments/",
             data=payload,
-            format='json',
+            format="json",
         )
 
         assert response.status_code == 200
         missionary.refresh_from_db()
 
-        assigned_ids = set(missionary.supervisors.values_list('id', flat=True))
+        assigned_ids = set(missionary.supervisors.values_list("id", flat=True))
         assert sup3.id in assigned_ids, "sup3 should be assigned after replacement"
         assert sup1.id not in assigned_ids, "sup1 should be removed on non-additive"
         assert sup2.id not in assigned_ids, "sup2 should be removed on non-additive"
@@ -211,6 +213,7 @@ class TestAssignmentsViewM2M:
 # ---------------------------------------------------------------------------
 # Auto-unassign on role change
 # ---------------------------------------------------------------------------
+
 
 @pytest.mark.django_db
 class TestAutoUnassignOnRoleChange:
@@ -232,21 +235,24 @@ class TestAutoUnassignOnRoleChange:
         missionary1.supervisors.add(sup)
         missionary2.supervisors.add(sup)
 
-        assert sup.supervised_users.count() == 2  # noqa: E501 (Plan 02 reverses FK→M2M reverse relation)
+        assert (
+            sup.supervised_users.count() == 2
+        )  # noqa: E501 (Plan 02 reverses FK→M2M reverse relation)
 
         # Change supervisor's role to missionary — Plan 03 should auto-clear
         sup.role = UserRole.MISSIONARY
         sup.save()
 
         # After role change, no missionaries should be linked to former supervisor
-        assert sup.supervised_users.count() == 0, (
-            "Changing role away from supervisor should auto-clear supervised_users"
-        )
+        assert (
+            sup.supervised_users.count() == 0
+        ), "Changing role away from supervisor should auto-clear supervised_users"
 
 
 # ---------------------------------------------------------------------------
 # Role-filter regression tests (Plan 06: Ghost supervisor fix)
 # ---------------------------------------------------------------------------
+
 
 @pytest.mark.django_db
 class TestAssignmentsViewRoleFilter:
@@ -278,19 +284,19 @@ class TestAssignmentsViewRoleFilter:
         missionary.supervisors.add(ex_sup)
 
         # Directly change role in DB, bypassing User.save() — creates ghost row
-        User.objects.filter(id=ex_sup.id).update(role='missionary')
+        User.objects.filter(id=ex_sup.id).update(role="missionary")
 
-        response = client.get('/api/v1/users/admin/assignments/')
+        response = client.get("/api/v1/users/admin/assignments/")
 
         assert response.status_code == 200
         missionary_entry = next(
-            (m for m in response.data['missionaries'] if str(m['id']) == str(missionary.id)),
+            (m for m in response.data["missionaries"] if str(m["id"]) == str(missionary.id)),
             None,
         )
         assert missionary_entry is not None, "Missionary must appear in GET response"
-        assert str(ex_sup.id) not in missionary_entry['supervisor_ids'], (
-            "Ghost supervisor (role changed to missionary) must not appear in supervisor_ids"
-        )
+        assert (
+            str(ex_sup.id) not in missionary_entry["supervisor_ids"]
+        ), "Ghost supervisor (role changed to missionary) must not appear in supervisor_ids"
 
     def test_ghost_coach_excluded_from_get(self):
         """A role-changed user (coach → missionary) must NOT appear in coach_ids.
@@ -305,19 +311,19 @@ class TestAssignmentsViewRoleFilter:
         missionary.coaches.add(ex_coach)
 
         # Directly change role in DB, bypassing User.save()
-        User.objects.filter(id=ex_coach.id).update(role='missionary')
+        User.objects.filter(id=ex_coach.id).update(role="missionary")
 
-        response = client.get('/api/v1/users/admin/assignments/')
+        response = client.get("/api/v1/users/admin/assignments/")
 
         assert response.status_code == 200
         missionary_entry = next(
-            (m for m in response.data['missionaries'] if str(m['id']) == str(missionary.id)),
+            (m for m in response.data["missionaries"] if str(m["id"]) == str(missionary.id)),
             None,
         )
         assert missionary_entry is not None, "Missionary must appear in GET response"
-        assert str(ex_coach.id) not in missionary_entry['coach_ids'], (
-            "Ghost coach (role changed to missionary) must not appear in coach_ids"
-        )
+        assert (
+            str(ex_coach.id) not in missionary_entry["coach_ids"]
+        ), "Ghost coach (role changed to missionary) must not appear in coach_ids"
 
     def test_active_supervisor_with_correct_role_appears_in_get(self):
         """An active supervisor with role='supervisor' DOES appear in supervisor_ids."""
@@ -326,17 +332,17 @@ class TestAssignmentsViewRoleFilter:
         sup = SupervisorUserFactory()
         missionary.supervisors.add(sup)
 
-        response = client.get('/api/v1/users/admin/assignments/')
+        response = client.get("/api/v1/users/admin/assignments/")
 
         assert response.status_code == 200
         missionary_entry = next(
-            (m for m in response.data['missionaries'] if str(m['id']) == str(missionary.id)),
+            (m for m in response.data["missionaries"] if str(m["id"]) == str(missionary.id)),
             None,
         )
         assert missionary_entry is not None
-        assert str(sup.id) in missionary_entry['supervisor_ids'], (
-            "Active supervisor with correct role must appear in supervisor_ids"
-        )
+        assert (
+            str(sup.id) in missionary_entry["supervisor_ids"]
+        ), "Active supervisor with correct role must appear in supervisor_ids"
 
     def test_inactive_supervisor_excluded_from_get(self):
         """A supervisor with is_active=False must NOT appear in supervisor_ids."""
@@ -348,22 +354,23 @@ class TestAssignmentsViewRoleFilter:
         # Deactivate the supervisor via direct DB update (bypasses save() hooks)
         User.objects.filter(id=sup.id).update(is_active=False)
 
-        response = client.get('/api/v1/users/admin/assignments/')
+        response = client.get("/api/v1/users/admin/assignments/")
 
         assert response.status_code == 200
         missionary_entry = next(
-            (m for m in response.data['missionaries'] if str(m['id']) == str(missionary.id)),
+            (m for m in response.data["missionaries"] if str(m["id"]) == str(missionary.id)),
             None,
         )
         assert missionary_entry is not None
-        assert str(sup.id) not in missionary_entry['supervisor_ids'], (
-            "Inactive supervisor (is_active=False) must not appear in supervisor_ids"
-        )
+        assert (
+            str(sup.id) not in missionary_entry["supervisor_ids"]
+        ), "Inactive supervisor (is_active=False) must not appear in supervisor_ids"
 
 
 # ---------------------------------------------------------------------------
 # Migration preservation (integration / manual test)
 # ---------------------------------------------------------------------------
+
 
 @pytest.mark.skip(
     reason=(

--- a/apps/users/tests/test_models.py
+++ b/apps/users/tests/test_models.py
@@ -1,8 +1,9 @@
 """
 Tests for User model.
 """
-import pytest
 from django.db import IntegrityError
+
+import pytest
 
 from apps.users.models import User, UserRole
 from apps.users.tests.factories import AdminUserFactory, UserFactory
@@ -29,19 +30,19 @@ class TestUserModel:
 
     def test_full_name_property(self):
         """Test full_name property."""
-        user = UserFactory(first_name='John', last_name='Doe')
-        assert user.full_name == 'John Doe'
+        user = UserFactory(first_name="John", last_name="Doe")
+        assert user.full_name == "John Doe"
 
     def test_email_unique(self):
         """Test that email must be unique."""
-        UserFactory(email='test@example.com')
+        UserFactory(email="test@example.com")
         with pytest.raises(IntegrityError):
-            UserFactory(email='test@example.com')
+            UserFactory(email="test@example.com")
 
     def test_user_str(self):
         """Test string representation."""
-        user = UserFactory(first_name='Jane', last_name='Smith', email='jane@example.com')
-        assert str(user) == 'Jane Smith (jane@example.com)'
+        user = UserFactory(first_name="Jane", last_name="Smith", email="jane@example.com")
+        assert str(user) == "Jane Smith (jane@example.com)"
 
 
 @pytest.mark.django_db
@@ -51,23 +52,17 @@ class TestUserManager:
     def test_create_user(self):
         """Test creating user via manager."""
         user = User.objects.create_user(
-            email='test@example.com',
-            password='testpass123',
-            first_name='Test',
-            last_name='User'
+            email="test@example.com", password="testpass123", first_name="Test", last_name="User"
         )
-        assert user.email == 'test@example.com'
-        assert user.check_password('testpass123')
+        assert user.email == "test@example.com"
+        assert user.check_password("testpass123")
         assert user.is_staff is False
         assert user.is_superuser is False
 
     def test_create_superuser(self):
         """Test creating superuser via manager."""
         user = User.objects.create_superuser(
-            email='admin@example.com',
-            password='adminpass123',
-            first_name='Admin',
-            last_name='User'
+            email="admin@example.com", password="adminpass123", first_name="Admin", last_name="User"
         )
         assert user.is_staff is True
         assert user.is_superuser is True
@@ -77,14 +72,11 @@ class TestUserManager:
         """Test that creating user without email raises error."""
         with pytest.raises(ValueError):
             User.objects.create_user(
-                email='',
-                password='testpass123',
-                first_name='Test',
-                last_name='User'
+                email="", password="testpass123", first_name="Test", last_name="User"
             )
 
     def test_get_by_natural_key_case_insensitive(self):
         """Test email lookup is case-insensitive."""
-        UserFactory(email='Test@Example.com')
-        user = User.objects.get_by_natural_key('test@example.com')
-        assert user.email == 'Test@Example.com'
+        UserFactory(email="Test@Example.com")
+        user = User.objects.get_by_natural_key("test@example.com")
+        assert user.email == "Test@Example.com"

--- a/apps/users/tests/test_views.py
+++ b/apps/users/tests/test_views.py
@@ -5,8 +5,7 @@ from rest_framework import status
 
 import pytest
 
-from apps.users.models import UserRole
-from apps.users.tests.factories import AdminUserFactory, UserFactory
+from apps.users.tests.factories import UserFactory
 
 
 @pytest.mark.django_db
@@ -204,7 +203,7 @@ class TestAuthEndpoints:
 
     def test_login_wrong_password(self, api_client, user_factory):
         """Test login with wrong password fails."""
-        user = user_factory(email="wrong@test.com")
+        user_factory(email="wrong@test.com")
 
         response = api_client.post(
             "/api/v1/auth/login/", {"email": "wrong@test.com", "password": "wrongpassword"}

--- a/apps/users/tests/test_views.py
+++ b/apps/users/tests/test_views.py
@@ -1,8 +1,9 @@
 """
 Tests for User API views.
 """
-import pytest
 from rest_framework import status
+
+import pytest
 
 from apps.users.models import UserRole
 from apps.users.tests.factories import AdminUserFactory, UserFactory
@@ -15,27 +16,24 @@ class TestCurrentUserView:
     def test_get_current_user(self, authenticated_client):
         """Test getting current user profile."""
         client, user = authenticated_client
-        response = client.get('/api/v1/users/me/')
+        response = client.get("/api/v1/users/me/")
 
         assert response.status_code == status.HTTP_200_OK
-        assert response.data['email'] == user.email
-        assert response.data['first_name'] == user.first_name
+        assert response.data["email"] == user.email
+        assert response.data["first_name"] == user.first_name
 
     def test_update_current_user(self, authenticated_client):
         """Test updating current user profile."""
         client, user = authenticated_client
-        response = client.patch('/api/v1/users/me/', {
-            'first_name': 'Updated',
-            'phone': '555-1234'
-        })
+        response = client.patch("/api/v1/users/me/", {"first_name": "Updated", "phone": "555-1234"})
 
         assert response.status_code == status.HTTP_200_OK
-        assert response.data['first_name'] == 'Updated'
-        assert response.data['phone'] == '555-1234'
+        assert response.data["first_name"] == "Updated"
+        assert response.data["phone"] == "555-1234"
 
     def test_unauthenticated_denied(self, api_client):
         """Test unauthenticated access is denied."""
-        response = api_client.get('/api/v1/users/me/')
+        response = api_client.get("/api/v1/users/me/")
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
 
@@ -48,32 +46,35 @@ class TestUserListView:
         client, admin = admin_client
         UserFactory.create_batch(5)
 
-        response = client.get('/api/v1/users/')
+        response = client.get("/api/v1/users/")
 
         assert response.status_code == status.HTTP_200_OK
-        assert len(response.data['results']) >= 5
+        assert len(response.data["results"]) >= 5
 
     def test_staff_cannot_list_users(self, authenticated_client):
         """Test staff cannot list users."""
         client, user = authenticated_client
-        response = client.get('/api/v1/users/')
+        response = client.get("/api/v1/users/")
 
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
     def test_admin_can_create_user(self, admin_client):
         """Test admin can create a new user."""
         client, admin = admin_client
-        response = client.post('/api/v1/users/', {
-            'email': 'newuser@example.com',
-            'first_name': 'New',
-            'last_name': 'User',
-            'password': 'securePass123!',
-            'password_confirm': 'securePass123!',
-            'role': 'missionary'
-        })
+        response = client.post(
+            "/api/v1/users/",
+            {
+                "email": "newuser@example.com",
+                "first_name": "New",
+                "last_name": "User",
+                "password": "securePass123!",
+                "password_confirm": "securePass123!",
+                "role": "missionary",
+            },
+        )
 
         assert response.status_code == status.HTTP_201_CREATED
-        assert response.data['email'] == 'newuser@example.com'
+        assert response.data["email"] == "newuser@example.com"
 
 
 @pytest.mark.django_db
@@ -83,29 +84,35 @@ class TestPasswordChange:
     def test_change_password(self, api_client, user_factory):
         """Test changing password with correct old password."""
         user = user_factory()
-        user.set_password('oldpass123')
+        user.set_password("oldpass123")
         user.save()
         api_client.force_authenticate(user=user)
 
-        response = api_client.post('/api/v1/users/me/password/', {
-            'old_password': 'oldpass123',
-            'new_password': 'newSecurePass123!',
-            'new_password_confirm': 'newSecurePass123!'
-        })
+        response = api_client.post(
+            "/api/v1/users/me/password/",
+            {
+                "old_password": "oldpass123",
+                "new_password": "newSecurePass123!",
+                "new_password_confirm": "newSecurePass123!",
+            },
+        )
 
         assert response.status_code == status.HTTP_200_OK
         user.refresh_from_db()
-        assert user.check_password('newSecurePass123!')
+        assert user.check_password("newSecurePass123!")
 
     def test_change_password_wrong_old_password(self, authenticated_client):
         """Test changing password with wrong old password fails."""
         client, user = authenticated_client
 
-        response = client.post('/api/v1/users/me/password/', {
-            'old_password': 'wrongpassword',
-            'new_password': 'newSecurePass123!',
-            'new_password_confirm': 'newSecurePass123!'
-        })
+        response = client.post(
+            "/api/v1/users/me/password/",
+            {
+                "old_password": "wrongpassword",
+                "new_password": "newSecurePass123!",
+                "new_password_confirm": "newSecurePass123!",
+            },
+        )
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
@@ -117,50 +124,62 @@ class TestAdminPasswordReset:
     def test_admin_can_reset_user_password(self, admin_client, user_factory):
         """Admin can reset another user's password without knowing old password."""
         client, admin = admin_client
-        target_user = user_factory(role='missionary')
+        target_user = user_factory(role="missionary")
 
-        response = client.post(f'/api/v1/users/{target_user.id}/password/', {
-            'new_password': 'newSecurePass123!',
-            'new_password_confirm': 'newSecurePass123!',
-        })
+        response = client.post(
+            f"/api/v1/users/{target_user.id}/password/",
+            {
+                "new_password": "newSecurePass123!",
+                "new_password_confirm": "newSecurePass123!",
+            },
+        )
 
         assert response.status_code == status.HTTP_200_OK
         target_user.refresh_from_db()
-        assert target_user.check_password('newSecurePass123!')
+        assert target_user.check_password("newSecurePass123!")
 
     def test_non_admin_cannot_reset_password(self, authenticated_client, user_factory):
         """Non-admin users cannot reset another user's password."""
         client, missionary = authenticated_client
-        target_user = user_factory(role='missionary')
+        target_user = user_factory(role="missionary")
 
-        response = client.post(f'/api/v1/users/{target_user.id}/password/', {
-            'new_password': 'newSecurePass123!',
-            'new_password_confirm': 'newSecurePass123!',
-        })
+        response = client.post(
+            f"/api/v1/users/{target_user.id}/password/",
+            {
+                "new_password": "newSecurePass123!",
+                "new_password_confirm": "newSecurePass123!",
+            },
+        )
 
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
     def test_passwords_must_match(self, admin_client, user_factory):
         """Password confirmation must match."""
         client, admin = admin_client
-        target_user = user_factory(role='missionary')
+        target_user = user_factory(role="missionary")
 
-        response = client.post(f'/api/v1/users/{target_user.id}/password/', {
-            'new_password': 'newSecurePass123!',
-            'new_password_confirm': 'differentPassword123!',
-        })
+        response = client.post(
+            f"/api/v1/users/{target_user.id}/password/",
+            {
+                "new_password": "newSecurePass123!",
+                "new_password_confirm": "differentPassword123!",
+            },
+        )
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
     def test_weak_password_rejected(self, admin_client, user_factory):
         """Django password validators reject weak passwords."""
         client, admin = admin_client
-        target_user = user_factory(role='missionary')
+        target_user = user_factory(role="missionary")
 
-        response = client.post(f'/api/v1/users/{target_user.id}/password/', {
-            'new_password': '123',
-            'new_password_confirm': '123',
-        })
+        response = client.post(
+            f"/api/v1/users/{target_user.id}/password/",
+            {
+                "new_password": "123",
+                "new_password_confirm": "123",
+            },
+        )
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
@@ -171,63 +190,60 @@ class TestAuthEndpoints:
 
     def test_login(self, api_client, user_factory):
         """Test login with correct credentials."""
-        user = user_factory(email='login@test.com')
-        user.set_password('testpass123')
+        user = user_factory(email="login@test.com")
+        user.set_password("testpass123")
         user.save()
 
-        response = api_client.post('/api/v1/auth/login/', {
-            'email': 'login@test.com',
-            'password': 'testpass123'
-        })
+        response = api_client.post(
+            "/api/v1/auth/login/", {"email": "login@test.com", "password": "testpass123"}
+        )
 
         assert response.status_code == status.HTTP_200_OK
-        assert 'access' in response.data
-        assert 'refresh' in response.data
+        assert "access" in response.data
+        assert "refresh" in response.data
 
     def test_login_wrong_password(self, api_client, user_factory):
         """Test login with wrong password fails."""
-        user = user_factory(email='wrong@test.com')
+        user = user_factory(email="wrong@test.com")
 
-        response = api_client.post('/api/v1/auth/login/', {
-            'email': 'wrong@test.com',
-            'password': 'wrongpassword'
-        })
+        response = api_client.post(
+            "/api/v1/auth/login/", {"email": "wrong@test.com", "password": "wrongpassword"}
+        )
 
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
     def test_token_refresh(self, api_client, user_factory):
         """Test refreshing access token."""
-        user = user_factory(email='refresh@test.com')
-        user.set_password('testpass123')
+        user = user_factory(email="refresh@test.com")
+        user.set_password("testpass123")
         user.save()
 
         # First login
-        login_response = api_client.post('/api/v1/auth/login/', {
-            'email': 'refresh@test.com',
-            'password': 'testpass123'
-        })
-        refresh_token = login_response.data['refresh']
+        login_response = api_client.post(
+            "/api/v1/auth/login/", {"email": "refresh@test.com", "password": "testpass123"}
+        )
+        refresh_token = login_response.data["refresh"]
 
         # Refresh token
-        response = api_client.post('/api/v1/auth/refresh/', {
-            'refresh': refresh_token
-        })
+        response = api_client.post("/api/v1/auth/refresh/", {"refresh": refresh_token})
 
         assert response.status_code == status.HTTP_200_OK
-        assert 'access' in response.data
+        assert "access" in response.data
 
 
 @pytest.mark.django_db
 class TestCoachAssignment:
     """Tests for coach coached_user_ids assignment (ROLE-04)."""
 
-    def test_admin_can_set_coached_user_ids(self, api_client, admin_user, coach_user, missionary_user):
+    def test_admin_can_set_coached_user_ids(
+        self, api_client, admin_user, coach_user, missionary_user
+    ):
         """ROLE-04: coached_user_ids PATCH persists M2M assignment."""
         api_client.force_authenticate(user=admin_user)
         response = api_client.patch(
-            f'/api/v1/users/{coach_user.id}/',
-            data={'coached_user_ids': [str(missionary_user.id)]},
-            format='json'
+            f"/api/v1/users/{coach_user.id}/",
+            data={"coached_user_ids": [str(missionary_user.id)]},
+            format="json",
         )
         assert response.status_code == 200
         coach_user.refresh_from_db()

--- a/apps/users/tests/test_views_goals.py
+++ b/apps/users/tests/test_views_goals.py
@@ -3,8 +3,10 @@ Integration test stubs for Goals API endpoint.
 GOAL-02: PATCH /api/v1/goals/me/ saves monthly_support_goal_cents and goal_weeks.
 GOAL-03: PATCH /api/v1/goals/me/ with journal_ids replaces GoalJournalSelection set.
 """
-import pytest
 from rest_framework.test import APIClient
+
+import pytest
+
 from apps.users.tests.factories import UserFactory
 
 
@@ -123,6 +125,7 @@ def test_calls_count_reflects_journal_events():
 
     # Create a JournalContact to attach events to
     from apps.contacts.tests.factories import ContactFactory
+
     contact = ContactFactory(owner=user)
     jc = JournalContact.objects.create(journal=journal, contact=contact)
 
@@ -130,8 +133,8 @@ def test_calls_count_reflects_journal_events():
     for _ in range(3):
         JournalStageEvent.objects.create(
             journal_contact=jc,
-            stage='contact',
-            event_type='call_logged',
+            stage="contact",
+            event_type="call_logged",
         )
 
     # Select this journal
@@ -148,6 +151,7 @@ def test_calls_count_reflects_journal_events():
 def test_supervisor_can_get_goal_readonly():
     """GOAL-10: Supervisor role can GET /api/v1/goals/me/ (read-only enforced in UI, not API)."""
     from apps.users.models import UserRole
+
     user = UserFactory(role=UserRole.SUPERVISOR)
     client = APIClient()
     client.force_authenticate(user=user)

--- a/apps/users/tests/test_views_viewable.py
+++ b/apps/users/tests/test_views_viewable.py
@@ -10,16 +10,17 @@ GREEN state: all tests pass after Plan 04 implements ViewableUsersView.
 Test coverage:
   - VIEWAS-12: Viewable users endpoint (admin sees all missionaries, supervisor sees assigned only)
 """
-import pytest
 from rest_framework.test import APIClient
 
+import pytest
 
 # --- ROLE ACCESS ---
+
 
 @pytest.mark.django_db
 def test_admin_sees_missionaries_and_supervisors():
     """Admin GET /api/users/viewable/ returns all active missionaries and supervisors."""
-    from apps.users.tests.factories import AdminUserFactory, UserFactory, SupervisorUserFactory
+    from apps.users.tests.factories import AdminUserFactory, SupervisorUserFactory, UserFactory
 
     admin = AdminUserFactory()
     missionary1 = UserFactory()
@@ -28,10 +29,10 @@ def test_admin_sees_missionaries_and_supervisors():
 
     client = APIClient()
     client.force_authenticate(user=admin)
-    response = client.get('/api/v1/users/viewable/')
+    response = client.get("/api/v1/users/viewable/")
 
     assert response.status_code == 200
-    ids = [item['id'] for item in response.data]
+    ids = [item["id"] for item in response.data]
     assert str(missionary1.id) in ids
     assert str(missionary2.id) in ids
     # Supervisor should appear (admin can view supervisors)
@@ -52,10 +53,10 @@ def test_supervisor_sees_assigned_only():
 
     client = APIClient()
     client.force_authenticate(user=supervisor)
-    response = client.get('/api/v1/users/viewable/')
+    response = client.get("/api/v1/users/viewable/")
 
     assert response.status_code == 200
-    ids = [item['id'] for item in response.data]
+    ids = [item["id"] for item in response.data]
     assert str(assigned_missionary.id) in ids
     assert str(unassigned_missionary.id) not in ids
 
@@ -69,7 +70,7 @@ def test_missionary_gets_403():
 
     client = APIClient()
     client.force_authenticate(user=missionary)
-    response = client.get('/api/v1/users/viewable/')
+    response = client.get("/api/v1/users/viewable/")
 
     assert response.status_code == 403
 
@@ -78,12 +79,13 @@ def test_missionary_gets_403():
 def test_unauthenticated_gets_401():
     """Unauthenticated GET /api/users/viewable/ returns 401."""
     client = APIClient()
-    response = client.get('/api/v1/users/viewable/')
+    response = client.get("/api/v1/users/viewable/")
 
     assert response.status_code == 401
 
 
 # --- FILTERING ---
+
 
 @pytest.mark.django_db
 def test_inactive_missionaries_excluded():
@@ -96,10 +98,10 @@ def test_inactive_missionaries_excluded():
 
     client = APIClient()
     client.force_authenticate(user=admin)
-    response = client.get('/api/v1/users/viewable/')
+    response = client.get("/api/v1/users/viewable/")
 
     assert response.status_code == 200
-    ids = [item['id'] for item in response.data]
+    ids = [item["id"] for item in response.data]
     assert str(active_missionary.id) in ids
     assert str(inactive_missionary.id) not in ids
 
@@ -116,10 +118,10 @@ def test_admin_roles_excluded():
 
     client = APIClient()
     client.force_authenticate(user=admin)
-    response = client.get('/api/v1/users/viewable/')
+    response = client.get("/api/v1/users/viewable/")
 
     assert response.status_code == 200
-    ids = [item['id'] for item in response.data]
+    ids = [item["id"] for item in response.data]
     assert str(missionary.id) in ids
     assert str(supervisor.id) in ids
     # Other admins should not appear
@@ -129,6 +131,7 @@ def test_admin_roles_excluded():
 
 
 # --- RESPONSE SHAPE ---
+
 
 @pytest.mark.django_db
 def test_response_shape():
@@ -140,9 +143,9 @@ def test_response_shape():
 
     client = APIClient()
     client.force_authenticate(user=admin)
-    response = client.get('/api/v1/users/viewable/')
+    response = client.get("/api/v1/users/viewable/")
 
     assert response.status_code == 200
     assert len(response.data) > 0
     for item in response.data:
-        assert set(item.keys()) == {'id', 'full_name'}
+        assert set(item.keys()) == {"id", "full_name"}

--- a/apps/users/urls.py
+++ b/apps/users/urls.py
@@ -13,14 +13,14 @@ from apps.users.views import (
 )
 from apps.users.views_assignments import AssignmentsView
 
-app_name = 'users'
+app_name = "users"
 
 urlpatterns = [
-    path('', UserListCreateView.as_view(), name='user-list'),
-    path('me/', CurrentUserView.as_view(), name='current-user'),
-    path('me/password/', PasswordChangeView.as_view(), name='password-change'),
-    path('admin/assignments/', AssignmentsView.as_view(), name='user-assignments'),
-    path('viewable/', ViewableUsersView.as_view(), name='user-viewable'),
-    path('<uuid:pk>/password/', AdminPasswordResetView.as_view(), name='admin-password-reset'),
-    path('<uuid:pk>/', UserDetailView.as_view(), name='user-detail'),
+    path("", UserListCreateView.as_view(), name="user-list"),
+    path("me/", CurrentUserView.as_view(), name="current-user"),
+    path("me/password/", PasswordChangeView.as_view(), name="password-change"),
+    path("admin/assignments/", AssignmentsView.as_view(), name="user-assignments"),
+    path("viewable/", ViewableUsersView.as_view(), name="user-viewable"),
+    path("<uuid:pk>/password/", AdminPasswordResetView.as_view(), name="admin-password-reset"),
+    path("<uuid:pk>/", UserDetailView.as_view(), name="user-detail"),
 ]

--- a/apps/users/urls_goals.py
+++ b/apps/users/urls_goals.py
@@ -6,5 +6,5 @@ from django.urls import path
 from apps.users.views_goals import GoalView
 
 urlpatterns = [
-    path('me/', GoalView.as_view(), name='goal-me'),
+    path("me/", GoalView.as_view(), name="goal-me"),
 ]

--- a/apps/users/views_assignments.py
+++ b/apps/users/views_assignments.py
@@ -1,8 +1,9 @@
 """
 Assignments API for admin to manage missionary-supervisor-coach relationships.
 """
-from rest_framework.views import APIView
 from rest_framework.response import Response
+from rest_framework.views import APIView
+
 from apps.core.permissions import IsAdmin
 from apps.users.models import User
 
@@ -11,67 +12,87 @@ class AssignmentsView(APIView):
     permission_classes = [IsAdmin]
 
     def get(self, request):
-        missionaries = User.objects.filter(
-            role='missionary', is_active=True
-        ).prefetch_related('supervisors', 'coaches').order_by('last_name', 'first_name')
+        missionaries = (
+            User.objects.filter(role="missionary", is_active=True)
+            .prefetch_related("supervisors", "coaches")
+            .order_by("last_name", "first_name")
+        )
 
-        supervisors = User.objects.filter(
-            role='supervisor', is_active=True
-        ).order_by('last_name', 'first_name')
+        supervisors = User.objects.filter(role="supervisor", is_active=True).order_by(
+            "last_name", "first_name"
+        )
 
-        coaches = User.objects.filter(
-            role='coach', is_active=True
-        ).order_by('last_name', 'first_name')
+        coaches = User.objects.filter(role="coach", is_active=True).order_by(
+            "last_name", "first_name"
+        )
 
         def person(u):
-            return {'id': str(u.id), 'first_name': u.first_name,
-                    'last_name': u.last_name, 'email': u.email}
+            return {
+                "id": str(u.id),
+                "first_name": u.first_name,
+                "last_name": u.last_name,
+                "email": u.email,
+            }
 
-        return Response({
-            'missionaries': [
-                {
-                    'id': str(m.id),
-                    'email': m.email,
-                    'full_name': m.full_name,
-                    'supervisor_ids': [str(s.id) for s in m.supervisors.filter(role='supervisor', is_active=True)],
-                    'coach_ids': [str(c.id) for c in m.coaches.filter(role='coach', is_active=True)],
-                }
-                for m in missionaries
-            ],
-            'supervisors': [person(u) for u in supervisors],
-            'coaches': [person(u) for u in coaches],
-        })
+        return Response(
+            {
+                "missionaries": [
+                    {
+                        "id": str(m.id),
+                        "email": m.email,
+                        "full_name": m.full_name,
+                        "supervisor_ids": [
+                            str(s.id)
+                            for s in m.supervisors.filter(role="supervisor", is_active=True)
+                        ],
+                        "coach_ids": [
+                            str(c.id) for c in m.coaches.filter(role="coach", is_active=True)
+                        ],
+                    }
+                    for m in missionaries
+                ],
+                "supervisors": [person(u) for u in supervisors],
+                "coaches": [person(u) for u in coaches],
+            }
+        )
 
     def patch(self, request):
-        assignments = request.data.get('assignments', [])
+        assignments = request.data.get("assignments", [])
         if not isinstance(assignments, list):
-            return Response({'detail': 'assignments must be a list'}, status=400)
+            return Response({"detail": "assignments must be a list"}, status=400)
 
         updated = 0
         errors = []
         warnings = []
 
         for item in assignments:
-            missionary_id = item.get('missionary_id')
-            supervisor_ids = item.get('supervisor_ids')  # list of uuid strs or null
-            coach_ids = item.get('coach_ids')  # list of uuid strs or null
-            additive = item.get('additive', False)
+            missionary_id = item.get("missionary_id")
+            supervisor_ids = item.get("supervisor_ids")  # list of uuid strs or null
+            coach_ids = item.get("coach_ids")  # list of uuid strs or null
+            additive = item.get("additive", False)
 
             try:
-                missionary = User.objects.get(id=missionary_id, role='missionary')
+                missionary = User.objects.get(id=missionary_id, role="missionary")
             except User.DoesNotExist:
-                errors.append({'missionary_id': missionary_id, 'error': 'Not found or not a missionary'})
+                errors.append(
+                    {"missionary_id": missionary_id, "error": "Not found or not a missionary"}
+                )
                 continue
 
             # Validate and assign supervisors
             if supervisor_ids is not None:
                 valid_supervisors = list(
-                    User.objects.filter(id__in=supervisor_ids, role='supervisor')
+                    User.objects.filter(id__in=supervisor_ids, role="supervisor")
                 )
                 found_ids = {str(s.id) for s in valid_supervisors}
                 invalid = [sid for sid in supervisor_ids if sid not in found_ids]
                 if invalid:
-                    errors.append({'missionary_id': missionary_id, 'error': f'Supervisor(s) not found or not supervisors: {invalid}'})
+                    errors.append(
+                        {
+                            "missionary_id": missionary_id,
+                            "error": f"Supervisor(s) not found or not supervisors: {invalid}",
+                        }
+                    )
                     continue
                 if additive:
                     missionary.supervisors.add(*valid_supervisors)
@@ -80,13 +101,16 @@ class AssignmentsView(APIView):
 
             # Validate and assign coaches
             if coach_ids is not None:
-                valid_coaches = list(
-                    User.objects.filter(id__in=coach_ids, role='coach')
-                )
+                valid_coaches = list(User.objects.filter(id__in=coach_ids, role="coach"))
                 found_ids = {str(c.id) for c in valid_coaches}
                 invalid = [cid for cid in coach_ids if cid not in found_ids]
                 if invalid:
-                    errors.append({'missionary_id': missionary_id, 'error': f'Coach(es) not found or not coaches: {invalid}'})
+                    errors.append(
+                        {
+                            "missionary_id": missionary_id,
+                            "error": f"Coach(es) not found or not coaches: {invalid}",
+                        }
+                    )
                     continue
                 if additive:
                     missionary.coaches.add(*valid_coaches)
@@ -96,9 +120,11 @@ class AssignmentsView(APIView):
             updated += 1
             # Soft warning: flag missionaries with 5+ supervisors
             if missionary.supervisors.count() >= 5:
-                warnings.append({
-                    'missionary_id': str(missionary.id),
-                    'warning': 'Missionary has 5+ supervisors assigned',
-                })
+                warnings.append(
+                    {
+                        "missionary_id": str(missionary.id),
+                        "warning": "Missionary has 5+ supervisors assigned",
+                    }
+                )
 
-        return Response({'updated': updated, 'errors': errors, 'warnings': warnings})
+        return Response({"updated": updated, "errors": errors, "warnings": warnings})

--- a/apps/users/views_auth.py
+++ b/apps/users/views_auth.py
@@ -1,10 +1,11 @@
 """
 Authentication views.
 """
-from drf_spectacular.utils import extend_schema, inline_serializer
 from rest_framework import permissions, serializers, status
 from rest_framework.response import Response
 from rest_framework.views import APIView
+
+from drf_spectacular.utils import extend_schema, inline_serializer
 from rest_framework_simplejwt.tokens import RefreshToken
 
 
@@ -12,39 +13,30 @@ class LogoutView(APIView):
     """
     POST: Logout by blacklisting the refresh token.
     """
+
     permission_classes = [permissions.IsAuthenticated]
 
     @extend_schema(
-        tags=['auth'],
-        summary='Logout user',
-        description='Logout by blacklisting the refresh token.',
+        tags=["auth"],
+        summary="Logout user",
+        description="Logout by blacklisting the refresh token.",
         request=inline_serializer(
-            name='LogoutRequest',
-            fields={'refresh': serializers.CharField(help_text='Refresh token to blacklist')}
+            name="LogoutRequest",
+            fields={"refresh": serializers.CharField(help_text="Refresh token to blacklist")},
         ),
         responses={
             200: inline_serializer(
-                name='LogoutResponse',
-                fields={'detail': serializers.CharField()}
+                name="LogoutResponse", fields={"detail": serializers.CharField()}
             ),
-            400: inline_serializer(
-                name='LogoutError',
-                fields={'detail': serializers.CharField()}
-            ),
-        }
+            400: inline_serializer(name="LogoutError", fields={"detail": serializers.CharField()}),
+        },
     )
     def post(self, request):
         try:
-            refresh_token = request.data.get('refresh')
+            refresh_token = request.data.get("refresh")
             if refresh_token:
                 token = RefreshToken(refresh_token)
                 token.blacklist()
-            return Response(
-                {'detail': 'Successfully logged out.'},
-                status=status.HTTP_200_OK
-            )
+            return Response({"detail": "Successfully logged out."}, status=status.HTTP_200_OK)
         except Exception:
-            return Response(
-                {'detail': 'Invalid token.'},
-                status=status.HTTP_400_BAD_REQUEST
-            )
+            return Response({"detail": "Invalid token."}, status=status.HTTP_400_BAD_REQUEST)

--- a/apps/users/views_goals.py
+++ b/apps/users/views_goals.py
@@ -1,11 +1,11 @@
 """
 API views for Goal tracking.
 """
+from django.db import transaction
+
 from rest_framework import permissions
 from rest_framework.response import Response
 from rest_framework.views import APIView
-
-from django.db import transaction
 
 from apps.journals.models import Journal
 from apps.users.goal_services import get_decisions_progress, get_goal_progress
@@ -19,10 +19,11 @@ class GoalView(APIView):
 
     Always scoped to request.user — no cross-user access.
     """
+
     permission_classes = [permissions.IsAuthenticated]
 
     def get(self, request):
-        user = getattr(request, 'view_as_user', None) or request.user
+        user = getattr(request, "view_as_user", None) or request.user
         data = get_goal_progress(user)
         data.update(get_decisions_progress(user))
         return Response(data)
@@ -30,52 +31,60 @@ class GoalView(APIView):
     def patch(self, request):
         user = request.user
         data = request.data
-        update_fields = ['updated_at']
+        update_fields = ["updated_at"]
 
-        if 'monthly_support_goal_cents' in data:
+        if "monthly_support_goal_cents" in data:
             try:
-                value = int(data['monthly_support_goal_cents'])
+                value = int(data["monthly_support_goal_cents"])
             except (TypeError, ValueError):
-                return Response({'error': 'monthly_support_goal_cents must be a non-negative integer'}, status=400)
+                return Response(
+                    {"error": "monthly_support_goal_cents must be a non-negative integer"},
+                    status=400,
+                )
             if value < 0:
-                return Response({'error': 'monthly_support_goal_cents must be a non-negative integer'}, status=400)
+                return Response(
+                    {"error": "monthly_support_goal_cents must be a non-negative integer"},
+                    status=400,
+                )
             user.monthly_support_goal_cents = value
-            update_fields.append('monthly_support_goal_cents')
+            update_fields.append("monthly_support_goal_cents")
 
-        if 'goal_weeks' in data:
+        if "goal_weeks" in data:
             try:
-                value = int(data['goal_weeks'])
+                value = int(data["goal_weeks"])
             except (TypeError, ValueError):
-                return Response({'error': 'goal_weeks must be a positive integer'}, status=400)
+                return Response({"error": "goal_weeks must be a positive integer"}, status=400)
             if value <= 0:
-                return Response({'error': 'goal_weeks must be a positive integer'}, status=400)
+                return Response({"error": "goal_weeks must be a positive integer"}, status=400)
             user.goal_weeks = value
-            update_fields.append('goal_weeks')
+            update_fields.append("goal_weeks")
 
-        if update_fields != ['updated_at']:
+        if update_fields != ["updated_at"]:
             user.save(update_fields=update_fields)
 
-        if 'journal_ids' in data:
-            journal_ids = data['journal_ids']
+        if "journal_ids" in data:
+            journal_ids = data["journal_ids"]
             if not isinstance(journal_ids, list):
-                return Response({'error': 'journal_ids must be a list'}, status=400)
+                return Response({"error": "journal_ids must be a list"}, status=400)
             # Validate journals belong to the requesting user (no cross-user journal selection)
             try:
                 valid_journals = list(Journal.objects.filter(id__in=journal_ids, owner=user))
             except Exception:
-                return Response({'error': 'journal_ids contains invalid values'}, status=400)
+                return Response({"error": "journal_ids contains invalid values"}, status=400)
             valid_journal_ids = {str(j.id) for j in valid_journals}
             submitted_ids = {str(jid) for jid in journal_ids}
             invalid_ids = submitted_ids - valid_journal_ids
             if invalid_ids:
-                return Response({'error': f'Invalid or inaccessible journal_ids: {sorted(invalid_ids)}'}, status=400)
+                return Response(
+                    {"error": f"Invalid or inaccessible journal_ids: {sorted(invalid_ids)}"},
+                    status=400,
+                )
             # Replace-all semantics: delete then bulk create (atomic to prevent partial state)
             with transaction.atomic():
                 GoalJournalSelection.objects.filter(user=user).delete()
-                GoalJournalSelection.objects.bulk_create([
-                    GoalJournalSelection(user=user, journal=j)
-                    for j in valid_journals
-                ])
+                GoalJournalSelection.objects.bulk_create(
+                    [GoalJournalSelection(user=user, journal=j) for j in valid_journals]
+                )
 
         data = get_goal_progress(user)
         data.update(get_decisions_progress(user))

--- a/config/asgi.py
+++ b/config/asgi.py
@@ -5,6 +5,6 @@ import os
 
 from django.core.asgi import get_asgi_application
 
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'config.settings.prod')
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings.prod")
 
 application = get_asgi_application()

--- a/config/celery.py
+++ b/config/celery.py
@@ -7,32 +7,32 @@ from celery import Celery
 from celery.schedules import crontab
 
 # Set the default Django settings module for the 'celery' program.
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'config.settings.prod')
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings.prod")
 
-app = Celery('donorcrm')
+app = Celery("donorcrm")
 
 # Using a string here means the worker doesn't have to serialize
 # the configuration object to child processes.
-app.config_from_object('django.conf:settings', namespace='CELERY')
+app.config_from_object("django.conf:settings", namespace="CELERY")
 
 # Load task modules from all registered Django apps.
 app.autodiscover_tasks()
 
 # Periodic tasks schedule
 app.conf.beat_schedule = {
-    'detect-at-risk-donors-daily': {
-        'task': 'apps.contacts.tasks.detect_at_risk_donors',
-        'schedule': crontab(hour=7, minute=0),  # Daily at 7 AM UTC
-        'options': {'expires': 3600},
+    "detect-at-risk-donors-daily": {
+        "task": "apps.contacts.tasks.detect_at_risk_donors",
+        "schedule": crontab(hour=7, minute=0),  # Daily at 7 AM UTC
+        "options": {"expires": 3600},
     },
-    'generate-weekly-summary': {
-        'task': 'apps.dashboard.tasks.generate_weekly_summary',
-        'schedule': crontab(hour=8, minute=0, day_of_week=1),  # Mondays at 8 AM UTC
-        'options': {'expires': 7200},
+    "generate-weekly-summary": {
+        "task": "apps.dashboard.tasks.generate_weekly_summary",
+        "schedule": crontab(hour=8, minute=0, day_of_week=1),  # Mondays at 8 AM UTC
+        "options": {"expires": 7200},
     },
 }
 
 
 @app.task(bind=True, ignore_result=True)
 def debug_task(self):
-    print(f'Request: {self.request!r}')
+    print(f"Request: {self.request!r}")

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -236,7 +236,10 @@ REST_FRAMEWORK = {
 # API Documentation (drf-spectacular)
 SPECTACULAR_SETTINGS = {
     "TITLE": "DonorCRM API",
-    "DESCRIPTION": "A missionary support management CRM API for tracking donors, gifts, recurring gifts, and tasks.",
+    "DESCRIPTION": (
+        "A missionary support management CRM API for tracking donors, gifts, "
+        "recurring gifts, and tasks."
+    ),
     "VERSION": "1.0.0",
     "SERVE_INCLUDE_SCHEMA": False,
     "COMPONENT_SPLIT_REQUEST": True,

--- a/config/urls.py
+++ b/config/urls.py
@@ -6,16 +6,17 @@ from django.contrib import admin
 from django.urls import include, path
 
 urlpatterns = [
-    path('admin/', admin.site.urls),
-    path('api/v1/', include('config.api_urls')),
+    path("admin/", admin.site.urls),
+    path("api/v1/", include("config.api_urls")),
 ]
 
 # Debug toolbar URLs (development only)
 if settings.DEBUG:
     try:
         import debug_toolbar
+
         urlpatterns = [
-            path('__debug__/', include(debug_toolbar.urls)),
+            path("__debug__/", include(debug_toolbar.urls)),
         ] + urlpatterns
     except ImportError:
         pass

--- a/config/wsgi.py
+++ b/config/wsgi.py
@@ -5,6 +5,6 @@ import os
 
 from django.core.wsgi import get_wsgi_application
 
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'config.settings.prod')
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings.prod")
 
 application = get_wsgi_application()


### PR DESCRIPTION
## What

Clears the **backend lint debt** and flips `black`/`isort`/`flake8` from advisory to **hard gates**.

- `style:` apply black (152 files reformatted) + isort across `apps/` and `config/`.
- `style:` fix all **137** remaining flake8 violations (unused imports/vars, long lines, `##` comments, placeholderless f-strings, redefinitions, ambiguous names).
- `ci:` remove `continue-on-error` from black/isort/flake8 → they now block.

**No behavior change.** Side-effecting calls were preserved (binding dropped, call kept); no Django side-effect imports were removed. Full suite green at **81% coverage** throughout.

## ESLint stays advisory (on purpose)

Frontend ESLint still has ~51 errors, mostly **strict react-hooks rules** — including 11 `rules-of-hooks` (real conditional-hook calls in form pages) and 16 `set-state-in-effect`. Fixing these requires careful per-component refactoring, and the frontend has **no unit-test net** (CI is build + lint only), so forcing them blind risks regressions. Tracked as a separate, app-verified effort before flipping ESLint to a hard gate.

## Test plan

- [x] `flake8 apps/ config/` → 0 violations; `black --check` / `isort --check-only` clean
- [x] Full backend suite green, 81.17% coverage
- [ ] CI green on this PR with black/isort/flake8 now **blocking**
