### PR TITLE
fix(security): patch dependency CVEs and clear the bandit gate

### DIFF
--- a/apps/contacts/admin.py
+++ b/apps/contacts/admin.py
@@ -1,6 +1,7 @@
 """
 Admin configuration for Contact model.
 """
+
 from django.contrib import admin
 
 from apps.contacts.models import Contact

--- a/apps/contacts/export_views.py
+++ b/apps/contacts/export_views.py
@@ -1,6 +1,7 @@
 """
 CSV export view for contacts with FilterSet-based filtering.
 """
+
 import csv
 from datetime import datetime
 

--- a/apps/contacts/filters.py
+++ b/apps/contacts/filters.py
@@ -1,6 +1,7 @@
 """
 FilterSet for Contact list filtering.
 """
+
 import django_filters
 
 from apps.contacts.models import Contact

--- a/apps/contacts/models.py
+++ b/apps/contacts/models.py
@@ -1,6 +1,7 @@
 """
 Contact model for donor and prospect management.
 """
+
 from decimal import Decimal
 
 from django.conf import settings

--- a/apps/contacts/serializers.py
+++ b/apps/contacts/serializers.py
@@ -1,6 +1,7 @@
 """
 Serializers for Contact model.
 """
+
 from rest_framework import serializers
 
 from apps.contacts.models import Contact

--- a/apps/contacts/services.py
+++ b/apps/contacts/services.py
@@ -5,6 +5,7 @@ Provides:
 - find_duplicates_for_contact: Find potential duplicates for a given contact's data
 - merge_contacts: Atomically merge two contacts (reassign FKs, union groups, soft-delete loser)
 """
+
 from collections import OrderedDict
 
 from django.db import OperationalError, models, transaction

--- a/apps/contacts/tasks.py
+++ b/apps/contacts/tasks.py
@@ -1,6 +1,7 @@
 """
 Celery tasks for contact management.
 """
+
 import logging
 
 from celery import shared_task

--- a/apps/contacts/tests/factories.py
+++ b/apps/contacts/tests/factories.py
@@ -1,6 +1,7 @@
 """
 Factories for Contact model tests.
 """
+
 import factory
 from faker import Faker
 

--- a/apps/contacts/tests/test_contact_journals.py
+++ b/apps/contacts/tests/test_contact_journals.py
@@ -7,6 +7,7 @@ Tests verify:
 - Query optimization prevents N+1 queries
 - Ownership validation
 """
+
 import datetime
 from decimal import Decimal
 

--- a/apps/contacts/tests/test_duplicate_api.py
+++ b/apps/contacts/tests/test_duplicate_api.py
@@ -4,6 +4,7 @@ API integration tests for duplicate detection and merge endpoints.
 Tests mock TrigramSimilarity-dependent service functions for SQLite compatibility
 while still testing the full HTTP request/response cycle.
 """
+
 import uuid
 from unittest.mock import patch
 

--- a/apps/contacts/tests/test_duplicate_detection.py
+++ b/apps/contacts/tests/test_duplicate_detection.py
@@ -3,6 +3,7 @@ Tests for duplicate contact detection functionality.
 SQLite-compatible -- TrigramSimilarity is mocked where needed since pg_trgm
 functions do not work on SQLite.
 """
+
 import pytest
 
 from apps.contacts.models import DismissedDuplicate

--- a/apps/contacts/tests/test_integration.py
+++ b/apps/contacts/tests/test_integration.py
@@ -1,6 +1,7 @@
 """
 Integration tests for the complete donor workflow.
 """
+
 from decimal import Decimal
 
 from django.utils import timezone

--- a/apps/contacts/tests/test_merge.py
+++ b/apps/contacts/tests/test_merge.py
@@ -2,6 +2,7 @@
 Tests for contact merge functionality.
 All tests are SQLite-safe (no pg_trgm usage).
 """
+
 from datetime import date
 
 import pytest

--- a/apps/contacts/tests/test_models.py
+++ b/apps/contacts/tests/test_models.py
@@ -1,6 +1,7 @@
 """
 Tests for Contact model methods.
 """
+
 from decimal import Decimal
 
 import pytest

--- a/apps/contacts/tests/test_org_contact_mapping.py
+++ b/apps/contacts/tests/test_org_contact_mapping.py
@@ -12,6 +12,7 @@ They specify all behaviors that Wave 1 tasks must implement:
 6. GET /contacts/search/?q=<org> finds org contacts (search Q filter)
 7. CSV export Name column shows organization_name for org contacts
 """
+
 from rest_framework.test import APIClient
 
 import pytest

--- a/apps/contacts/tests/test_serializers_coverage.py
+++ b/apps/contacts/tests/test_serializers_coverage.py
@@ -7,6 +7,7 @@ ContactJournalMembershipSerializer fallback branches (current_stage and
 decision computed without prefetch). Tests assert real persisted state and
 owner-scoped group visibility so they fail when the serializer logic breaks.
 """
+
 from rest_framework.test import APIClient
 
 import pytest

--- a/apps/contacts/tests/test_services_coverage.py
+++ b/apps/contacts/tests/test_services_coverage.py
@@ -10,6 +10,7 @@ owns a decision and the loser's is deleted.
 These run on SQLite; the PostgreSQL TrigramSimilarity name-matching path is
 skipped via ImportError in the service and is not exercised here.
 """
+
 import pytest
 
 from apps.contacts.services import find_duplicates_for_contact, merge_contacts

--- a/apps/contacts/tests/test_views_coverage.py
+++ b/apps/contacts/tests/test_views_coverage.py
@@ -8,6 +8,7 @@ merge/dismiss permission and validation branches. Each test asserts real
 DRF status codes, payload values, and owner-scoping so it fails when the
 underlying feature breaks.
 """
+
 import uuid
 from datetime import date, timedelta
 

--- a/apps/contacts/urls.py
+++ b/apps/contacts/urls.py
@@ -1,6 +1,7 @@
 """
 URL patterns for contacts endpoints.
 """
+
 from django.urls import path
 
 from apps.contacts.export_views import ContactExportCSVView

--- a/apps/contacts/views.py
+++ b/apps/contacts/views.py
@@ -1,6 +1,7 @@
 """
 Views for Contact management.
 """
+
 from django.db.models import Prefetch, Q
 
 from rest_framework import filters, generics, permissions, status

--- a/apps/core/access_log_middleware.py
+++ b/apps/core/access_log_middleware.py
@@ -19,6 +19,7 @@ Design choices
 - **No request body inspection.** The path + method are enough; reading
   request bodies would risk ingesting PII into the audit log itself.
 """
+
 from __future__ import annotations
 
 import logging

--- a/apps/core/audit.py
+++ b/apps/core/audit.py
@@ -19,6 +19,7 @@ Usage::
         ip=request.META.get("REMOTE_ADDR"),
     )
 """
+
 from __future__ import annotations
 
 import logging

--- a/apps/core/blind_index.py
+++ b/apps/core/blind_index.py
@@ -38,6 +38,7 @@ Rotation procedure:
      new key.
   4. Remove the old key from the env var, redeploy.
 """
+
 from __future__ import annotations
 
 import base64

--- a/apps/core/db_tls_check.py
+++ b/apps/core/db_tls_check.py
@@ -13,6 +13,7 @@ Failures behavior:
 Logged via ``apps.core.audit.audit_event`` so the result is grep-able next to
 auth and crypto events.
 """
+
 from __future__ import annotations
 
 from typing import Optional

--- a/apps/core/email.py
+++ b/apps/core/email.py
@@ -1,6 +1,7 @@
 """
 Email service for DonorCRM notifications.
 """
+
 import logging
 from typing import Optional
 

--- a/apps/core/encryption.py
+++ b/apps/core/encryption.py
@@ -40,6 +40,7 @@ Threat model
   hold the keys). For that, KMS-backed envelope encryption is required —
   tracked as Phase 5 in ``docs/security/encryption-rollout.md``.
 """
+
 from __future__ import annotations
 
 import base64

--- a/apps/core/encryption_registry.py
+++ b/apps/core/encryption_registry.py
@@ -4,6 +4,7 @@ Drives ``rotate_pii_encryption --all`` so a single command re-encrypts every
 PII column under the current write key. Add a tuple here whenever a field is
 migrated to ``EncryptedTextField``.
 """
+
 from __future__ import annotations
 
 from typing import List, Tuple

--- a/apps/core/exceptions.py
+++ b/apps/core/exceptions.py
@@ -1,6 +1,7 @@
 """
 Custom exceptions for DonorCRM.
 """
+
 import logging
 
 from django.core.exceptions import ValidationError as DjangoValidationError

--- a/apps/core/fiscal_year.py
+++ b/apps/core/fiscal_year.py
@@ -8,6 +8,7 @@ but going through Django's timezone helper means the math stays correct if
 TIME_ZONE is ever switched to a US zone (where the FY boundary at midnight
 local time would otherwise be off by one day around June 1 / May 31).
 """
+
 from datetime import date
 
 from django.utils import timezone

--- a/apps/core/gift_utils.py
+++ b/apps/core/gift_utils.py
@@ -3,6 +3,7 @@ Shared gift aggregation utilities for DonorCRM.
 Provides frequency multipliers and SQL aggregation helpers used by
 dashboard services and goal services.
 """
+
 from decimal import Decimal
 
 from django.db.models import Case, DecimalField, F, Sum, Value, When

--- a/apps/core/late_donations.py
+++ b/apps/core/late_donations.py
@@ -7,6 +7,7 @@ than the expected interval for the gift's frequency, with a 50% grace period.
 
 Grace period is intentionally hardcoded (locked 2026-05-01).
 """
+
 from datetime import timedelta
 
 from django.utils import timezone

--- a/apps/core/management/commands/generate_sample_data.py
+++ b/apps/core/management/commands/generate_sample_data.py
@@ -1,6 +1,7 @@
 """
 Management command to generate sample data for testing.
 """
+
 import random
 from datetime import timedelta
 
@@ -270,9 +271,11 @@ class Command(BaseCommand):
                 title=f"{template[0]} - {contact.full_name}",
                 task_type=template[1],
                 priority=template[2],
-                status=TaskStatus.PENDING
-                if due_offset >= 0
-                else random.choice([TaskStatus.PENDING, TaskStatus.IN_PROGRESS]),
+                status=(
+                    TaskStatus.PENDING
+                    if due_offset >= 0
+                    else random.choice([TaskStatus.PENDING, TaskStatus.IN_PROGRESS])
+                ),
                 due_date=today + timedelta(days=due_offset),
                 description=fake.sentence() if random.random() > 0.5 else "",
             )

--- a/apps/core/management/commands/purge_expired_data.py
+++ b/apps/core/management/commands/purge_expired_data.py
@@ -6,6 +6,7 @@ every deletion class with counts via ``apps.core.audit.audit_event``.
 
 Defaults are conservative — pass ``--dry-run`` to count without deleting.
 """
+
 from __future__ import annotations
 
 from datetime import timedelta

--- a/apps/core/management/commands/reset_missionaries.py
+++ b/apps/core/management/commands/reset_missionaries.py
@@ -2,6 +2,7 @@
 Management command to wipe all data, remove non-kept users,
 and create fresh missionary accounts from test_solicitors.csv.
 """
+
 import os
 
 from django.core.management.base import BaseCommand
@@ -177,7 +178,12 @@ class Command(BaseCommand):
         with connection.cursor() as cursor:
             for table in allowed_tables:
                 if table in existing_tables:
-                    cursor.execute("DELETE FROM %s" % connection.ops.quote_name(table))
+                    # nosec B608: `table` is from the hardcoded allowed_tables
+                    # tuple above (not user input) and passed through
+                    # connection.ops.quote_name(); no injection vector.
+                    cursor.execute(
+                        "DELETE FROM %s" % connection.ops.quote_name(table)  # nosec B608
+                    )
                     self.stdout.write(f"  Deleted legacy {table}: {cursor.rowcount}")
 
         # --- Contact (PROTECT from User — must delete before user) ---

