### PR TITLE
fix(insights): stabilize flaky team-trends week-boundary test

### DIFF
--- a/apps/insights/tests/test_team_trends.py
+++ b/apps/insights/tests/test_team_trends.py
@@ -139,10 +139,10 @@ class TestTeamTrendsView:
             cadence="one_time",
             status="pending",
         )
-        # Update created_at to current week
-        Decision.objects.filter(journal_contact=journal_contact2).update(
-            created_at=now - timedelta(days=1)
-        )
+        # Update created_at to current week. Use the same instant as the first
+        # decision so neither crosses the Monday week boundary when the test runs
+        # early in the week (see test_counts_donations_by_week for the same fix).
+        Decision.objects.filter(journal_contact=journal_contact2).update(created_at=now)
 
         response = client.get("/api/v1/insights/admin/team-trends/")
         assert response.status_code == status.HTTP_200_OK


### PR DESCRIPTION
## Summary
Fixes a date-dependent flaky test that was failing the `backend (pytest + lint)` check on **all 11 open Dependabot PRs** (#85–#95). The dependency bumps were not the cause — the test fails whenever CI runs on a **Monday**.

## Root cause
`get_team_trends()` buckets activity into weeks that **start on Monday** (`apps/insights/services.py:817-824`). The test `test_counts_decisions_by_week` placed its second decision at `now - timedelta(days=1)`. When CI runs on a Monday, "yesterday" is Sunday — the *previous* week's bucket — so the most-recent week counts 1 decision instead of 2:

```
assert last_week["decisions_logged"] == 2  →  assert 1 == 2
```

The Dependabot PRs all ran on **2026-06-08, a Monday**, so every one failed. `main` last passed on a Thursday. The sibling test `test_counts_donations_by_week` already avoids this by using the same day.

## Fix
Pin both decisions to the same instant (`now`), so neither crosses the week boundary — matching the existing pattern in `test_counts_donations_by_week`.

## Test plan
- [x] `pytest apps/insights/tests/test_team_trends.py` — 12 passed
- [x] `black` / `isort` / `flake8` clean
- [ ] CI green (note: this fix run is not on a Monday; behavior is now date-independent regardless)