### PR TITLE
fix: sort group contact emails by plaintext, not ciphertext (closes #60)

### DIFF
--- a/apps/groups/tests/test_views_coverage.py
+++ b/apps/groups/tests/test_views_coverage.py
@@ -245,20 +245,22 @@ class TestGroupContactsRemoval:
 class TestGroupContactEmailsView:
     """The group contact-emails export endpoint."""
 
-    def test_returns_group_contact_emails_with_count(self):
-        """Returns every in-group contact email plus a matching count.
+    def test_returns_group_contact_emails_sorted_with_count(self):
+        """Returns every in-group email, case-insensitively sorted, plus a count.
 
-        NOTE: order is not asserted. The Contact.email column is encrypted at
-        rest, so the view's order_by('email') sorts by ciphertext rather than
-        plaintext (see bug report). We assert the set + count, which is the
-        correct behavioral contract regardless of ordering.
+        Regression guard for the encrypted-ordering bug: Contact.email is
+        encrypted at rest with a random nonce, so a DB-level order_by('email')
+        sorts by (random) ciphertext. The view decrypts and sorts in Python, so
+        the result must be alphabetical regardless of insertion order. Several
+        mixed-case emails are inserted out of order so a ciphertext/random order
+        cannot coincidentally pass.
         """
         user = UserFactory(role="missionary")
         group = GroupFactory(owner=user)
-        c1 = ContactFactory(owner=user, email="zed@example.com")
-        c2 = ContactFactory(owner=user, email="amy@example.com")
-        c1.groups.add(group)
-        c2.groups.add(group)
+        emails = ["zoe@example.com", "Amy@example.com", "mike@example.com", "Bob@example.com"]
+        for addr in emails:
+            contact = ContactFactory(owner=user, email=addr)
+            contact.groups.add(group)
 
         client = APIClient()
         client.force_authenticate(user=user)
@@ -266,8 +268,8 @@ class TestGroupContactEmailsView:
         response = client.get(f"/api/v1/groups/{group.id}/contacts/emails/")
 
         assert response.status_code == status.HTTP_200_OK
-        assert set(response.data["emails"]) == {"amy@example.com", "zed@example.com"}
-        assert response.data["count"] == 2
+        assert response.data["emails"] == sorted(emails, key=str.casefold)
+        assert response.data["count"] == 4
 
     def test_excludes_blank_and_null_emails(self):
         """Contacts with empty-string emails are excluded from the export."""

--- a/apps/groups/views.py
+++ b/apps/groups/views.py
@@ -166,10 +166,13 @@ class GroupContactEmailsView(APIView):
         except Group.DoesNotExist:
             return Response({"detail": "Group not found."}, status=status.HTTP_404_NOT_FOUND)
 
-        emails = list(
+        # email is encrypted at rest with a random nonce, so a DB-level
+        # .order_by("email") sorts by (effectively random) ciphertext. Pull the
+        # decrypted plaintext via values_list and sort case-insensitively here.
+        emails = sorted(
             group.contacts.exclude(email__isnull=True)
             .exclude(email="")
-            .values_list("email", flat=True)
-            .order_by("email")
+            .values_list("email", flat=True),
+            key=str.casefold,
         )
         return Response({"emails": emails, "count": len(emails)})


### PR DESCRIPTION
Fixes #60. `GroupContactEmailsView` sorted by the encrypted `email` column (random-nonce ciphertext), so the exported list came back unordered despite the apparent `.order_by("email")`. Now decrypts via `values_list` and sorts case-insensitively in Python.

Security: no change — same data, same authorization, already decrypted in the request; only the sort order changes (see discussion). The test now inserts mixed-case emails out of order and asserts the sorted output, so it fails if ordering regresses (verified it fails without the fix).

- [x] Fix passes; test fails without the fix (real regression guard)
- [x] black/isort/flake8 clean (now blocking)
- [ ] CI green