--- a/apps/core/management/commands/rotate_pii_encryption.py
+++ b/apps/core/management/commands/rotate_pii_encryption.py
@@ -21,6 +21,7 @@ Usage
   python manage.py rotate_pii_encryption --all --batch-size 1000
   python manage.py rotate_pii_encryption --all --resume-from-id <uuid>
 """
+
 from __future__ import annotations
 
 from typing import Iterable, Tuple

--- a/apps/core/management/commands/set_missionary_goals.py
+++ b/apps/core/management/commands/set_missionary_goals.py
@@ -3,6 +3,7 @@
 One-shot command to update missionary goals so dashboard percentages
 show a natural distribution (67%–104% from recurring alone).
 """
+
 from django.core.management.base import BaseCommand
 
 from apps.users.models import User

--- a/apps/core/models.py
+++ b/apps/core/models.py
@@ -1,6 +1,7 @@
 """
 Base models for DonorCRM.
 """
+
 import uuid
 
 from django.conf import settings

--- a/apps/core/pagination.py
+++ b/apps/core/pagination.py
@@ -1,6 +1,7 @@
 """
 Custom pagination classes for DonorCRM API.
 """
+
 from rest_framework.pagination import PageNumberPagination
 
 

--- a/apps/core/permissions.py
+++ b/apps/core/permissions.py
@@ -10,6 +10,7 @@ Access Control Matrix:
 Owner scoping in views uses get_visible_user_ids() as the central choke point.
 Write operations are gated by IsStaffOrAbove (excludes coach from writes).
 """
+
 from rest_framework import permissions
 
 

--- a/apps/core/sentry_scrubbing.py
+++ b/apps/core/sentry_scrubbing.py
@@ -19,6 +19,7 @@ The patterns target obvious PII shapes:
 
 Tested by ``apps.core.tests.test_sentry_scrubbing``.
 """
+
 from __future__ import annotations
 
 import re

--- a/apps/core/support_math.py
+++ b/apps/core/support_math.py
@@ -19,6 +19,7 @@ Formula (single source of truth, agreed 2026-05-01):
 Callers pass a Q object describing how to filter Gift.donor_contact and
 RecurringGift.donor_contact (e.g. by owner=user, or by id__in=[...]).
 """
+
 from datetime import date
 from decimal import Decimal
 

--- a/apps/core/tests/raising_cache.py
+++ b/apps/core/tests/raising_cache.py
@@ -5,6 +5,7 @@ deleted Redis instance) deterministically, without depending on a real server
 or network timing. Point ``CACHES["default"]["BACKEND"]`` at this class via
 ``override_settings`` to reproduce the production failure mode.
 """
+
 from django.core.cache.backends.base import BaseCache
 
 

--- a/apps/core/tests/test_access_log.py
+++ b/apps/core/tests/test_access_log.py
@@ -3,6 +3,7 @@
 Verifies the path-pattern classifier, that PII reads are recorded with
 the right resource_type / resource_id, and that non-PII paths are skipped.
 """
+
 from __future__ import annotations
 
 from django.urls import reverse

--- a/apps/core/tests/test_blind_index.py
+++ b/apps/core/tests/test_blind_index.py
@@ -1,4 +1,5 @@
 """Tests for apps.core.blind_index — HMAC-SHA256 blind-index for equality."""
+
 from __future__ import annotations
 
 import base64

--- a/apps/core/tests/test_db_tls_check.py
+++ b/apps/core/tests/test_db_tls_check.py
@@ -3,6 +3,7 @@
 Limited to backends-agnostic behavior because the test DB is SQLite. The
 Postgres TLS query is exercised in production by ``CoreConfig.ready()``.
 """
+
 from __future__ import annotations
 
 from unittest import mock

--- a/apps/core/tests/test_email_coverage.py
+++ b/apps/core/tests/test_email_coverage.py
@@ -4,6 +4,7 @@ Behavioral tests for apps.core.email send helpers.
 The test settings use the locmem email backend, so real sends land in
 django.core.mail.outbox. Failure paths are exercised with unittest.mock.
 """
+
 from unittest import mock
 
 from django.core import mail

--- a/apps/core/tests/test_encryption.py
+++ b/apps/core/tests/test_encryption.py
@@ -8,6 +8,7 @@ Covers:
   * key rotation (aes256 → aes256, and Fernet → aes256 upgrade)
   * EncryptedTextField behavior + ORM round-trip
 """
+
 from __future__ import annotations
 
 import base64

--- a/apps/core/tests/test_fiscal_year.py
+++ b/apps/core/tests/test_fiscal_year.py
@@ -6,6 +6,7 @@ FISC-02: months_remaining returns months from current month to end of fiscal yea
 Imports are deferred inside each test so pytest can collect all items even before
 apps/core/fiscal_year.py exists. Tests fail at runtime with ImportError (correct RED state).
 """
+
 from datetime import date
 
 # FISC-01: fiscal_year_start boundary cases

--- a/apps/core/tests/test_middleware.py
+++ b/apps/core/tests/test_middleware.py
@@ -11,6 +11,7 @@ Test coverage:
   - VIEWAS-07: Mutation blocking (POST/PUT/PATCH/DELETE blocked when header present)
   - VIEWAS-08: Permission validation (only admin/supervisor can use header; target must be valid)
 """
+
 from rest_framework.test import APIClient
 
 import pytest

--- a/apps/core/tests/test_middleware_coverage.py
+++ b/apps/core/tests/test_middleware_coverage.py
@@ -10,6 +10,7 @@ exercise the production paths the middleware was built for:
 SECURITY-RELEVANT: confirms only admin/supervisor can activate View As and that
 a forged/invalid bearer cannot.
 """
+
 from types import SimpleNamespace
 from unittest import mock
 

--- a/apps/core/tests/test_permissions.py
+++ b/apps/core/tests/test_permissions.py
@@ -8,6 +8,7 @@ Verifies that:
   - missionary sees only own data (returns {missionary.id})
   - View As override scopes to target user
 """
