### PR TITLE
fix: remove broken ?owner= filter from gift/recurring exports (#63)

### DIFF
--- a/apps/gifts/export_views.py
+++ b/apps/gifts/export_views.py
@@ -36,14 +36,11 @@ class GiftExportCSVView(APIView):
 
         user = request.user
 
-        # Same owner-scoping as GiftListCreateView
+        # Same owner-scoping as GiftListCreateView. Cross-user access is
+        # reached only via View As (X-View-As-User-Id -> get_visible_user_ids),
+        # never a ?owner= query param.
         visible = get_visible_user_ids(user, request=request)
         queryset = Gift.objects.filter(donor_contact__owner_id__in=visible)
-
-        # Admin/supervisor owner filter
-        owner_id = request.query_params.get("owner")
-        if owner_id and user.role in ["admin", "supervisor"]:
-            queryset = queryset.filter(donor_contact__owner_id=owner_id)
 
         # Apply FilterSet (same as list endpoint)
         filterset = GiftFilterSet(request.query_params, queryset=queryset)
@@ -99,14 +96,11 @@ class RecurringGiftExportCSVView(APIView):
 
         user = request.user
 
-        # Same owner-scoping as RecurringGiftListCreateView
+        # Same owner-scoping as RecurringGiftListCreateView. Cross-user access
+        # is reached only via View As (X-View-As-User-Id -> get_visible_user_ids),
+        # never a ?owner= query param.
         visible = get_visible_user_ids(user, request=request)
         queryset = RecurringGift.objects.filter(donor_contact__owner_id__in=visible)
-
-        # Admin/supervisor owner filter
-        owner_id = request.query_params.get("owner")
-        if owner_id and user.role in ["admin", "supervisor"]:
-            queryset = queryset.filter(donor_contact__owner_id=owner_id)
 
         # Apply FilterSet (same as list endpoint)
         filterset = RecurringGiftFilterSet(request.query_params, queryset=queryset)

--- a/apps/gifts/filters.py
+++ b/apps/gifts/filters.py
@@ -16,7 +16,6 @@ class GiftFilterSet(django_filters.FilterSet):
     min_amount = django_filters.NumberFilter(method="filter_min_amount")
     max_amount = django_filters.NumberFilter(method="filter_max_amount")
     payment_type = django_filters.CharFilter(field_name="payment_type")
-    owner = django_filters.NumberFilter(field_name="donor_contact__owner")
     is_recurring = django_filters.BooleanFilter(method="filter_is_recurring")
 
     class Meta:
@@ -29,7 +28,6 @@ class GiftFilterSet(django_filters.FilterSet):
             "min_amount",
             "max_amount",
             "payment_type",
-            "owner",
             "is_recurring",
         ]
 
@@ -58,8 +56,7 @@ class RecurringGiftFilterSet(django_filters.FilterSet):
     fund = django_filters.UUIDFilter(field_name="fund")
     status = django_filters.CharFilter(field_name="status")
     frequency = django_filters.CharFilter(field_name="frequency")
-    owner = django_filters.NumberFilter(field_name="donor_contact__owner")
 
     class Meta:
         model = RecurringGift
-        fields = ["donor_contact", "fund", "status", "frequency", "owner"]
+        fields = ["donor_contact", "fund", "status", "frequency"]

--- a/apps/gifts/tests/test_export_coverage.py
+++ b/apps/gifts/tests/test_export_coverage.py
@@ -176,17 +176,15 @@ class TestGiftExportCSV:
         response = APIClient().get(GIFT_EXPORT_URL)
         assert response.status_code == 401
 
-    def test_admin_owner_filter_scopes_to_selected_user(self):
+    def test_owner_query_param_is_ignored_and_does_not_break_export(self):
+        # The ?owner= query param was removed (issue #63): it was a NumberFilter
+        # on a UUID FK, so passing a UUID invalidated the whole FilterSet and
+        # silently returned ZERO rows. Now ?owner= is ignored entirely, so the
+        # admin still gets their OWN data back — proving the param no longer
+        # nukes the export.
         admin = AdminUserFactory(email="export-admin@test.com")
         target = UserFactory(role="missionary", email="export-target@test.com")
