### PR TITLE
docs: rename project to DonorCRM-SPO (repo-facing references)

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -13,7 +13,7 @@ This guide covers how to build, test, and run the DonorCRM Django backend.
 
 ```bash
 git clone <repository-url>
-cd DonorCRM
+cd DonorCRM-SPO
 
 # Copy environment template
 cp .env.example .env

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# DonorCRM
+# DonorCRM-SPO
 
 A purpose-built CRM for missionaries and nonprofit fundraisers at Saint Paul's Outreach (SPO). Simple, motivating, and actually used.
 
@@ -115,8 +115,8 @@ User → React SPA → Axios (JWT + View As header) → Django DRF View
 ### Backend Setup
 
 ```bash
-git clone https://github.com/matkukla/DonorCRM.git
-cd DonorCRM
+git clone https://github.com/matkukla/DonorCRM-SPO.git
+cd DonorCRM-SPO
 
 python3 -m venv venv
 source venv/bin/activate

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -236,7 +236,7 @@ REST_FRAMEWORK = {
 
 # API Documentation (drf-spectacular)
 SPECTACULAR_SETTINGS = {
-    "TITLE": "DonorCRM API",
+    "TITLE": "DonorCRM-SPO API",
     "DESCRIPTION": (
         "A missionary support management CRM API for tracking donors, gifts, "
         "recurring gifts, and tasks."


### PR DESCRIPTION
## Summary

Renames the project to **DonorCRM-SPO** at the repo/branding layer, matching the GitHub repo rename (`matkukla/DonorCRM` → `matkukla/DonorCRM-SPO`).

Scope was deliberately limited to **repo-facing references** — the spoken product name stays "DonorCRM" in prose, and **no deployment identifiers were touched**:

- `README.md` — H1 title + clone instructions (`.git` URL and `cd` target)
- `BUILD.md` — `cd` target
- `config/settings/base.py` — drf-spectacular API title (`DonorCRM API` → `DonorCRM-SPO API`)

## Explicitly NOT changed (production-safe)

- Render service names (`donorcrm-web`, `donorcrm-frontend`, `donorcrm-db`) and their `*.onrender.com` URLs
- Database name/user (`donorcrm`)
- Celery app name (`Celery("donorcrm")`)
- Email domain (`@donorcrm.app`)
- `health-watch.yml` probe URL

Production keeps running on the existing `donorcrm-web.onrender.com` infrastructure — the repo rename and these doc edits are independent of the deployed services.

## Test plan

- [x] No test asserts on the old API title string (grep-verified)
- [x] No deployment identifier changed (`render.yaml` diff = 0 files)
- [ ] CI (backend + frontend) green on this PR