+
 import pytest
 
 from apps.users.tests.factories import (

--- a/apps/core/tests/test_rotate_pii_encryption.py
+++ b/apps/core/tests/test_rotate_pii_encryption.py
@@ -9,6 +9,7 @@ Covers the realistic scenarios:
   * ``--resume-from-id`` skips ahead.
   * Unknown app/model/field is a CommandError.
 """
+
 from __future__ import annotations
 
 from io import StringIO
@@ -86,8 +87,10 @@ class TestRotatePiiEncryption:
         from apps.contacts.models import Contact
 
         with connection.cursor() as cur:
+            # nosec B608: db_table is Django-internal metadata (not user input);
+            # values are bound via %s placeholders. Test helper only.
             cur.execute(
-                f'UPDATE "{Contact._meta.db_table}" SET notes = %s WHERE id = %s',
+                f'UPDATE "{Contact._meta.db_table}" SET notes = %s WHERE id = %s',  # nosec B608
                 [value, self._pk_param(pk)],
             )
 
@@ -97,8 +100,10 @@ class TestRotatePiiEncryption:
         from apps.contacts.models import Contact
 
         with connection.cursor() as cur:
+            # nosec B608: db_table is Django-internal metadata (not user input);
+            # the id is bound via a %s placeholder. Test helper only.
             cur.execute(
-                f'SELECT notes FROM "{Contact._meta.db_table}" WHERE id = %s',
+                f'SELECT notes FROM "{Contact._meta.db_table}" WHERE id = %s',  # nosec B608
                 [self._pk_param(pk)],
             )
             row = cur.fetchone()

--- a/apps/core/tests/test_sentry_scrubbing.py
+++ b/apps/core/tests/test_sentry_scrubbing.py
@@ -1,4 +1,5 @@
 """Tests for apps.core.sentry_scrubbing — PII scrubbing in Sentry payloads."""
+
 from __future__ import annotations
 
 from apps.core import sentry_scrubbing

--- a/apps/core/tests/test_throttling.py
+++ b/apps/core/tests/test_throttling.py
@@ -4,6 +4,7 @@ These verify that a cache outage degrades rate limiting to "allow" instead of
 turning throttled endpoints into 500s, while normal throttling still works when
 the cache is healthy.
 """
+
 from unittest.mock import Mock
 
 from django.contrib.auth.models import AnonymousUser

--- a/apps/core/tests/test_uploads_coverage.py
+++ b/apps/core/tests/test_uploads_coverage.py
@@ -4,6 +4,7 @@ Behavioral tests for apps.core.uploads.detect_upload_kind.
 These cover magic-byte detection (XLSX/XLS), the permissive CSV heuristic,
 the filename-assisted single-column CSV path, and the UNKNOWN fallbacks.
 """
+
 from apps.core.uploads import UploadKind, detect_upload_kind
 
 

--- a/apps/core/tests/test_validators.py
+++ b/apps/core/tests/test_validators.py
@@ -1,6 +1,7 @@
 """
 Tests for custom password validators.
 """
+
 from django.core.exceptions import ValidationError
 from django.test import TestCase
 

--- a/apps/core/throttling.py
+++ b/apps/core/throttling.py
@@ -15,6 +15,7 @@ backend errors out we log it and allow the request rather than failing the
 whole endpoint. This is the standard "fail open" posture for rate limiting:
 a degraded limiter is preferable to a hard outage.
 """
+
 import logging
 
 from django.core.exceptions import ImproperlyConfigured

--- a/apps/core/uploads.py
+++ b/apps/core/uploads.py
@@ -13,6 +13,7 @@ Usage
     if kind not in (UploadKind.CSV, UploadKind.XLSX):
         return Response({"detail": "Unsupported file type."}, status=400)
 """
+
 from __future__ import annotations
 
 from enum import Enum

--- a/apps/core/validators.py
+++ b/apps/core/validators.py
@@ -1,6 +1,7 @@
 """
 Custom password validators for DonorCRM.
 """
+
 import re
 
 from django.core.exceptions import ValidationError

--- a/apps/dashboard/services.py
+++ b/apps/dashboard/services.py
@@ -1,6 +1,7 @@
 """
 Service functions for dashboard aggregations.
 """
+
 import logging
 from datetime import date, timedelta
 from decimal import Decimal
@@ -237,9 +238,9 @@ def get_giving_summary(user, as_of_date=None):
         "expecting": expecting,
         "total": given_float + expecting,
         "recurring_pledges_annual": float(annualized_recurring),
-        "recurring_pledges_monthly": float(annualized_recurring / 12)
-        if annualized_recurring
-        else 0,
+        "recurring_pledges_monthly": (
+            float(annualized_recurring / 12) if annualized_recurring else 0
+        ),
         "annual_goal": annual_goal,
         "monthly_goal": monthly_goal,
         "percentage": ((given_float + expecting) / annual_goal * 100) if annual_goal > 0 else 0,

--- a/apps/dashboard/tasks.py
+++ b/apps/dashboard/tasks.py
@@ -1,6 +1,7 @@
 """
 Celery tasks for dashboard/reporting.
 """
+
 import logging
 
 from celery import shared_task

--- a/apps/dashboard/tests/test_services.py
+++ b/apps/dashboard/tests/test_services.py
@@ -1,6 +1,7 @@
 """
 Tests for dashboard service functions.
 """
+
 from datetime import date, timedelta
 from decimal import Decimal
 

--- a/apps/dashboard/tests/test_views.py
+++ b/apps/dashboard/tests/test_views.py
@@ -1,6 +1,7 @@
 """
 Tests for Dashboard API views.
 """
+
 from rest_framework import status
 from rest_framework.test import APIClient
 

--- a/apps/dashboard/tests/test_views_coverage.py
+++ b/apps/dashboard/tests/test_views_coverage.py
@@ -6,6 +6,7 @@ selecting another user, missionary denial, invalid/missing user_id), the
 mark-seen endpoint, the per-user layout endpoint, and JSON payload values
 for the giving/monthly/recent-gift tiles (dollars derived from cents).
 """
+
 import uuid
 from datetime import date
 

--- a/apps/dashboard/urls.py
+++ b/apps/dashboard/urls.py
@@ -1,6 +1,7 @@
 """
 URL patterns for dashboard endpoints.
 """
+
 from django.urls import path
 
 from apps.dashboard.views import (

--- a/apps/dashboard/views.py
+++ b/apps/dashboard/views.py
@@ -1,6 +1,7 @@
 """
 Views for Dashboard data.
 """
+
 import uuid
 
 from rest_framework import permissions

--- a/apps/events/admin.py
+++ b/apps/events/admin.py
@@ -1,6 +1,7 @@
 """
 Admin configuration for Event model.
 """
+
 from django.contrib import admin
 
 from apps.events.models import Event

--- a/apps/events/models.py
+++ b/apps/events/models.py
@@ -1,6 +1,7 @@
 """
 Event model for audit trail and notifications.
 """
+
 from django.conf import settings
 from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType

--- a/apps/events/serializers.py
+++ b/apps/events/serializers.py
@@ -1,6 +1,7 @@
 """
 Serializers for Event model.
 """
+
 from rest_framework import serializers
 
 from apps.events.models import Event

--- a/apps/events/services.py
+++ b/apps/events/services.py
@@ -1,6 +1,7 @@
 """
 Service functions for events.
 """
+
 from apps.events.models import Event
 
 

--- a/apps/events/tests/factories.py
+++ b/apps/events/tests/factories.py
@@ -1,6 +1,7 @@
 """
 Factories for Event model tests.
 """
+
 import factory
 from faker import Faker
 

--- a/apps/events/tests/test_models.py
+++ b/apps/events/tests/test_models.py
@@ -1,6 +1,7 @@
 """
 Tests for Event model.
 """
+
 import pytest
 
 from apps.events.models import Event, EventSeverity, EventType

--- a/apps/events/tests/test_views.py
+++ b/apps/events/tests/test_views.py
@@ -1,6 +1,7 @@
 """
 Tests for Event API views.
 """
+
 from rest_framework import status
 from rest_framework.test import APIClient
 

--- a/apps/events/urls.py
+++ b/apps/events/urls.py
@@ -1,6 +1,7 @@
 """
 URL patterns for events endpoints.
 """
+
 from django.urls import path
 
 from apps.events.views import (

--- a/apps/events/views.py
+++ b/apps/events/views.py
@@ -1,6 +1,7 @@
 """
 Views for Event management.
 """
+
 from django.db import models
 from django.db.models import Count
 

--- a/apps/feedback/admin.py
+++ b/apps/feedback/admin.py
@@ -2,6 +2,7 @@
 Admin registration for FeedbackEntry — secondary surface alongside the
 React /admin/feedback page. Feedback may contain PII; admin role only.
 """
+
 from django.contrib import admin
 
 from apps.feedback.models import FeedbackEntry

--- a/apps/feedback/apps.py
+++ b/apps/feedback/apps.py
@@ -1,6 +1,7 @@
 """
 App configuration for feedback submissions.
 """
+
 from django.apps import AppConfig
 
 

--- a/apps/feedback/filters.py
+++ b/apps/feedback/filters.py
@@ -1,6 +1,7 @@
 """
 Filters for FeedbackEntry list view.
 """
+
 import django_filters
 
 from apps.feedback.models import FeedbackEntry

--- a/apps/feedback/models.py
+++ b/apps/feedback/models.py
@@ -1,6 +1,7 @@
 """
 Models for user-submitted feedback (bug reports, feature requests, etc.).
 """
+
 from django.conf import settings
 from django.db import models
 

--- a/apps/feedback/permissions.py
+++ b/apps/feedback/permissions.py
@@ -1,6 +1,7 @@
 """
 Custom permission classes for feedback endpoints.
 """
+
 from rest_framework import permissions
 
 

--- a/apps/feedback/serializers.py
+++ b/apps/feedback/serializers.py
@@ -7,6 +7,7 @@ Two serializers separate concerns:
 - FeedbackEntrySerializer: admin read/update view. All fields read-only
   except status.
 """
+
 from rest_framework import serializers
 
 from apps.feedback.models import FeedbackEntry

--- a/apps/feedback/tests/test_models.py
+++ b/apps/feedback/tests/test_models.py
@@ -1,6 +1,7 @@
 """
 Tests for FeedbackEntry model.
 """
+
 import pytest
 
 from apps.feedback.models import FeedbackEntry, FeedbackStatus, FeedbackType

--- a/apps/feedback/tests/test_serializers.py
+++ b/apps/feedback/tests/test_serializers.py
@@ -1,6 +1,7 @@
 """
 Tests for FeedbackEntry serializers.
 """
+
 import pytest
 
 from apps.feedback.models import FeedbackEntry, FeedbackType

--- a/apps/feedback/tests/test_views.py
+++ b/apps/feedback/tests/test_views.py
@@ -1,6 +1,7 @@
 """
 Tests for feedback API views.
 """
+
 from rest_framework import status
 from rest_framework.test import APIClient
 

--- a/apps/feedback/urls.py
+++ b/apps/feedback/urls.py
@@ -1,6 +1,7 @@
 """
 URL patterns for feedback endpoints.
 """
+
 from django.urls import path
 
 from apps.feedback.views import FeedbackDetailView, FeedbackListCreateView

--- a/apps/feedback/views.py
+++ b/apps/feedback/views.py
@@ -1,6 +1,7 @@
 """
 Views for feedback API endpoints.
 """
+
 from rest_framework import generics
 from rest_framework.filters import OrderingFilter, SearchFilter
 

--- a/apps/gifts/admin.py
+++ b/apps/gifts/admin.py
@@ -1,6 +1,7 @@
 """
 Admin configuration for gift tracking models.
 """
+
 from django.contrib import admin
 
 from apps.gifts.models import Gift, GiftCredit, RecurringGift, RecurringGiftCredit, Solicitor

--- a/apps/gifts/apps.py
+++ b/apps/gifts/apps.py
@@ -1,6 +1,7 @@
 """
 App configuration for the gifts app.
 """
+
 from django.apps import AppConfig
 
 

--- a/apps/gifts/export_views.py
+++ b/apps/gifts/export_views.py
@@ -1,6 +1,7 @@
 """
 CSV export views for Gift and RecurringGift with FilterSet-based filtering.
 """
+
 import csv
 from datetime import datetime
 

--- a/apps/gifts/export_views.py
+++ b/apps/gifts/export_views.py
@@ -36,14 +36,11 @@ class GiftExportCSVView(APIView):
 
         user = request.user
 
-        # Same owner-scoping as GiftListCreateView
+        # Same owner-scoping as GiftListCreateView. Cross-user access is
+        # reached only via View As (X-View-As-User-Id -> get_visible_user_ids),
+        # never a ?owner= query param.
         visible = get_visible_user_ids(user, request=request)
         queryset = Gift.objects.filter(donor_contact__owner_id__in=visible)
-
-        # Admin/supervisor owner filter
-        owner_id = request.query_params.get("owner")
-        if owner_id and user.role in ["admin", "supervisor"]:
-            queryset = queryset.filter(donor_contact__owner_id=owner_id)
 
         # Apply FilterSet (same as list endpoint)
         filterset = GiftFilterSet(request.query_params, queryset=queryset)
@@ -99,14 +96,11 @@ class RecurringGiftExportCSVView(APIView):
 
         user = request.user
 
-        # Same owner-scoping as RecurringGiftListCreateView
+        # Same owner-scoping as RecurringGiftListCreateView. Cross-user access
+        # is reached only via View As (X-View-As-User-Id -> get_visible_user_ids),
+        # never a ?owner= query param.
         visible = get_visible_user_ids(user, request=request)
         queryset = RecurringGift.objects.filter(donor_contact__owner_id__in=visible)
-
-        # Admin/supervisor owner filter
-        owner_id = request.query_params.get("owner")
-        if owner_id and user.role in ["admin", "supervisor"]:
-            queryset = queryset.filter(donor_contact__owner_id=owner_id)
 
         # Apply FilterSet (same as list endpoint)
         filterset = RecurringGiftFilterSet(request.query_params, queryset=queryset)

--- a/apps/gifts/filters.py
+++ b/apps/gifts/filters.py
@@ -1,6 +1,7 @@
 """
 Filters for Gift and RecurringGift models.
 """
+
 import django_filters
 
 from apps.gifts.models import Gift, RecurringGift

--- a/apps/gifts/filters.py
+++ b/apps/gifts/filters.py
@@ -16,7 +16,6 @@ class GiftFilterSet(django_filters.FilterSet):
     min_amount = django_filters.NumberFilter(method="filter_min_amount")
     max_amount = django_filters.NumberFilter(method="filter_max_amount")
     payment_type = django_filters.CharFilter(field_name="payment_type")
-    owner = django_filters.NumberFilter(field_name="donor_contact__owner")
     is_recurring = django_filters.BooleanFilter(method="filter_is_recurring")
 
     class Meta:
@@ -29,7 +28,6 @@ class GiftFilterSet(django_filters.FilterSet):
             "min_amount",
             "max_amount",
             "payment_type",
-            "owner",
             "is_recurring",
         ]
 
@@ -58,8 +56,7 @@ class RecurringGiftFilterSet(django_filters.FilterSet):
     fund = django_filters.UUIDFilter(field_name="fund")
     status = django_filters.CharFilter(field_name="status")
     frequency = django_filters.CharFilter(field_name="frequency")
-    owner = django_filters.NumberFilter(field_name="donor_contact__owner")
 
     class Meta:
         model = RecurringGift
-        fields = ["donor_contact", "fund", "status", "frequency", "owner"]
+        fields = ["donor_contact", "fund", "status", "frequency"]

--- a/apps/gifts/management/commands/generate_recurring_gift_payments.py
+++ b/apps/gifts/management/commands/generate_recurring_gift_payments.py
@@ -5,6 +5,7 @@ For each RecurringGift, generates a Gift record per payment period from
 start_date through min(end_date, today). Uses deterministic external_gift_id
 for idempotency.
 """
+
 from django.core.management.base import BaseCommand
 
 from apps.gifts.models import Gift, RecurringGift, RecurringGiftFrequency

--- a/apps/gifts/models.py
+++ b/apps/gifts/models.py
@@ -5,6 +5,7 @@ Provides Solicitor, Gift, GiftCredit, RecurringGift, and RecurringGiftCredit
 models to replace the existing Donation/Pledge system with cents-based amounts
 and multi-solicitor credit attribution.
 """
+
 from decimal import Decimal
 
 from django.db import models

--- a/apps/gifts/recurring_utils.py
+++ b/apps/gifts/recurring_utils.py
@@ -4,6 +4,7 @@ Utilities for generating Gift payment records from RecurringGift commitments.
 Provides date generation, external ID creation, and sync logic for keeping
 Gift records in sync with their source RecurringGift.
 """
+
 import logging
 from datetime import date
 

--- a/apps/gifts/serializers.py
+++ b/apps/gifts/serializers.py
@@ -1,6 +1,7 @@
 """
 Serializers for Gift and RecurringGift models.
 """
+
 from rest_framework import serializers
 
 from apps.gifts.models import Gift, GiftCredit, RecurringGift

--- a/apps/gifts/signals.py
+++ b/apps/gifts/signals.py
@@ -4,6 +4,7 @@ Signals for Gift model.
 Mirrors the Donation signal handlers for contact stat updates and event
 creation, adapted for the Gift model's field names (donor_contact, amount_dollars).
 """
+
 import threading
 
 from django.db.models.signals import post_delete, post_save, pre_delete

--- a/apps/gifts/tests/factories.py
+++ b/apps/gifts/tests/factories.py
@@ -1,6 +1,7 @@
 """
 Factories for Gift and RecurringGift model tests.
 """
+
 from datetime import timedelta
 
 from django.utils import timezone

--- a/apps/gifts/tests/test_export_coverage.py
+++ b/apps/gifts/tests/test_export_coverage.py
@@ -6,6 +6,7 @@ export can still return 200 with a header row but NO data rows. These tests
 parse the streamed body and assert the header AND at least one correct data
 row (dollars formatted from cents), which catches that class of bug.
 """
+
 import csv
 import io
 from datetime import date

--- a/apps/gifts/tests/test_export_coverage.py
+++ b/apps/gifts/tests/test_export_coverage.py
@@ -176,17 +176,15 @@ class TestGiftExportCSV:
         response = APIClient().get(GIFT_EXPORT_URL)
         assert response.status_code == 401
 
-    def test_admin_owner_filter_scopes_to_selected_user(self):
+    def test_owner_query_param_is_ignored_and_does_not_break_export(self):
+        # The ?owner= query param was removed (issue #63): it was a NumberFilter
+        # on a UUID FK, so passing a UUID invalidated the whole FilterSet and
+        # silently returned ZERO rows. Now ?owner= is ignored entirely, so the
+        # admin still gets their OWN data back — proving the param no longer
+        # nukes the export.
         admin = AdminUserFactory(email="export-admin@test.com")
         target = UserFactory(role="missionary", email="export-target@test.com")
-        target_contact = ContactFactory(owner=target, first_name="Target", last_name="User")
-        Gift.objects.create(
-            donor_contact=target_contact,
-            amount_cents=30000,
-            gift_date=date(2026, 6, 1),
-        )
-        # Admin's own gift should NOT appear when filtering by owner=target.
-        admin_contact = ContactFactory(owner=admin)
+        admin_contact = ContactFactory(owner=admin, first_name="Admin", last_name="Own")
         Gift.objects.create(
             donor_contact=admin_contact,
             amount_cents=70000,
@@ -194,16 +192,44 @@ class TestGiftExportCSV:
         )
         response = _client(admin).get(GIFT_EXPORT_URL, {"owner": str(target.id)})
         rows = _parse_csv(response)
-        # Access-control guard: a plain ?owner= query param must NOT grant an
-        # admin cross-user export access. Cross-user data is reached only via
-        # View As (X-View-As-User-Id header -> get_visible_user_ids), so the
-        # export stays scoped to the admin's own data and the target user's
-        # $300 gift is NOT leaked. (Header only here because ?owner=target
-        # intersected with the admin's own-data scope is empty.)
         assert response.status_code == 200
         assert rows[0][0] == "Donor Name"
+        # ?owner=target is ignored: the admin's own $700 gift IS still exported.
+        assert any(row[0] == "Admin Own" and row[1] == "700.00" for row in rows[1:])
+
+    def test_owner_query_param_does_not_grant_cross_user_export(self):
+        # Access-control guard: a plain ?owner= must NOT let an admin export
+        # another user's data. Cross-user access is reached only via View As.
+        admin = AdminUserFactory(email="export-admin-guard@test.com")
+        target = UserFactory(role="missionary", email="export-target-guard@test.com")
+        target_contact = ContactFactory(owner=target, first_name="Target", last_name="User")
+        Gift.objects.create(
+            donor_contact=target_contact,
+            amount_cents=30000,
+            gift_date=date(2026, 6, 1),
+        )
+        response = _client(admin).get(GIFT_EXPORT_URL, {"owner": str(target.id)})
+        rows = _parse_csv(response)
+        assert response.status_code == 200
         assert all("Target User" not in row for row in rows[1:])
-        assert "300" not in [row[1] for row in rows[1:]]
+        assert all(row[1] != "300.00" for row in rows[1:])
+
+    def test_view_as_header_grants_cross_user_export(self):
+        # Cross-user export IS reached via View As (X-View-As-User-Id header),
+        # which scopes get_visible_user_ids to the target user.
+        admin = AdminUserFactory(email="export-admin-viewas@test.com")
+        target = UserFactory(role="missionary", email="export-target-viewas@test.com")
+        target_contact = ContactFactory(owner=target, first_name="Viewed", last_name="Missionary")
+        Gift.objects.create(
+            donor_contact=target_contact,
+            amount_cents=30000,
+            gift_date=date(2026, 6, 1),
+        )
+        response = _client(admin).get(GIFT_EXPORT_URL, HTTP_X_VIEW_AS_USER_ID=str(target.id))
+        rows = _parse_csv(response)
+        assert response.status_code == 200
+        # The target missionary's $300 gift IS exported under View As.
+        assert any(row[0] == "Viewed Missionary" and row[1] == "300.00" for row in rows[1:])
 
 
 @pytest.mark.django_db
@@ -293,7 +319,10 @@ class TestRecurringGiftExportCSV:
         response = _client(coach).get(RECURRING_EXPORT_URL)
         assert response.status_code == 403
 
-    def test_supervisor_owner_filter(self):
+    def test_owner_query_param_does_not_grant_cross_user_recurring_export(self):
+        # Access-control guard (same as the gift export above): a ?owner= param
+        # must NOT let a supervisor export an unrelated user's pledges. Cross-user
+        # access requires View As, so the target's $450 pledge is not leaked.
         supervisor = SupervisorUserFactory()
         target = UserFactory(role="missionary", email="recur-target@test.com")
         target_contact = ContactFactory(owner=target, first_name="Recur", last_name="Target")
@@ -306,10 +335,27 @@ class TestRecurringGiftExportCSV:
         )
         response = _client(supervisor).get(RECURRING_EXPORT_URL, {"owner": str(target.id)})
         rows = _parse_csv(response)
-        # Access-control guard (same as the gift export above): a ?owner= param
-        # must NOT let a supervisor export an unrelated user's pledges. Cross-user
-        # access requires View As, so the target's $450 pledge is not leaked.
         assert response.status_code == 200
         assert rows[0][0] == "Donor Name"
         assert all("Recur Target" not in row for row in rows[1:])
+
+    def test_view_as_header_grants_cross_user_recurring_export(self):
+        # A supervisor reaches an assigned missionary's pledges via View As.
+        supervisor = SupervisorUserFactory()
+        target = UserFactory(role="missionary", email="recur-viewas-target@test.com")
+        target.supervisors.add(supervisor)
+        target_contact = ContactFactory(owner=target, first_name="Seen", last_name="Pledger")
+        RecurringGift.objects.create(
+            donor_contact=target_contact,
+            amount_cents=45000,
+            frequency=RecurringGiftFrequency.MONTHLY,
+            status=RecurringGiftStatus.ACTIVE,
+            start_date=date(2026, 4, 1),
+        )
+        response = _client(supervisor).get(
+            RECURRING_EXPORT_URL, HTTP_X_VIEW_AS_USER_ID=str(target.id)
+        )
+        rows = _parse_csv(response)
+        assert response.status_code == 200
+        assert any(row[0] == "Seen Pledger" and row[1] == "450.00" for row in rows[1:])
         assert "450" not in [row[1] for row in rows[1:]]

--- a/apps/gifts/tests/test_recurring_utils.py
+++ b/apps/gifts/tests/test_recurring_utils.py
@@ -1,6 +1,7 @@
 """
 Tests for recurring gift payment generation utilities.
 """
+
 from datetime import date
 
 import pytest

--- a/apps/gifts/tests/test_signals.py
+++ b/apps/gifts/tests/test_signals.py
@@ -8,6 +8,7 @@ Verifies that:
 - Updating a Gift amount triggers contact stat recalculation
 - Deleting a Gift triggers contact stat recalculation
 """
+
 from datetime import date, timedelta
 from decimal import Decimal
 

--- a/apps/gifts/tests/test_views.py
+++ b/apps/gifts/tests/test_views.py
@@ -6,6 +6,7 @@ Verifies that:
 - Admin users see only their own gifts (cross-user access via View As only)
 - Same patterns apply to RecurringGift views
 """
+
 from datetime import date, timedelta
 
 from rest_framework import status

--- a/apps/gifts/urls.py
+++ b/apps/gifts/urls.py
@@ -1,6 +1,7 @@
 """
 URL patterns for gift endpoints.
 """
+
 from django.urls import path
 
 from apps.gifts.export_views import GiftExportCSVView, RecurringGiftExportCSVView

--- a/apps/gifts/views.py
+++ b/apps/gifts/views.py
@@ -1,6 +1,7 @@
 """
 Views for Gift and RecurringGift CRUD API endpoints.
 """
+
 from rest_framework import generics, permissions
 from rest_framework.filters import OrderingFilter, SearchFilter
 

--- a/apps/groups/admin.py
+++ b/apps/groups/admin.py
@@ -1,6 +1,7 @@
 """
 Admin configuration for Group model.
 """
+
 from django.contrib import admin
 
 from apps.groups.models import Group

--- a/apps/groups/models.py
+++ b/apps/groups/models.py
@@ -1,6 +1,7 @@
 """
 Group model for organizing contacts with tags/segments.
 """
+
 from django.conf import settings
 from django.db import models
 

--- a/apps/groups/serializers.py
+++ b/apps/groups/serializers.py
@@ -1,6 +1,7 @@
 """
 Serializers for Group model.
 """
+
 from rest_framework import serializers
 
 from apps.groups.models import Group

--- a/apps/groups/tests/factories.py
+++ b/apps/groups/tests/factories.py
@@ -1,6 +1,7 @@
 """
 Factories for Group model tests.
 """
+
 import factory
 from faker import Faker
 

--- a/apps/groups/tests/test_models.py
+++ b/apps/groups/tests/test_models.py
@@ -1,6 +1,7 @@
 """
 Tests for Group model.
 """
+
 import pytest
 
 from apps.contacts.tests.factories import ContactFactory

--- a/apps/groups/tests/test_views.py
+++ b/apps/groups/tests/test_views.py
@@ -1,6 +1,7 @@
 """
 Tests for Group API views.
 """
+
 from rest_framework import status
 from rest_framework.test import APIClient
 

--- a/apps/groups/tests/test_views_coverage.py
+++ b/apps/groups/tests/test_views_coverage.py
@@ -7,6 +7,7 @@ Targets the branches the existing test_views.py leaves uncovered:
   - admin-with-global-visibility removal branch
   - GroupContactEmailsView (entirely untested before)
 """
+
 from rest_framework import status
 from rest_framework.test import APIClient
 

--- a/apps/groups/urls.py
+++ b/apps/groups/urls.py
@@ -1,6 +1,7 @@
 """
 URL patterns for groups endpoints.
 """
+
 from django.urls import path
 
 from apps.groups.views import (

--- a/apps/groups/views.py
+++ b/apps/groups/views.py
@@ -1,6 +1,7 @@
 """
 Views for Group management.
 """
+
 from django.db.models import Count, Q
 
 from rest_framework import generics, permissions, status

--- a/apps/imports/admin.py
+++ b/apps/imports/admin.py
@@ -1,6 +1,7 @@
 """
 Admin configuration for import infrastructure models.
 """
+
 from django.contrib import admin
 
 from apps.imports.models import (

--- a/apps/imports/generic_services.py
+++ b/apps/imports/generic_services.py
@@ -8,6 +8,7 @@ any CSV format (not just Raiser's Edge) with configurable matching strategy
 Returns ImportBatch in the same response shape as RE imports so the existing
 ImportResultBanner works without modification.
 """
+
 import csv
 import hashlib
 import io

--- a/apps/imports/management/commands/audit_import_health.py
+++ b/apps/imports/management/commands/audit_import_health.py
@@ -9,6 +9,7 @@ Usage:
     python manage.py audit_import_health --verbose
     python manage.py audit_import_health --json
 """
+
 import difflib
 import json
 from decimal import Decimal

--- a/apps/imports/management/commands/import_re_constituents.py
+++ b/apps/imports/management/commands/import_re_constituents.py
@@ -4,6 +4,7 @@ Management command for importing RE Constituent CSV files.
 Usage:
     python manage.py import_re_constituents <file> --owner admin@example.com [--force]
 """
+
 import os
 
 from django.core.management.base import BaseCommand, CommandError

--- a/apps/imports/management/commands/import_re_gifts.py
+++ b/apps/imports/management/commands/import_re_gifts.py
@@ -4,6 +4,7 @@ Management command for importing RE Gift CSV files.
 Usage:
     python manage.py import_re_gifts <file> --owner admin@example.com [--force]
 """
+
 from django.core.management.base import BaseCommand, CommandError
 
 from apps.imports.models import ImportBatchStatus

--- a/apps/imports/management/commands/import_re_recurring_gifts.py
+++ b/apps/imports/management/commands/import_re_recurring_gifts.py
@@ -4,6 +4,7 @@ Management command for importing RE Recurring Gift CSV files.
 Usage:
     python manage.py import_re_recurring_gifts <file> --owner admin@example.com [--force]
 """
+
 from django.core.management.base import BaseCommand, CommandError
 
 from apps.imports.models import ImportBatchStatus

--- a/apps/imports/management/commands/import_re_solicitors.py
+++ b/apps/imports/management/commands/import_re_solicitors.py
@@ -4,6 +4,7 @@ Management command for importing RE Solicitor CSV files.
 Usage:
     python manage.py import_re_solicitors <file> --owner admin@example.com [--force]
 """
+
 from django.core.management.base import BaseCommand, CommandError
 
 from apps.imports.models import ImportBatchStatus

--- a/apps/imports/management/commands/import_spo_gifts.py
+++ b/apps/imports/management/commands/import_spo_gifts.py
@@ -6,6 +6,7 @@ Imports SPO gifts and attributes them to missionaries via GiftCredit.
 Usage:
     python manage.py import_spo_gifts <file> --owner admin@example.com [--force]
 """
+
 from django.core.management.base import BaseCommand, CommandError
 
 from apps.imports.models import ImportBatchStatus

--- a/apps/imports/management/commands/import_spo_prayers.py
+++ b/apps/imports/management/commands/import_spo_prayers.py
@@ -6,6 +6,7 @@ Extracts prayer intentions from SPO gifts CSV (prayer-only rerun pass).
 Usage:
     python manage.py import_spo_prayers <file> --owner admin@example.com [--force]
 """
+
 from django.core.management.base import BaseCommand, CommandError
 
 from apps.imports.models import ImportBatchStatus

--- a/apps/imports/management/commands/reconcile_missionaries.py
+++ b/apps/imports/management/commands/reconcile_missionaries.py
@@ -6,6 +6,7 @@ Reconciles SPO missionary accounts from a Solicitors CSV file.
 Usage:
     python manage.py reconcile_missionaries <file> --owner admin@example.com [--force]
 """
+
 from django.core.management.base import BaseCommand, CommandError
 
 from apps.imports.models import ImportBatchStatus

--- a/apps/imports/models.py
+++ b/apps/imports/models.py
@@ -4,6 +4,7 @@ Models for CSV import infrastructure.
 Provides Fund, ImportRun, and ImportRowError models for tracking
 CSV imports from SPO and other external systems.
 """
+
 from django.db import models
 
 from apps.core.models import TimeStampedModel

--- a/apps/imports/mpd_services.py
+++ b/apps/imports/mpd_services.py
@@ -4,6 +4,7 @@ Service functions for Smartsheet MPD Dashboard Report import.
 Handles file parsing (CSV/XLSX), column mapping, user matching,
 currency/boolean/percentage parsing, and MPDSnapshot creation.
 """
+
 import csv
 import logging
 from decimal import Decimal, InvalidOperation
@@ -464,14 +465,16 @@ def match_users(parsed_rows: list[dict]) -> tuple[list[tuple], list[dict]]:
                     "first_name": row_data.get("_first_name", ""),
                     "last_name": row_data.get("_last_name", ""),
                     # Financial fields for admin visibility in results dialog
-                    "current_mpd_cap": str(row_data.get("current_mpd_cap", ""))
-                    if row_data.get("current_mpd_cap") is not None
-                    else None,
-                    "latest_roll_forward_balance": str(
-                        row_data.get("latest_roll_forward_balance", "")
-                    )
-                    if row_data.get("latest_roll_forward_balance") is not None
-                    else None,
+                    "current_mpd_cap": (
+                        str(row_data.get("current_mpd_cap", ""))
+                        if row_data.get("current_mpd_cap") is not None
+                        else None
+                    ),
+                    "latest_roll_forward_balance": (
+                        str(row_data.get("latest_roll_forward_balance", ""))
+                        if row_data.get("latest_roll_forward_balance") is not None
+                        else None
+                    ),
                     "months_remaining_rf": row_data.get("months_remaining_rf", ""),
                 }
             )
@@ -489,14 +492,16 @@ def match_users(parsed_rows: list[dict]) -> tuple[list[tuple], list[dict]]:
                     "first_name": row_data.get("_first_name", ""),
                     "last_name": row_data.get("_last_name", ""),
                     # Financial fields for admin visibility in results dialog
-                    "current_mpd_cap": str(row_data.get("current_mpd_cap", ""))
-                    if row_data.get("current_mpd_cap") is not None
-                    else None,
-                    "latest_roll_forward_balance": str(
-                        row_data.get("latest_roll_forward_balance", "")
-                    )
-                    if row_data.get("latest_roll_forward_balance") is not None
-                    else None,
+                    "current_mpd_cap": (
+                        str(row_data.get("current_mpd_cap", ""))
+                        if row_data.get("current_mpd_cap") is not None
+                        else None
+                    ),
+                    "latest_roll_forward_balance": (
+                        str(row_data.get("latest_roll_forward_balance", ""))
+                        if row_data.get("latest_roll_forward_balance") is not None
+                        else None
+                    ),
                     "months_remaining_rf": row_data.get("months_remaining_rf", ""),
                 }
             )

--- a/apps/imports/re_services.py
+++ b/apps/imports/re_services.py
@@ -5,6 +5,7 @@ Provides utility functions (cascading encoding, SHA256 dedup, header validation,
 name normalization) and orchestrator functions for RE CSV imports.
 Both management commands and API endpoints call the same service functions.
 """
+
 import csv
 import hashlib
 import io

--- a/apps/imports/services.py
+++ b/apps/imports/services.py
@@ -1,6 +1,7 @@
 """
 Service functions for CSV import/export.
 """
+
 import csv
 import io
 import logging

--- a/apps/imports/spo_services.py
+++ b/apps/imports/spo_services.py
@@ -8,6 +8,7 @@ Implements the three-step SPO data pipeline:
 
 Both management commands and API endpoints call these service functions.
 """
+
 import csv
 import hashlib
 import io

--- a/apps/imports/tasks.py
+++ b/apps/imports/tasks.py
@@ -1,6 +1,7 @@
 """
 Celery tasks for asynchronous CSV imports.
 """
+
 import logging
 import uuid
 

--- a/apps/imports/tests/test_audit_import_health.py
+++ b/apps/imports/tests/test_audit_import_health.py
@@ -4,6 +4,7 @@ Tests for the audit_import_health management command.
 Covers all 5 sections, --verbose/--json flags, zero-solicitors edge case,
 and HEALTHY vs NEEDS ATTENTION verdict logic.
 """
+
 import json
 from io import StringIO
 

--- a/apps/imports/tests/test_entity_import.py
+++ b/apps/imports/tests/test_entity_import.py
@@ -1,6 +1,7 @@
 """
 Tests for Entity CSV import functionality.
 """
+
 import io
 
 from django.contrib.auth import get_user_model

--- a/apps/imports/tests/test_fund_import.py
+++ b/apps/imports/tests/test_fund_import.py
@@ -1,6 +1,7 @@
 """
 Tests for Fund CSV import functionality.
 """
+
 import io
 
 from django.contrib.auth import get_user_model

--- a/apps/imports/tests/test_generic_imports.py
+++ b/apps/imports/tests/test_generic_imports.py
@@ -6,6 +6,7 @@ Covers:
 - Donation import: Gift creation, missing contact errors, stat recalculation
 - API views: endpoints, response shape, staff access, coach denied
 """
+
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import TestCase
 

--- a/apps/imports/tests/test_generic_services_coverage.py
+++ b/apps/imports/tests/test_generic_services_coverage.py
@@ -14,6 +14,7 @@ import_generic_donations:
 These exercise real import behavior with realistic CSV rows and assert on the
 records actually written (money in cents) and the returned ImportBatch summary.
 """
+
 from unittest.mock import patch
 
 from django.test import TestCase

--- a/apps/imports/tests/test_mpd_views.py
+++ b/apps/imports/tests/test_mpd_views.py
@@ -3,6 +3,7 @@ Tests for MPD API views: MPDMyDataView and MPDOverviewView.
 
 Covers monthly_average_snapshot field in both endpoints (MPD-01, MPD-02).
 """
+
 from decimal import Decimal
 
 from django.contrib.auth import get_user_model

--- a/apps/imports/tests/test_pledge_import.py
+++ b/apps/imports/tests/test_pledge_import.py
@@ -6,6 +6,7 @@ get_pledges_template) were removed in Phase 30-02 and replaced by the RE
 Recurring Gift import pipeline. This test file verifies the legacy endpoint
 returns 410 Gone.
 """
+
 from django.contrib.auth import get_user_model
 from django.urls import reverse
 

--- a/apps/imports/tests/test_re_services.py
+++ b/apps/imports/tests/test_re_services.py
@@ -9,6 +9,7 @@ Covers all 4 RE import functions with minimal CSV inputs:
 
 Plus SHA256 dedup and malformed CSV handling.
 """
+
 import pytest
 
 from apps.contacts.models import Contact

--- a/apps/imports/tests/test_services.py
+++ b/apps/imports/tests/test_services.py
@@ -1,6 +1,7 @@
 """
 Tests for import/export services.
 """
+
 import pytest
 
 from apps.contacts.models import Contact

--- a/apps/imports/tests/test_services_coverage.py
+++ b/apps/imports/tests/test_services_coverage.py
@@ -11,6 +11,7 @@ Targets currently-uncovered helpers and validation branches:
 Each test asserts real, observable behavior: the sanitized value, the parsed
 Decimal/date, or the specific validation error string returned.
 """
+
 from datetime import date
 from decimal import Decimal
 

--- a/apps/imports/tests/test_spo_commands.py
+++ b/apps/imports/tests/test_spo_commands.py
@@ -3,6 +3,7 @@ Tests for SPO management commands: reconcile_missionaries, import_spo_gifts, imp
 
 TDD plan 04: Stubs filled in.
 """
+
 import csv as csv_mod
 import io
 import os

--- a/apps/imports/tests/test_spo_csv_fixture_mapping.py
+++ b/apps/imports/tests/test_spo_csv_fixture_mapping.py
@@ -11,6 +11,7 @@ Fixture files:
   test_data/test_recurring_gifts.csv — type-label "Recurring Gift", 300 rows
   test_data/test_constituents.csv    — type-label "Constituent", 400 rows
 """
+
 import os
 
 from django.test import TestCase

--- a/apps/imports/tests/test_spo_services.py
+++ b/apps/imports/tests/test_spo_services.py
@@ -5,6 +5,7 @@ TDD plan 02: TestReconcileMissionaries stubs filled in.
 TDD plan 03: TestImportSpoGifts stubs filled in
 (import_spo_gifts, import_spo_prayers, TestIdempotency).
 """
+
 import csv as csv_mod
 import io
 

--- a/apps/imports/tests/test_spo_views.py
+++ b/apps/imports/tests/test_spo_views.py
@@ -6,6 +6,7 @@ Tests for SPO import API views:
 
 TDD plan 04: Stubs filled in.
 """
+
 import csv as csv_mod
 import io
 

--- a/apps/imports/tests/test_transaction_import.py
+++ b/apps/imports/tests/test_transaction_import.py
@@ -6,6 +6,7 @@ import_transactions, update_contact_stats_for_import) were removed in
 Phase 30-02 and replaced by the RE Gift import pipeline. This test file
 verifies the legacy endpoint returns 410 Gone.
 """
+
 from django.contrib.auth import get_user_model
 from django.urls import reverse
 

--- a/apps/imports/tests/test_views.py
+++ b/apps/imports/tests/test_views.py
@@ -1,6 +1,7 @@
 """
 Tests for import views.
 """
+
 from django.contrib.auth import get_user_model
 from django.urls import reverse
 

--- a/apps/imports/urls.py
+++ b/apps/imports/urls.py
@@ -1,6 +1,7 @@
 """
 URL patterns for import/export endpoints.
 """
+
 from django.urls import path
 
 from apps.imports.views import (

--- a/apps/imports/views.py
+++ b/apps/imports/views.py
@@ -1,6 +1,7 @@
 """
 Views for CSV import/export.
 """
+
 import csv
 import io
 import logging
@@ -779,9 +780,11 @@ class MPDOverviewView(APIView):
                 entry = {
                     "user_id": str(user.id),
                     "user_name": user.full_name,
-                    "monthly_average_snapshot": str(snapshot.monthly_average)
-                    if snapshot and snapshot.monthly_average
-                    else None,
+                    "monthly_average_snapshot": (
+                        str(snapshot.monthly_average)
+                        if snapshot and snapshot.monthly_average
+                        else None
+                    ),
                 }
                 entry.update({k: v for k, v in computed.items() if k != "has_data"})
                 missionaries.append(entry)

--- a/apps/insights/admin_analytics_services.py
+++ b/apps/insights/admin_analytics_services.py
@@ -14,6 +14,7 @@ services compute org-wide aggregates (matching existing admin analytics
 endpoints such as get_dashboard_overview, which intentionally bypass user
 scoping for cross-tenant views).
 """
+
 from calendar import monthrange
 from datetime import date, timedelta
 

--- a/apps/insights/export_views.py
+++ b/apps/insights/export_views.py
@@ -1,6 +1,7 @@
 """
 CSV export views for admin analytics endpoints.
 """
+
 import csv
 import logging
 from datetime import datetime

--- a/apps/insights/serializers.py
+++ b/apps/insights/serializers.py
@@ -1,6 +1,7 @@
 """
 DRF serializers for insights/analytics endpoints.
 """
+
 from rest_framework import serializers
 
 # Nested serializers

--- a/apps/insights/services.py
+++ b/apps/insights/services.py
@@ -1,6 +1,7 @@
 """
 Service functions for insights/reports data aggregations.
 """
+
 from datetime import date, timedelta
 
 from django.db.models import CharField, Count, IntegerField, OuterRef, Q, Subquery, Sum, Value
@@ -515,15 +516,17 @@ def get_stalled_contacts(
                 "email": c.email,
                 "owner_email": c.owner.email,
                 "owner_name": f"{c.owner.first_name} {c.owner.last_name}".strip(),
-                "last_activity_date": c.last_activity_date.isoformat()
-                if c.last_activity_date
-                else None,
+                "last_activity_date": (
+                    c.last_activity_date.isoformat() if c.last_activity_date else None
+                ),
                 "days_stalled": (
                     (reference_time - c.last_activity_date).days
                     if c.last_activity_date
-                    else (reference_time - c.journal_membership_date).days
-                    if c.journal_membership_date
-                    else None
+                    else (
+                        (reference_time - c.journal_membership_date).days
+                        if c.journal_membership_date
+                        else None
+                    )
                 ),
                 "status": c.status,
             }
@@ -623,9 +626,11 @@ def _annotate_user_performance(queryset):
 def _serialize_user_performance(user):
     """Turn an annotated user row (from _annotate_user_performance) into the API shape."""
     conversion_rate = round(
-        (user._contacts_with_decisions / user.contacts_in_journals * 100)
-        if user.contacts_in_journals > 0
-        else 0,
+        (
+            (user._contacts_with_decisions / user.contacts_in_journals * 100)
+            if user.contacts_in_journals > 0
+            else 0
+        ),
         1,
     )
     return {
@@ -1072,9 +1077,9 @@ def get_stage_contacts(stage, limit=100):
                 "full_name": c.full_name,
                 "email": c.email,
                 "owner_name": f"{c.owner.first_name} {c.owner.last_name}".strip(),
-                "last_activity_date": c.last_activity_date.isoformat()
-                if c.last_activity_date
-                else None,
+                "last_activity_date": (
+                    c.last_activity_date.isoformat() if c.last_activity_date else None
+                ),
             }
             for c in contacts
         ],

--- a/apps/insights/tests/test_admin_analytics_services.py
+++ b/apps/insights/tests/test_admin_analytics_services.py
@@ -8,6 +8,7 @@ Covers:
   - get_weekly_engagement
   - get_fiscal_year_donations
 """
+
 from calendar import monthrange
 from datetime import date, timedelta
 from unittest.mock import patch

--- a/apps/insights/tests/test_admin_analytics_views.py
+++ b/apps/insights/tests/test_admin_analytics_views.py
@@ -6,6 +6,7 @@ Verifies:
   - Response shape matches serializer contract.
   - Query params (limit, weeks) are honored and validated.
 """
+
 from rest_framework import status
 from rest_framework.test import APIClient
 

--- a/apps/insights/tests/test_csv_export.py
+++ b/apps/insights/tests/test_csv_export.py
@@ -1,6 +1,7 @@
 """
 Tests for CSV export endpoints in insights app.
 """
+
 import csv
 from datetime import timedelta
 from decimal import Decimal

--- a/apps/insights/tests/test_csv_stream_errors.py
+++ b/apps/insights/tests/test_csv_stream_errors.py
@@ -3,6 +3,7 @@ Tests that the CSV export `_safe_csv_stream` wrapper surfaces a sentinel
 error row instead of silently truncating when the row generator raises
 mid-stream.
 """
+
 import csv
 import io
 

--- a/apps/insights/tests/test_date_filtering.py
+++ b/apps/insights/tests/test_date_filtering.py
@@ -1,6 +1,7 @@
 """
 Tests for date range filtering on admin analytics endpoints.
 """
+
 from datetime import date, timedelta
 from decimal import Decimal
 

--- a/apps/insights/tests/test_late_donations.py
+++ b/apps/insights/tests/test_late_donations.py
@@ -5,6 +5,7 @@ Regression: this endpoint previously returned an empty stub even when there
 were active recurring pledges that had missed their expected payment window.
 Now delegates to apps.core.late_donations.compute_late_donations.
 """
+
 from datetime import date, timedelta
 
 import pytest

--- a/apps/insights/tests/test_monthly_commitments.py
+++ b/apps/insights/tests/test_monthly_commitments.py
@@ -2,6 +2,7 @@
 Tests for /insights/monthly-commitments/ — specifically the last_fulfilled_date
 field that the frontend table renders.
 """
+
 from datetime import date, timedelta
 
 import pytest

--- a/apps/insights/tests/test_org_settings.py
+++ b/apps/insights/tests/test_org_settings.py
@@ -2,6 +2,7 @@
 Tests for the org-wide annual goal setting and its effect on the
 Fiscal Year Pace tile.
 """
+
 from rest_framework.test import APIClient
 
 import pytest

--- a/apps/insights/tests/test_services_coverage.py
+++ b/apps/insights/tests/test_services_coverage.py
@@ -13,6 +13,7 @@ These exercise service functions that are reachable but previously untested:
 Time is pinned mid-fiscal-year so gifts/events dated near boundaries stay in
 the past, matching the convention in test_admin_analytics_services.py.
 """
+
 from datetime import date, timedelta
 
 from django.utils import timezone

--- a/apps/insights/tests/test_stage_contacts.py
+++ b/apps/insights/tests/test_stage_contacts.py
@@ -1,6 +1,7 @@
 """
 Tests for stage contacts endpoint.
 """
+
 from django.test import TestCase
 from django.urls import reverse
 

--- a/apps/insights/tests/test_team_trends.py
+++ b/apps/insights/tests/test_team_trends.py
@@ -1,6 +1,7 @@
 """
 Tests for team trends endpoint.
 """
+
 from datetime import timedelta
 from decimal import Decimal
 

--- a/apps/insights/tests/test_user_detail.py
+++ b/apps/insights/tests/test_user_detail.py
@@ -1,6 +1,7 @@
 """
 Tests for user detail endpoints in insights app.
 """
+
 from decimal import Decimal
 
 from rest_framework import status

--- a/apps/insights/tests/test_user_drilldown.py
+++ b/apps/insights/tests/test_user_drilldown.py
@@ -1,6 +1,7 @@
 """
 Tests for user drilldown endpoint (Phase 18).
 """
+
 from datetime import timedelta
 from decimal import Decimal
 

--- a/apps/insights/tests/test_user_performance_perf.py
+++ b/apps/insights/tests/test_user_performance_perf.py
@@ -10,6 +10,7 @@ Covers:
   calculation yields, so the Subquery refactor did not silently change
   the conversion rate or decision counts exposed to the dashboard.
 """
+
 from decimal import Decimal
 
 from django.db import connection

--- a/apps/insights/tests/test_views.py
+++ b/apps/insights/tests/test_views.py
@@ -1,6 +1,7 @@
 """
 Tests for admin analytics endpoints in insights app.
 """
+
 from decimal import Decimal
 
 from rest_framework import status

--- a/apps/insights/tests/test_views_coverage.py
+++ b/apps/insights/tests/test_views_coverage.py
@@ -11,6 +11,7 @@ Focuses on previously-untested view branches:
 
 Time is pinned mid-fiscal-year where gift dates matter.
 """
+
 from datetime import date
 
 from rest_framework import status

--- a/apps/insights/urls.py
+++ b/apps/insights/urls.py
@@ -1,6 +1,7 @@
 """
 URL patterns for insights app.
 """
+
 from django.urls import path
 
 from apps.insights.export_views import StalledContactsCSVView, TeamActivityCSVView

--- a/apps/insights/views.py
+++ b/apps/insights/views.py
@@ -2,7 +2,6 @@
 Views for Insights/Reports data.
 """
 
-
 from django.db import transaction
 
 from rest_framework import permissions, status

--- a/apps/journals/admin.py
+++ b/apps/journals/admin.py
@@ -1,6 +1,7 @@
 """
 Django admin configuration for journals app.
 """
+
 from django.contrib import admin
 
 from apps.journals.models import Journal, JournalContact, JournalStageEvent

--- a/apps/journals/apps.py
+++ b/apps/journals/apps.py
@@ -1,6 +1,7 @@
 """
 Journals app configuration.
 """
+
 from django.apps import AppConfig
 
 

--- a/apps/journals/export_views.py
+++ b/apps/journals/export_views.py
@@ -1,6 +1,7 @@
 """
 CSV export view for journals with FilterSet-based filtering.
 """
+
 import csv
 from datetime import datetime
 

--- a/apps/journals/filters.py
+++ b/apps/journals/filters.py
@@ -1,4 +1,5 @@
 """FilterSet for Journal list filtering."""
+
 import django_filters
 
 from apps.journals.models import Journal

--- a/apps/journals/models.py
+++ b/apps/journals/models.py
@@ -1,6 +1,7 @@
 """
 Journal models for donor engagement tracking.
 """
+
 from decimal import Decimal
 
 from django.conf import settings

--- a/apps/journals/serializers.py
+++ b/apps/journals/serializers.py
@@ -1,6 +1,7 @@
 """
 Serializers for Journal models.
 """
+
 from decimal import Decimal
 
 from django.db import IntegrityError, transaction

--- a/apps/journals/signals.py
+++ b/apps/journals/signals.py
@@ -1,6 +1,7 @@
 """
 Signals for Journal event logging.
 """
+
 import logging
 
 from django.db.models.signals import post_save

--- a/apps/journals/tests/test_decisions.py
+++ b/apps/journals/tests/test_decisions.py
@@ -10,6 +10,7 @@ Tests verify:
 - Monthly equivalent calculation for all cadences
 - Paginated history retrieval
 """
+
 from decimal import Decimal
 
 from django.contrib.auth import get_user_model

--- a/apps/journals/tests/test_export_coverage.py
+++ b/apps/journals/tests/test_export_coverage.py
@@ -9,6 +9,7 @@ Verifies:
 - FilterSet application (owner filter)
 - JournalContactSerializer stage_events/decision summary branches
 """
+
 import csv
 import io
 from decimal import Decimal

--- a/apps/journals/tests/test_journal_members.py
+++ b/apps/journals/tests/test_journal_members.py
@@ -12,6 +12,7 @@ Tests verify:
 - Archived journal exclusion
 - Journal-specific listing
 """
+
 from django.contrib.auth import get_user_model
 from django.urls import reverse
 

--- a/apps/journals/tests/test_next_steps.py
+++ b/apps/journals/tests/test_next_steps.py
@@ -8,6 +8,7 @@ Tests verify:
 - Ownership validation (only owner can access)
 - Cross-user protection
 """
+
 from django.contrib.auth import get_user_model
 from django.urls import reverse
 

--- a/apps/journals/tests/test_scheduled_stage.py
+++ b/apps/journals/tests/test_scheduled_stage.py
@@ -11,6 +11,7 @@ Tests verify:
 - Goal services calls_count excludes meeting_scheduled events
 - Goal services meetings_count excludes meeting_scheduled events
 """
+
 from decimal import Decimal
 
 from django.contrib.auth import get_user_model

--- a/apps/journals/tests/test_views_coverage.py
+++ b/apps/journals/tests/test_views_coverage.py
@@ -9,6 +9,7 @@ Exercises real HTTP request/response behavior through the DRF API:
 - Decision history list filtering
 - Analytics ViewSet endpoints (trends, activity, pipeline, queue, report, admin-summary)
 """
+
 from datetime import timedelta
 from decimal import Decimal
 

--- a/apps/journals/urls.py
+++ b/apps/journals/urls.py
@@ -1,6 +1,7 @@
 """
 URL configuration for journals app.
 """
+
 from django.urls import include, path
 
 from rest_framework.routers import DefaultRouter

--- a/apps/journals/views.py
+++ b/apps/journals/views.py
@@ -1,6 +1,7 @@
 """
 Views for Journal management.
 """
+
 from collections import defaultdict
 from datetime import timedelta
 

--- a/apps/prayers/admin.py
+++ b/apps/prayers/admin.py
@@ -1,6 +1,7 @@
 """
 Admin configuration for prayer intention models.
 """
+
 from django.contrib import admin
 
 from apps.prayers.models import PrayerIntention

--- a/apps/prayers/apps.py
+++ b/apps/prayers/apps.py
@@ -1,6 +1,7 @@
 """
 App configuration for prayer intentions.
 """
+
 from django.apps import AppConfig
 
 

--- a/apps/prayers/filters.py
+++ b/apps/prayers/filters.py
@@ -1,6 +1,7 @@
 """
 Filters for PrayerIntention model.
 """
+
 import django_filters
 
 from apps.prayers.models import PrayerIntention

--- a/apps/prayers/models.py
+++ b/apps/prayers/models.py
@@ -4,6 +4,7 @@ Models for prayer intention tracking.
 Provides PrayerIntention model to track prayer requests per contact,
 with M2M gift linkage for auto-creation from RE gift descriptions.
 """
+
 from django.db import models
 
 from apps.core.encryption import EncryptedTextField

--- a/apps/prayers/serializers.py
+++ b/apps/prayers/serializers.py
@@ -1,6 +1,7 @@
 """
 Serializers for PrayerIntention model.
 """
+
 from django.utils import timezone
 
 from rest_framework import serializers

--- a/apps/prayers/tests/test_views_coverage.py
+++ b/apps/prayers/tests/test_views_coverage.py
@@ -5,6 +5,7 @@ Exercises CRUD, owner-scoping, status-timestamp management, mark-prayed,
 and today's-focus rotation. Each test asserts real behavior so it fails
 when the feature breaks.
 """
+
 from datetime import timedelta
 
 from django.utils import timezone

--- a/apps/prayers/urls.py
+++ b/apps/prayers/urls.py
@@ -1,6 +1,7 @@
 """
 URL patterns for prayer intention endpoints.
 """
+
 from django.urls import path
 
 from apps.prayers.views import (

--- a/apps/prayers/views.py
+++ b/apps/prayers/views.py
@@ -1,6 +1,7 @@
 """
 Views for Prayer Intention API endpoints.
 """
+
 import hashlib
 
 from django.db.models import Case, Value, When

--- a/apps/tasks/admin.py
+++ b/apps/tasks/admin.py
@@ -1,6 +1,7 @@
 """
 Admin configuration for Task model.
 """
+
 from django.contrib import admin
 
 from apps.tasks.models import Task

--- a/apps/tasks/broadcast_serializers.py
+++ b/apps/tasks/broadcast_serializers.py
@@ -3,6 +3,7 @@ Serializers for broadcast task operations.
 
 Provides list, detail, and create serializers for the BroadcastTask model.
 """
+
 from rest_framework import serializers
 
 from apps.tasks.models import BroadcastTask, TaskPriority, TaskType

--- a/apps/tasks/broadcast_services.py
+++ b/apps/tasks/broadcast_services.py
@@ -4,6 +4,7 @@ Service functions for broadcast task operations.
 Handles target resolution, bulk copy creation, cascade edits, and cancellation.
 All mutating operations are wrapped in database transactions for atomicity.
 """
+
 from django.db import transaction
 from django.utils import timezone
 

--- a/apps/tasks/broadcast_views.py
+++ b/apps/tasks/broadcast_views.py
@@ -1,4 +1,5 @@
 """Views for Broadcast Task management."""
+
 from django.db.models import Count, Q
 
 from rest_framework import filters, generics, permissions, status

--- a/apps/tasks/export_views.py
+++ b/apps/tasks/export_views.py
@@ -1,6 +1,7 @@
 """
 CSV export view for tasks with FilterSet-based filtering.
 """
+
 import csv
 from datetime import datetime
 

--- a/apps/tasks/filters.py
+++ b/apps/tasks/filters.py
@@ -1,6 +1,7 @@
 """
 FilterSet for Task list filtering.
 """
+
 import django_filters
 
 from apps.tasks.models import Task

--- a/apps/tasks/models.py
+++ b/apps/tasks/models.py
@@ -1,6 +1,7 @@
 """
 Task model for reminders and action items.
 """
+
 from django.conf import settings
 from django.db import models
 from django.utils import timezone

--- a/apps/tasks/serializers.py
+++ b/apps/tasks/serializers.py
@@ -1,6 +1,7 @@
 """
 Serializers for Task model.
 """
+
 from rest_framework import serializers
 
 from apps.journals.models import Journal

--- a/apps/tasks/tests/factories.py
+++ b/apps/tasks/tests/factories.py
@@ -1,6 +1,7 @@
 """
 Factories for Task model tests.
 """
+
 from datetime import timedelta
 
 from django.utils import timezone

--- a/apps/tasks/tests/test_broadcast_services.py
+++ b/apps/tasks/tests/test_broadcast_services.py
@@ -1,6 +1,7 @@
 """
 Tests for broadcast task service functions.
 """
+
 from datetime import timedelta
 
 from django.utils import timezone

--- a/apps/tasks/tests/test_broadcast_views.py
+++ b/apps/tasks/tests/test_broadcast_views.py
@@ -1,6 +1,7 @@
 """
 Tests for broadcast task API views.
 """
+
 from datetime import timedelta
 
 from django.utils import timezone

--- a/apps/tasks/tests/test_export_coverage.py
+++ b/apps/tasks/tests/test_export_coverage.py
@@ -6,6 +6,7 @@ export can still return 200 with a header row but NO data rows. These tests
 parse the streamed body and assert the header AND at least one correct data
 row, which catches that class of bug.
 """
+
 import csv
 import io
 from datetime import date

--- a/apps/tasks/tests/test_models.py
+++ b/apps/tasks/tests/test_models.py
@@ -1,6 +1,7 @@
 """
 Tests for Task model.
 """
+
 from datetime import timedelta
 
 from django.utils import timezone

--- a/apps/tasks/tests/test_views.py
+++ b/apps/tasks/tests/test_views.py
@@ -1,6 +1,7 @@
 """
 Tests for Task API views.
 """
+
 from datetime import timedelta
 
 from django.utils import timezone

--- a/apps/tasks/urls.py
+++ b/apps/tasks/urls.py
@@ -1,6 +1,7 @@
 """
 URL patterns for tasks endpoints.
 """
+
 from django.urls import path
 
 from apps.tasks.broadcast_views import (

--- a/apps/tasks/views.py
+++ b/apps/tasks/views.py
@@ -1,6 +1,7 @@
 """
 Views for Task management.
 """
+
 from datetime import date, timedelta
 
 from rest_framework import filters, generics, permissions, status

--- a/apps/users/admin.py
+++ b/apps/users/admin.py
@@ -1,6 +1,7 @@
 """
 Admin configuration for User model.
 """
+
 from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin as BaseUserAdmin
 

--- a/apps/users/goal_services.py
+++ b/apps/users/goal_services.py
@@ -1,6 +1,7 @@
 """
 Service functions for Goal tracking calculations.
 """
+
 from decimal import Decimal
 
 from django.db.models import Q, Sum

--- a/apps/users/management/commands/capitalize_missionary_names.py
+++ b/apps/users/management/commands/capitalize_missionary_names.py
@@ -1,4 +1,5 @@
 """Capitalize first and last name of all missionary users."""
+
 from django.core.management.base import BaseCommand
 
 from apps.users.models import User, UserRole

--- a/apps/users/management/commands/purge_ghost_assignments.py
+++ b/apps/users/management/commands/purge_ghost_assignments.py
@@ -5,6 +5,7 @@ Ghost rows are M2M entries in users_user_supervisors or users_user_coaches
 where the referenced user no longer holds the expected role (supervisor or coach).
 These were created by migration 0006 which copied FK data without role validation.
 """
+
 from django.core.management.base import BaseCommand
 
 from apps.users.models import User

--- a/apps/users/management/commands/sync_solicitor_accounts.py
+++ b/apps/users/management/commands/sync_solicitor_accounts.py
@@ -2,6 +2,7 @@
 Management command to ensure all solicitor accounts from test_solicitors.csv
 exist with @spo.org emails and a consistent password.
 """
+
 import os
 
 from django.contrib.auth import get_user_model

--- a/apps/users/managers.py
+++ b/apps/users/managers.py
@@ -1,6 +1,7 @@
 """
 Custom manager for User model.
 """
+
 from django.contrib.auth.models import BaseUserManager
 
 

--- a/apps/users/models.py
+++ b/apps/users/models.py
@@ -2,6 +2,7 @@
 Custom User model for DonorCRM.
 Uses email as primary identifier with role-based access control.
 """
+
 from django.contrib.auth.models import AbstractBaseUser, PermissionsMixin
 from django.db import models
 from django.utils import timezone

--- a/apps/users/serializers.py
+++ b/apps/users/serializers.py
@@ -1,6 +1,7 @@
 """
 Serializers for User model and authentication.
 """
+
 from django.contrib.auth.password_validation import validate_password
 
 from rest_framework import serializers

--- a/apps/users/tests/factories.py
+++ b/apps/users/tests/factories.py
@@ -1,6 +1,7 @@
 """
 Factories for User model tests.
 """
+
 import factory
 from faker import Faker
 

--- a/apps/users/tests/test_goal_services.py
+++ b/apps/users/tests/test_goal_services.py
@@ -4,6 +4,7 @@ GOAL-04: get_goal_progress(user) computes effective_monthly_support from journal
 GH-26: get_decisions_progress(user) computes monthly-normalized decision amounts
 vs journal goal sums.
 """
+
 from datetime import date
 from decimal import Decimal
 

--- a/apps/users/tests/test_link_solicitors_command.py
+++ b/apps/users/tests/test_link_solicitors_command.py
@@ -4,6 +4,7 @@ Tests for the link_solicitors_and_reassign_owners management command.
 Verifies that contact ownership is reassigned based on both GiftCredit
 and RecurringGiftCredit records.
 """
+
 from datetime import date
 
 from django.core.management import call_command

--- a/apps/users/tests/test_m2m_assignments.py
+++ b/apps/users/tests/test_m2m_assignments.py
@@ -10,6 +10,7 @@ yet created — current model has ForeignKey `supervisor` not ManyToManyField
 
 Run: pytest apps/users/tests/test_m2m_assignments.py -q
 """
+
 from rest_framework.test import APIClient
 
 import pytest

--- a/apps/users/tests/test_models.py
+++ b/apps/users/tests/test_models.py
@@ -1,6 +1,7 @@
 """
 Tests for User model.
 """
+
 from django.db import IntegrityError
 
 import pytest

--- a/apps/users/tests/test_views.py
+++ b/apps/users/tests/test_views.py
@@ -1,6 +1,7 @@
 """
 Tests for User API views.
 """
+
 from rest_framework import status
 
 import pytest

--- a/apps/users/tests/test_views_assignments_coverage.py
+++ b/apps/users/tests/test_views_assignments_coverage.py
@@ -5,6 +5,7 @@ The existing test_m2m_assignments.py covers the happy paths and GET role-filteri
 These tests target the PATCH error/validation/coach branches and the 5+ supervisor
 warning that remain uncovered.
 """
+
 import uuid
 
 from rest_framework.test import APIClient

--- a/apps/users/tests/test_views_goals.py
+++ b/apps/users/tests/test_views_goals.py
@@ -3,6 +3,7 @@ Integration test stubs for Goals API endpoint.
 GOAL-02: PATCH /api/v1/goals/me/ saves monthly_support_goal_cents and goal_weeks.
 GOAL-03: PATCH /api/v1/goals/me/ with journal_ids replaces GoalJournalSelection set.
 """
+
 from rest_framework.test import APIClient
 
 import pytest

--- a/apps/users/tests/test_views_viewable.py
+++ b/apps/users/tests/test_views_viewable.py
@@ -10,6 +10,7 @@ GREEN state: all tests pass after Plan 04 implements ViewableUsersView.
 Test coverage:
   - VIEWAS-12: Viewable users endpoint (admin sees all missionaries, supervisor sees assigned only)
 """
+
 from rest_framework.test import APIClient
 
 import pytest

--- a/apps/users/urls.py
+++ b/apps/users/urls.py
@@ -1,6 +1,7 @@
 """
 URL patterns for user management endpoints.
 """
+
 from django.urls import path
 
 from apps.users.views import (

--- a/apps/users/urls_auth.py
+++ b/apps/users/urls_auth.py
@@ -1,6 +1,7 @@
 """
 URL patterns for authentication endpoints.
 """
+
 from django.urls import path
 
 from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView

--- a/apps/users/urls_goals.py
+++ b/apps/users/urls_goals.py
@@ -1,6 +1,7 @@
 """
 URL patterns for Goal tracking endpoints.
 """
+
 from django.urls import path
 
 from apps.users.views_goals import GoalView

--- a/apps/users/views.py
+++ b/apps/users/views.py
@@ -1,6 +1,7 @@
 """
 Views for user management.
 """
+
 from django.db.models import Count, Q
 
 from rest_framework import generics, permissions, status

--- a/apps/users/views_assignments.py
+++ b/apps/users/views_assignments.py
@@ -1,6 +1,7 @@
 """
 Assignments API for admin to manage missionary-supervisor-coach relationships.
 """
+
 from rest_framework.response import Response
 from rest_framework.views import APIView
 

--- a/apps/users/views_auth.py
+++ b/apps/users/views_auth.py
@@ -1,6 +1,7 @@
 """
 Authentication views.
 """
+
 from rest_framework import permissions, serializers, status
 from rest_framework.response import Response
 from rest_framework.views import APIView

--- a/apps/users/views_goals.py
+++ b/apps/users/views_goals.py
@@ -1,6 +1,7 @@
 """
 API views for Goal tracking.
 """
+
 from django.db import transaction
 
 from rest_framework import permissions

--- a/config/api_urls.py
+++ b/config/api_urls.py
@@ -2,6 +2,7 @@
 API URL configuration for DonorCRM.
 All API endpoints are prefixed with /api/v1/
 """
+
 from django.conf import settings
 from django.db import OperationalError, connection
 from django.http import JsonResponse

--- a/config/asgi.py
+++ b/config/asgi.py
@@ -1,6 +1,7 @@
 """
 ASGI config for DonorCRM project.
 """
+
 import os
 
 from django.core.asgi import get_asgi_application

--- a/config/celery.py
+++ b/config/celery.py
@@ -1,6 +1,7 @@
 """
 Celery configuration for DonorCRM.
 """
+
 import os
 
 from celery import Celery

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -1,6 +1,7 @@
 """
 Base settings for DonorCRM project.
 """
+
 import os
 from datetime import timedelta
 from pathlib import Path

--- a/config/settings/dev.py
+++ b/config/settings/dev.py
@@ -1,6 +1,7 @@
 """
 Development settings for DonorCRM.
 """
+
 from .base import *  # noqa: F401, F403
 
 DEBUG = True

--- a/config/settings/prod.py
+++ b/config/settings/prod.py
@@ -1,6 +1,7 @@
 """
 Production settings for DonorCRM.
 """
+
 import os
 
 import dj_database_url

--- a/config/settings/test.py
+++ b/config/settings/test.py
@@ -1,6 +1,7 @@
 """
 Test settings for DonorCRM.
 """
+
 from .base import *  # noqa: F401, F403
 
 DEBUG = False

--- a/config/urls.py
+++ b/config/urls.py
@@ -1,6 +1,7 @@
 """
 URL configuration for DonorCRM project.
 """
+
 from django.conf import settings
 from django.contrib import admin
 from django.urls import include, path

--- a/config/wsgi.py
+++ b/config/wsgi.py
@@ -1,6 +1,7 @@
 """
 WSGI config for DonorCRM project.
 """
+
 import os
 
 from django.core.wsgi import get_wsgi_application

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -23,7 +23,10 @@ django-csp>=4.0,<5.0
 # Per-account lockout to defend credential stuffing across IP rotation.
 django-axes>=6.4,<7.0
 # Field-level encryption for donor PII (apps/core/encryption.py).
-cryptography>=42.0,<46.0
+# Floor raised to 46.0.7: fixes CVE-2026-26007, PYSEC-2026-35, PYSEC-2026-36
+# (all present in 45.0.7). 46.x uses the same Fernet/AESGCM APIs this code
+# relies on; the major only dropped Python <3.8 and bumped OpenSSL/Rust.
+cryptography>=46.0.7,<47.0
 
 # Utilities
 python-dateutil>=2.8,<3.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,15 +1,21 @@
 -r base.txt
 
 # Testing
-pytest>=7.4,<8.0
-pytest-django>=4.5,<5.0
-pytest-cov>=4.1,<5.0
+# pytest floor raised to 9.0.3 (CVE-2025-71176, present in 7.4.4); pytest-cov
+# 7.x and pytest-django 4.12 are the pytest-9-compatible plugin lines.
+pytest>=9.0.3,<10.0
+pytest-django>=4.12,<5.0
+pytest-cov>=7.0,<8.0
 factory-boy>=3.3,<4.0
 faker>=19.0,<20.0
 freezegun>=1.5.5,<2.0  # deterministic clock for fiscal-year tests
 
 # Code quality
-black>=23.0,<24.0
+# black floor raised to 26.3.1: clears PYSEC-2024-48 (24.3.0) AND
+# CVE-2026-32274 (26.3.1), both present in 23.12.1. The 2024 stable style
+# (introduced in 24.x and unchanged through 26.x) reformats the codebase;
+# it's been applied so the `black --check` CI gate stays green.
+black>=26.3.1,<27.0
 isort>=5.12,<6.0
 flake8>=6.0,<7.0
 


### PR DESCRIPTION
## Summary

Greens the `security` workflow, which had **two independent pre-existing failures** on `main` (both visible in the latest scheduled/push runs): `pip-audit` and `bandit`.

### 1. Dependency CVEs (`pip-audit --strict`)

| Package | Was | Now | CVEs cleared |
|---|---|---|---|
| `cryptography` (runtime) | 45.0.7 | `>=46.0.7,<47.0` | CVE-2026-26007, PYSEC-2026-35, PYSEC-2026-36 |
| `pytest` (dev) | 7.4.4 | `>=9.0.3,<10.0` | CVE-2025-71176 |
| `black` (dev) | 23.12.1 | `>=26.3.1,<27.0` | PYSEC-2024-48, CVE-2026-32274 |

- `cryptography` is a runtime dependency (field-level PII encryption in `apps/core/encryption.py`). 46.x keeps the same `Fernet` / `MultiFernet` / `AESGCM` APIs the code relies on — the major only dropped Python <3.8 and bumped OpenSSL/Rust. Verified the full suite passes under it.
- `pytest-cov` (`>=7.0`) and `pytest-django` (`>=4.12`) bumped alongside for pytest-9 compatibility.
- The `black` bump applies the **2024 stable style** across `apps/` and `config/` (237 files reformatted, whitespace-only) so the `black --check` hard gate stays green. No logic changes in those files.

### 2. `bandit` (static analysis)

The bandit job was *also* failing — 3 Medium-severity `B608` ("possible SQL injection") findings, all pre-existing on `main`. Verified each is a false positive and suppressed with a targeted `# nosec B608` + rationale, so the gate continues to block *real* findings:

- `reset_missionaries.py` — table name comes from a hardcoded `("donations", "pledges")` allowlist passed through `connection.ops.quote_name()`; no user input.
- `test_rotate_pii_encryption.py` (×2) — test helpers interpolating Django-internal `Contact._meta.db_table` (not user input) with `%s`-bound params.

## Test plan

Run locally, mirroring the CI `security` + `backend` jobs exactly:

- [x] `bandit -r apps/ -ll --skip B101` → exit 0, "No issues identified"
- [x] `pip-audit -r requirements/base.txt --strict` → clean
- [x] `pip-audit -r requirements/prod.txt --strict` → clean
- [x] `pip-audit -r requirements/dev.txt --strict` → clean
- [x] `black --check apps/ config/` → clean (291 files)
- [x] `isort --check-only apps/ config/` → clean
- [x] `flake8 apps/ config/` → 0 issues
- [x] `pytest` → 1282 passed, 2 skipped, **81.15% coverage** (80% gate met), no regressions under pytest 9

## Notes

- The `B608` suppressions are genuinely safe; if a fully parameterized rewrite of the `reset_missionaries` legacy-table DELETE is preferred over a `# nosec`, happy to do that as a follow-up.