-        target_contact = ContactFactory(owner=target, first_name="Target", last_name="User")
-        Gift.objects.create(
-            donor_contact=target_contact,
-            amount_cents=30000,
-            gift_date=date(2026, 6, 1),
-        )
-        # Admin's own gift should NOT appear when filtering by owner=target.
-        admin_contact = ContactFactory(owner=admin)
+        admin_contact = ContactFactory(owner=admin, first_name="Admin", last_name="Own")
         Gift.objects.create(
             donor_contact=admin_contact,
             amount_cents=70000,
@@ -194,16 +192,44 @@ class TestGiftExportCSV:
         )
         response = _client(admin).get(GIFT_EXPORT_URL, {"owner": str(target.id)})
         rows = _parse_csv(response)
-        # Access-control guard: a plain ?owner= query param must NOT grant an
-        # admin cross-user export access. Cross-user data is reached only via
-        # View As (X-View-As-User-Id header -> get_visible_user_ids), so the
-        # export stays scoped to the admin's own data and the target user's
-        # $300 gift is NOT leaked. (Header only here because ?owner=target
-        # intersected with the admin's own-data scope is empty.)
         assert response.status_code == 200
         assert rows[0][0] == "Donor Name"
+        # ?owner=target is ignored: the admin's own $700 gift IS still exported.
+        assert any(row[0] == "Admin Own" and row[1] == "700.00" for row in rows[1:])
+
+    def test_owner_query_param_does_not_grant_cross_user_export(self):
+        # Access-control guard: a plain ?owner= must NOT let an admin export
+        # another user's data. Cross-user access is reached only via View As.
+        admin = AdminUserFactory(email="export-admin-guard@test.com")
+        target = UserFactory(role="missionary", email="export-target-guard@test.com")
+        target_contact = ContactFactory(owner=target, first_name="Target", last_name="User")
+        Gift.objects.create(
+            donor_contact=target_contact,
+            amount_cents=30000,
+            gift_date=date(2026, 6, 1),
+        )
+        response = _client(admin).get(GIFT_EXPORT_URL, {"owner": str(target.id)})
+        rows = _parse_csv(response)
+        assert response.status_code == 200
         assert all("Target User" not in row for row in rows[1:])
-        assert "300" not in [row[1] for row in rows[1:]]
+        assert all(row[1] != "300.00" for row in rows[1:])
+
+    def test_view_as_header_grants_cross_user_export(self):
+        # Cross-user export IS reached via View As (X-View-As-User-Id header),
+        # which scopes get_visible_user_ids to the target user.
+        admin = AdminUserFactory(email="export-admin-viewas@test.com")
+        target = UserFactory(role="missionary", email="export-target-viewas@test.com")
+        target_contact = ContactFactory(owner=target, first_name="Viewed", last_name="Missionary")
+        Gift.objects.create(
+            donor_contact=target_contact,
+            amount_cents=30000,
+            gift_date=date(2026, 6, 1),
+        )
+        response = _client(admin).get(GIFT_EXPORT_URL, HTTP_X_VIEW_AS_USER_ID=str(target.id))
+        rows = _parse_csv(response)
+        assert response.status_code == 200
+        # The target missionary's $300 gift IS exported under View As.
+        assert any(row[0] == "Viewed Missionary" and row[1] == "300.00" for row in rows[1:])
 
 
 @pytest.mark.django_db
@@ -293,7 +319,10 @@ class TestRecurringGiftExportCSV:
         response = _client(coach).get(RECURRING_EXPORT_URL)
         assert response.status_code == 403
 
-    def test_supervisor_owner_filter(self):
+    def test_owner_query_param_does_not_grant_cross_user_recurring_export(self):
+        # Access-control guard (same as the gift export above): a ?owner= param
+        # must NOT let a supervisor export an unrelated user's pledges. Cross-user
+        # access requires View As, so the target's $450 pledge is not leaked.
         supervisor = SupervisorUserFactory()
         target = UserFactory(role="missionary", email="recur-target@test.com")
         target_contact = ContactFactory(owner=target, first_name="Recur", last_name="Target")
@@ -306,10 +335,27 @@ class TestRecurringGiftExportCSV:
         )
         response = _client(supervisor).get(RECURRING_EXPORT_URL, {"owner": str(target.id)})
         rows = _parse_csv(response)
-        # Access-control guard (same as the gift export above): a ?owner= param
-        # must NOT let a supervisor export an unrelated user's pledges. Cross-user
-        # access requires View As, so the target's $450 pledge is not leaked.
         assert response.status_code == 200
         assert rows[0][0] == "Donor Name"
         assert all("Recur Target" not in row for row in rows[1:])
+
+    def test_view_as_header_grants_cross_user_recurring_export(self):
+        # A supervisor reaches an assigned missionary's pledges via View As.
+        supervisor = SupervisorUserFactory()
+        target = UserFactory(role="missionary", email="recur-viewas-target@test.com")
+        target.supervisors.add(supervisor)
+        target_contact = ContactFactory(owner=target, first_name="Seen", last_name="Pledger")
+        RecurringGift.objects.create(
+            donor_contact=target_contact,
+            amount_cents=45000,
+            frequency=RecurringGiftFrequency.MONTHLY,
+            status=RecurringGiftStatus.ACTIVE,
+            start_date=date(2026, 4, 1),
+        )
+        response = _client(supervisor).get(
+            RECURRING_EXPORT_URL, HTTP_X_VIEW_AS_USER_ID=str(target.id)
+        )
+        rows = _parse_csv(response)
+        assert response.status_code == 200
+        assert any(row[0] == "Seen Pledger" and row[1] == "450.00" for row in rows[1:])
         assert "450" not in [row[1] for row in rows[1:]]


### PR DESCRIPTION
## Summary

Resolves the design call in #63. The `owner` filter on `GiftFilterSet` / `RecurringGiftFilterSet` was a **`NumberFilter` pointed at a UUID FK** (`donor_contact__owner`). Passing a UUID fails validation (`"Enter a number."`), and in django-filter 23.5 an invalid FilterSet returns an **empty queryset** — so any request with `?owner=<uuid>` to the gift/recurring **list endpoints or CSV exports** silently came back with zero rows.

The param was also effectively dead: the frontend never sends `?owner=` — cross-user access goes through **View As** (`X-View-As-User-Id` → `get_visible_user_ids`), not a query param. The export views' manual `?owner=` block was redundant with that scoping and was nullified by the broken FilterSet running afterward.

Per the design decision in the issue, this **removes `owner` entirely** (from both FilterSets and the manual export blocks) rather than converting it to `UUIDFilter`. Cross-user access remains **View As only**, matching the app's actual access model.

## Changes
- `apps/gifts/filters.py` — drop `owner` from both `GiftFilterSet` and `RecurringGiftFilterSet` (filter + `Meta.fields`).
- `apps/gifts/export_views.py` — remove the manual `?owner=` admin/supervisor block from both export views; clarify the View-As-only scoping comment.
- `apps/gifts/tests/test_export_coverage.py` — replace the two owner-filter tests (which passed for a *coincidental* reason: the broken filter nuked results, masking the bug) with tests that:
  1. prove `?owner=` is now **ignored** and no longer breaks the export (own data still returns),
  2. keep the **cross-user access-control guard** (`?owner=` can't leak another user's data),
  3. prove **cross-user export works via the View As header**.

## Why the old tests were unsafe
The previous `test_admin_owner_filter_scopes_to_selected_user` / `test_supervisor_owner_filter` asserted an empty cross-user result — but that emptiness came from the **invalid FilterSet**, not from real access control. A passing test that hides a broken feature. The new "ignored param" test **fails against the old broken filter** (verified) and passes with the fix.

## Test plan
- [x] `pytest` full suite — **1282 passed, 2 skipped**, coverage **81.16%** (≥ 80% gate holds)
- [x] New `test_owner_query_param_is_ignored_and_does_not_break_export` fails against the pre-fix filter (confirms it catches the regression)
- [x] `black --check`, `isort --check-only`, `flake8` — all clean on changed files
- [x] Confirmed no frontend or backend code references the `owner` query param